### PR TITLE
Support when openapi data type is array.

### DIFF
--- a/aliyuncli/aliyunOpenApiData.py
+++ b/aliyuncli/aliyunOpenApiData.py
@@ -360,7 +360,13 @@ class aliyunOpenApiDataHandler():
                 if len(key)>0 and key in keyValues:
                     arg=keyValues[key]
                     if arg is not None and len(arg)>0:
-                        param=arg[0]
+                        if len(arg) == 1:
+                            param=arg[0]
+                        else:
+                            param=[]
+                            for i in range(len(arg)):
+                                if i < len(arg)-1:
+                                    param.append(arg[i])
                         getattr(instance,func)(param)
         userKey=self.getUserKey()
         userSecret=self.getUserSecret()

--- a/aliyuncli/aliyunOpenApiData.py
+++ b/aliyuncli/aliyunOpenApiData.py
@@ -360,13 +360,10 @@ class aliyunOpenApiDataHandler():
                 if len(key)>0 and key in keyValues:
                     arg=keyValues[key]
                     if arg is not None and len(arg)>0:
-                        if len(arg) == 1:
+                        if key != 'InstanceIds':
                             param=arg[0]
                         else:
-                            param=[]
-                            for i in range(len(arg)):
-                                if i < len(arg)-1:
-                                    param.append(arg[i])
+                            param=arg
                         getattr(instance,func)(param)
         userKey=self.getUserKey()
         userSecret=self.getUserSecret()


### PR DESCRIPTION
When transport array old pop use '["arraydata1","arraydata2"]' data to send to serve as string,
which is considered unsafe, and in sdk array is really string.So in cli we can use this format to support really array:
datas=data1 end
datas=data1 data2 end