### PR TITLE
Improve testcases of context, errors and flag_field

### DIFF
--- a/cli/context_test.go
+++ b/cli/context_test.go
@@ -2,3 +2,105 @@
  * Copyright (C) 2017-2018 Alibaba Group Holding Limited
  */
 package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aliyun/aliyun-cli/i18n"
+)
+
+var cmd = &Command{
+	Name:  "oss",
+	flags: NewFlagSet(),
+}
+
+func TestHelpFlag(t *testing.T) {
+	fs := NewFlagSet()
+	fs.Add(NewHelpFlag())
+	f := HelpFlag(fs)
+	assert.Equal(t, &Flag{Name: "help", Short: i18n.T("print help", "打印帮助信息"), AssignedMode: AssignedNone, formation: "--help"}, f)
+}
+
+func TestNewHelpFlag(t *testing.T) {
+	f := NewHelpFlag()
+	assert.Equal(t, &Flag{Name: "help", Short: i18n.T("print help", "打印帮助信息"), AssignedMode: AssignedNone}, f)
+}
+
+func TestNewCommandContext(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	assert.Equal(t, &Context{
+		flags:        NewFlagSet(),
+		unknownFlags: nil,
+		writer:       w,
+		help:         false,
+		command:      nil,
+		completion:   nil,
+	}, ctx)
+}
+
+func TestCtx(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	assert.False(t, ctx.IsHelp())
+	assert.Nil(t, ctx.Command())
+	assert.Nil(t, ctx.Completion())
+	assert.Equal(t, ctx.flags, ctx.Flags())
+	assert.Equal(t, w, ctx.Writer())
+	assert.Nil(t, ctx.UnknownFlags())
+	ctx.SetCompletion(&Completion{Current: "M", Args: []string{"GOOD", "BAD"}, line: "MrX", point: 2})
+	assert.Equal(t, &Completion{Current: "M", Args: []string{"GOOD", "BAD"}, line: "MrX", point: 2}, ctx.Completion())
+
+	//EnterCommand
+	ctx.EnterCommand(cmd)
+	assert.Nil(t, ctx.unknownFlags)
+	ctx.EnterCommand(cmd)
+	assert.Equal(t, &Flag{Name: "help", Short: i18n.T("print help", "打印帮助信息"), AssignedMode: AssignedNone, formation: "--help"}, ctx.flags.Get("help"))
+}
+
+func TestCheckFlags(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	ctx.flags.AddByName("MrX")
+	assert.Nil(t, ctx.CheckFlags())
+	ctx.flags.flags[0].Required = true
+	assert.EqualError(t, ctx.CheckFlags(), "missing flag --MrX")
+	ctx.flags.flags[0].assigned = true
+	ctx.flags.flags[0].Fields = []Field{Field{Key: "m", Required: true}}
+	assert.EqualError(t, ctx.CheckFlags(), "bad flag format --MrX with field m= required")
+	ctx.flags.flags[0].Fields[0].Required = false
+	ctx.flags.flags[0].ExcludeWith = []string{"MrX"}
+	ctx.flags.flags[0].value = "M"
+	assert.EqualError(t, ctx.CheckFlags(), "flag --MrX is exclusive with --MrX")
+}
+
+func TestDetectFlag(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	ctx.flags.AddByName("MrX")
+	f, err := ctx.detectFlag("mrx")
+	assert.Nil(t, f)
+	assert.NotNil(t, err)
+	f, err = ctx.detectFlag("MrX")
+	assert.NotNil(t, f)
+	assert.Nil(t, err)
+	ctx.unknownFlags = NewFlagSet()
+	f, err = ctx.detectFlag("mrx")
+	assert.NotNil(t, f)
+	assert.Nil(t, err)
+}
+
+func TestDetectFlagByShorthand(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	ctx.flags.Add(&Flag{Name: "profile", Shorthand: 'p'})
+	f, err := ctx.detectFlagByShorthand('p')
+	assert.Equal(t, &Flag{Name: "profile", Shorthand: 'p', formation: "-p"}, f)
+	assert.Nil(t, err)
+	f, err = ctx.detectFlagByShorthand('c')
+	assert.Nil(t, f)
+	assert.EqualError(t, err, "unknown flag -c")
+}

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017-2018 Alibaba Group Holding Limited
+ */
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorWithTip(t *testing.T) {
+	err := NewErrorWithTip(errors.New("err test"), "%s-%d", "nicai", 1)
+	e, ok := err.(*errorWithTip)
+	assert.True(t, ok)
+	assert.Equal(t, &errorWithTip{err: errors.New("err test"), tip: fmt.Sprintf("%s-%d", "nicai", 1)}, e)
+	assert.Equal(t, e.Error(), "err test")
+	assert.Equal(t, "nicai-1", e.GetTip("ch"))
+}
+
+func TestInvalidCommandError(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	err := NewInvalidCommandError("MrX", ctx)
+	e, ok := err.(*InvalidCommandError)
+	assert.True(t, ok)
+	assert.Equal(t, "'MrX' is not a vaild command", e.Error())
+
+	//GetSuggestions TODO
+}
+
+func TestInvalidFlagError(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := NewCommandContext(w)
+	err := NewInvalidFlagError("MrX", ctx)
+	e, ok := err.(*InvalidFlagError)
+	assert.True(t, ok)
+	assert.Equal(t, "invalid flag MrX", e.Error())
+
+	//GetSuggestions TODO
+}

--- a/cli/flag_field_test.go
+++ b/cli/flag_field_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017-2018 Alibaba Group Holding Limited
+ */
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func resetField() *Field {
+	return &Field{
+		Key:    "first",
+		values: make([]string, 0),
+	}
+}
+func TestField(t *testing.T) {
+	//assign
+	field := resetField()
+	field.assign("hello")
+	assert.True(t, field.assigned)
+	assert.Equal(t, "hello", field.value)
+	assert.Len(t, field.values, 1)
+	assert.Equal(t, "hello", field.values[0])
+
+	//GetValue
+	value, ok := field.getValue()
+	assert.True(t, ok)
+	assert.Equal(t, "hello", value)
+	field.assigned = false
+	value, ok = field.getValue()
+	assert.False(t, ok)
+	assert.Empty(t, value)
+	field.DefaultValue = "default"
+	value, ok = field.getValue()
+	assert.False(t, ok)
+	assert.Equal(t, "default", value)
+
+	//check
+	assert.Nil(t, field.check())
+	field.assigned = false
+	field.Required = true
+	assert.EqualError(t, field.check(), "first= required")
+	field.Key = ""
+	assert.EqualError(t, field.check(), "value required")
+
+	field.Required = false
+	field.values = []string{"first", "second"}
+	assert.EqualError(t, field.check(), "value duplicated")
+	field.Key = "first"
+	assert.EqualError(t, field.check(), "first= duplicated")
+}

--- a/cli/levenshtein_test.go
+++ b/cli/levenshtein_test.go
@@ -27,6 +27,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testCases = []struct {
@@ -137,6 +139,19 @@ var testCases = []struct {
 			Ins,
 		},
 	},
+}
+
+func TestEditOpString(t *testing.T) {
+	editOp1 := EditOperation(3)
+	assert.Equal(t, "match", editOp1.String())
+	editOp1 = EditOperation(0)
+	assert.Equal(t, "ins", editOp1.String())
+	editOp1 = EditOperation(2)
+	assert.Equal(t, "sub", editOp1.String())
+	editOp1 = EditOperation(1)
+	assert.Equal(t, "del", editOp1.String())
+	// editOp1 = EditOperation(4)
+	// assert.Equal(t, "del", editOp1.String())
 }
 
 func TestDistanceForStrings(t *testing.T) {

--- a/cli/suggestion_test.go
+++ b/cli/suggestion_test.go
@@ -5,18 +5,23 @@ package cli
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestSuggestion(t *testing.T) {
-	s := NewSuggester("aaa", 2)
+func TestNewSuggester(t *testing.T) {
+	suggestion := NewSuggester("flags", 2)
+	assert.Equal(t, &Suggester{suggestFor: "flags", distance: 2}, suggestion)
+}
 
+func TestApply(t *testing.T) {
+	s := NewSuggester("aaa", 2)
 	s.Apply("aab")
-	s.Apply("aa2")
 	s.Apply("aa2")
 	s.Apply("aa2b")
 	s.Apply("baa2b")
 
-	for _, r := range s.results {
-		t.Logf("%s\n", r)
-	}
+	result := s.GetResults()
+	assert.Subset(t, result, []string{"aab", "aa2"})
+	assert.Len(t, result, 2)
 }


### PR DESCRIPTION
```
go test .\cli\... .\config\...
ok      github.com/aliyun/aliyun-cli/cli        (cached)
ok      github.com/aliyun/aliyun-cli/config     0.380s
```