### PR TITLE
Added line-break after help message

### DIFF
--- a/openapi/library.go
+++ b/openapi/library.go
@@ -91,7 +91,7 @@ func (a *Library) PrintProductUsage(productCode string, withApi bool) error {
 		//w.Flush()
 	}
 
-	cli.Printf(a.writer, "\nRun `aliyun %s <ApiName> --help` to get more information about api", product.GetLowerCode())
+	cli.Printf(a.writer, "\nRun `aliyun %s <ApiName> --help` to get more information about api\n", product.GetLowerCode())
 	return nil
 }
 

--- a/openapi/library.go
+++ b/openapi/library.go
@@ -91,7 +91,7 @@ func (a *Library) PrintProductUsage(productCode string, withApi bool) error {
 		//w.Flush()
 	}
 
-	cli.Printf(a.writer, "\nRun `aliyun %s <ApiName> --help` to get more information about api\n", product.GetLowerCode())
+	cli.Printf(a.writer, "\nRun `aliyun %s <ApiName> --help` to get more information about this API\n", product.GetLowerCode())
 	return nil
 }
 


### PR DESCRIPTION
Small PR, but adds a needed line-break after the help message (ie `aliyun help ecs`). Also, updated the wording for better context.