### PR TITLE
Fix issues with user.Current()

### DIFF
--- a/oss/lib/config_helper.go
+++ b/oss/lib/config_helper.go
@@ -2,12 +2,12 @@ package lib
 
 import (
 	"fmt"
+	configparser "github.com/alyu/configparser"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
-
-	configparser "github.com/alyu/configparser"
 )
 
 // sections in config file
@@ -53,8 +53,17 @@ func DecideConfigFile(configFile string) string {
 	if configFile == "" {
 		configFile = DefaultConfigFile
 	}
-	usr, _ := user.Current()
-	dir := usr.HomeDir
+	usr, err := user.Current()
+	var dir string
+	if err != nil {
+		ex, derr := os.Executable()
+		if derr != nil {
+			return "/tmp"
+		}
+		dir = filepath.Dir(ex)
+	} else {
+		dir = usr.HomeDir
+	}
 	if len(configFile) >= 2 && strings.HasPrefix(configFile, "~"+string(os.PathSeparator)) {
 		configFile = strings.Replace(configFile, "~", dir, 1)
 	}

--- a/oss/lib/storage_url.go
+++ b/oss/lib/storage_url.go
@@ -144,8 +144,9 @@ func (fu *FileURL) Init(urlStr, encodingType string) error {
 		ex, derr := os.Executable()
 		if derr != nil {
 			dir = "/tmp"
+		} else {
+			dir = filepath.Dir(ex)
 		}
-		dir = filepath.Dir(ex)
 	} else {
 		dir = usr.HomeDir
 	}

--- a/oss/lib/storage_url.go
+++ b/oss/lib/storage_url.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"path/filepath"
 )
 
 // SchemePrefix is the prefix of oss url
@@ -137,8 +138,17 @@ func (fu *FileURL) Init(urlStr, encodingType string) error {
 		urlStr = vurl
 	}
 
-	usr, _ := user.Current()
-	dir := usr.HomeDir
+	usr, err := user.Current()
+	var dir string
+	if err != nil {
+		ex, derr := os.Executable()
+		if derr != nil {
+			dir = "/tmp"
+		}
+		dir = filepath.Dir(ex)
+	} else {
+		dir = usr.HomeDir
+	}
 	if len(urlStr) >= 2 && urlStr[:2] == "~"+string(os.PathSeparator) {
 		urlStr = strings.Replace(urlStr, "~", dir, 1)
 	}


### PR DESCRIPTION
When running Aliyun CLI through cloud-init on an aliyun ECS instance, I get null ptr segfaults because user.Current() returns an error that isn't handled.   Here we handle that code by using a reasonable default for the config to be stored: (`pwd`) and if that fails then we simply place the config in: `/tmp`.