### PR TITLE
Perfected testcases and fix potential error code logic

### DIFF
--- a/cli/flag.go
+++ b/cli/flag.go
@@ -151,7 +151,7 @@ func (f *Flag) GetIntegerOrDefault(def int) int {
 		return def
 	}
 	if f.assigned {
-		if i, err := strconv.Atoi(f.value); err != nil {
+		if i, err := strconv.Atoi(f.value); err == nil {
 			return i
 		}
 	}

--- a/cli/flag_set_test.go
+++ b/cli/flag_set_test.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2017-2018 Alibaba Group Holding Limited
+ */
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFlagSet(t *testing.T) {
+	fs := NewFlagSet()
+	assert.NotNil(t, fs.flags)
+	assert.NotNil(t, fs.index)
+}
+
+func TestFlags(t *testing.T) {
+	fs := NewFlagSet()
+	assert.NotNil(t, fs.flags)
+	assert.Len(t, fs.flags, 0)
+}
+
+func TestAdd(t *testing.T) {
+	defer func() {
+		a := recover()
+		err, _ := a.(error)
+		assert.EqualError(t, err, "flag duplicated --MrX")
+		//the err message has "---MrX" before, and it should be "--MrX"
+		// assert.EqualError(t, err, "flag duplicated ---MrX")
+	}()
+	fs := NewFlagSet()
+	f := &Flag{Name: "MrX"}
+	fs.Add(f)
+	assert.Subset(t, fs.flags, []*Flag{&Flag{Name: "MrX"}})
+	assert.Len(t, fs.flags, 1)
+	fs.Add(f)
+}
+
+func TestAddByName(t *testing.T) {
+	fs := NewFlagSet()
+	f, err := fs.AddByName("MrX2")
+	assert.Equal(t, &Flag{Name: "MrX2"}, f)
+	assert.Nil(t, err)
+
+	f, err = fs.AddByName("MrX2")
+	assert.Nil(t, f)
+	assert.EqualError(t, err, "flag duplicated --MrX2")
+
+}
+
+func TestGet(t *testing.T) {
+	fs := NewFlagSet()
+	fs.AddByName("MrX")
+	assert.Equal(t, &Flag{Name: "MrX", formation: "--MrX"}, fs.Get("MrX"))
+	assert.Nil(t, fs.Get("MrX2"))
+}
+
+func TestGetByShorthand(t *testing.T) {
+	fs := NewFlagSet()
+	assert.Nil(t, fs.GetByShorthand('X'))
+	fs.Add(&Flag{Name: "profile", Shorthand: 'p'})
+	exf := &Flag{Name: "profile", Shorthand: 'p', formation: "-p"}
+	fs.GetByShorthand('p')
+	assert.Equal(t, exf, fs.GetByShorthand('p'))
+}
+
+func TestGetSuggestions(t *testing.T) {
+	//TODO after prefected cli/suggestion.go testcase
+}
+
+func TestGetValue(t *testing.T) {
+	fs := NewFlagSet()
+	str, ok := fs.GetValue("NonExist")
+	assert.False(t, ok)
+	assert.Empty(t, str)
+	fs.AddByName("MrX")
+	str, ok = fs.GetValue("MrX")
+	assert.False(t, ok)
+	assert.Empty(t, str)
+}
+
+func TestAssignedCount(t *testing.T) {
+	fs := NewFlagSet()
+	fs.AddByName("MrX")
+	assert.Zero(t, fs.assignedCount())
+	fs.Flags()[0].assigned = true
+	assert.Equal(t, 1, fs.assignedCount())
+}
+
+func TestPut(t *testing.T) {
+	fs := NewFlagSet()
+	fs.put(&Flag{Name: "profile", Shorthand: 'p'})
+	assert.Len(t, fs.flags, 1)
+	fs.put(&Flag{Name: "profile", Shorthand: 'r'})
+	assert.Len(t, fs.flags, 1)
+	assert.Equal(t, 'r', fs.flags[0].Shorthand)
+	fs.put(&Flag{Name: "profil", Shorthand: 'a'})
+	assert.Len(t, fs.flags, 2)
+}
+
+func TestMergeWith(t *testing.T) {
+	var a = func(f *Flag) bool {
+		//merge with the rule that you need
+		//in this case , I need merge all
+		return true
+	}
+	fs := NewFlagSet()
+	assert.True(t, reflect.DeepEqual(fs, fs.mergeWith(nil, a)))
+	fs2 := NewFlagSet()
+	fs2.Add(&Flag{Name: "profile", Shorthand: 'p'})
+	fs2.Add(&Flag{Name: "mode", Shorthand: 'm'})
+	assert.Len(t, fs.mergeWith(fs2, a).flags, 2)
+	fs.Add(&Flag{Name: "AK", Shorthand: 'a'})
+	assert.Len(t, fs.mergeWith(fs2, a).flags, 3)
+}

--- a/cli/flag_test.go
+++ b/cli/flag_test.go
@@ -91,10 +91,7 @@ func TestFlag(t *testing.T) {
 	f.GetIntegerOrDefault(23)
 	assert.Equal(t, 23, f.GetIntegerOrDefault(23))
 	f.assigned = true
-
-	// assert.Equal(t, 1, f.GetIntegerOrDefault(23))
-	//the code below just for pass test,the correct code is on it
-	assert.Equal(t, 23, f.GetIntegerOrDefault(23))
+	assert.Equal(t, 1, f.GetIntegerOrDefault(23))
 
 	//GetFormations
 	assert.Len(t, f.GetFormations(), 2)

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -1,26 +1,12 @@
 package config
 
 import (
+	"testing"
+
 	"github.com/aliyun/aliyun-cli/cli"
 	"github.com/aliyun/aliyun-cli/i18n"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
-
-var NewMethodFlag func() *cli.Flag
-
-func NewFlagTest(t *testing.T, fn func() *cli.Flag, expectFlag *cli.Flag, values []string) {
-	flag := fn()
-	value, ok := flag.GetValue()
-	assert.Equal(t, false, ok)
-	assert.Equal(t, value, "")
-	assert.Nil(t, flag.GetValues())
-	assert.Equal(t, false, flag.IsAssigned())
-	assert.Subset(t, flag.GetFormations(), values)
-	assert.Len(t, flag.GetFormations(), len(values))
-	assert.Equal(t, expectFlag, flag)
-
-}
 
 func TestAddFlag(t *testing.T) {
 	var (
@@ -297,20 +283,49 @@ func TestAddFlag(t *testing.T) {
 			DefaultValue: "",
 		}
 	)
+	f := NewProfileFlag()
+	assert.Equal(t, newProfileFlag, f)
 
-	NewFlagTest(t, NewProfileFlag, newProfileFlag, []string{"--profile", "-p"})
-	NewFlagTest(t, NewModeFlag, newModeFlag, []string{"--mode"})
-	NewFlagTest(t, NewAccessKeyIdFlag, newAccessKeyIDFlag, []string{"--access-key-id"})
-	NewFlagTest(t, NewAccessKeySecretFlag, newAccessKeySecretFlag, []string{"--access-key-secret"})
-	NewFlagTest(t, NewStsTokenFlag, newStsTokenFlag, []string{"--sts-token"})
-	NewFlagTest(t, NewRamRoleNameFlag, newRamRoleNameFlag, []string{"--ram-role-name"})
-	NewFlagTest(t, NewRamRoleArnFlag, newRamRoleArnFlag, []string{"--ram-role-arn"})
-	NewFlagTest(t, NewRoleSessionNameFlag, newRoleSessionNameFlag, []string{"--role-session-name"})
-	NewFlagTest(t, NewPrivateKeyFlag, newPrivateKeyFlag, []string{"--private-key"})
-	NewFlagTest(t, NewKeyPairNameFlag, newKeyPairNameFlag, []string{"--key-pair-name"})
-	NewFlagTest(t, NewRegionFlag, newRegionFlag, []string{"--region"})
-	NewFlagTest(t, NewLanguageFlag, newLanguageFlag, []string{"--language"})
-	NewFlagTest(t, NewRetryTimeoutFlag, newRetryTimeoutFlag, []string{"--retry-timeout"})
-	NewFlagTest(t, NewRetryCountFlag, newRetryCountFlag, []string{"--retry-count"})
-	NewFlagTest(t, NewSkipSecureVerify, newSkipSecureVerify, []string{"--skip-secure-verify"})
+	f = NewModeFlag()
+	assert.Equal(t, newModeFlag, f)
+
+	f = NewAccessKeyIdFlag()
+	assert.Equal(t, newAccessKeyIDFlag, f)
+
+	f = NewAccessKeySecretFlag()
+	assert.Equal(t, newAccessKeySecretFlag, f)
+
+	f = NewStsTokenFlag()
+	assert.Equal(t, newStsTokenFlag, f)
+
+	f = NewRamRoleNameFlag()
+	assert.Equal(t, newRamRoleNameFlag, f)
+
+	f = NewRamRoleArnFlag()
+	assert.Equal(t, newRamRoleArnFlag, f)
+
+	f = NewRoleSessionNameFlag()
+	assert.Equal(t, newRoleSessionNameFlag, f)
+
+	f = NewPrivateKeyFlag()
+	assert.Equal(t, newPrivateKeyFlag, f)
+
+	f = NewKeyPairNameFlag()
+	assert.Equal(t, newKeyPairNameFlag, f)
+
+	f = NewRegionFlag()
+	assert.Equal(t, newRegionFlag, f)
+
+	f = NewLanguageFlag()
+	assert.Equal(t, newLanguageFlag, f)
+
+	f = NewRetryTimeoutFlag()
+	assert.Equal(t, newRetryTimeoutFlag, f)
+
+	f = NewRetryCountFlag()
+	assert.Equal(t, newRetryCountFlag, f)
+
+	f = NewSkipSecureVerify()
+	assert.Equal(t, newSkipSecureVerify, f)
+
 }


### PR DESCRIPTION
Perfected testcases of cli/flags and cli/flag_set
fix two potential erro code logic and update the testcases:
cli/flag.go
```
func (f *Flag) GetIntegerOrDefault(def int) int
```
cli/flag_set.go
```
func (fs *FlagSet) put(f *Flag)
```
