### PR TITLE
Recall the revise of code of flag_set to publish the program

### DIFF
--- a/cli/flag_set.go
+++ b/cli/flag_set.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"fmt"
-	"reflect"
 )
 
 type FlagSet struct {
@@ -186,15 +185,13 @@ func (fs *FlagSet) mergeWith(from *FlagSet, applier func(f *Flag) bool) *FlagSet
 // put flag, replace old value if duplicated
 func (fs *FlagSet) put(f *Flag) {
 
-	for i, lv := range fs.flags {
-		if f.Name == lv.Name && !reflect.DeepEqual(f, lv) {
-			fs.flags = append(fs.flags[:i], fs.flags[i+1:]...)
-			for _, s := range f.GetFormations() {
-				delete(fs.index, s)
-			}
-			fs.Add(f)
+	for _, lv := range fs.flags {
+		if lv == f {
 			return
 		}
 	}
-	fs.Add(f)
+	fs.flags = append(fs.flags, f)
+	for _, s := range f.GetFormations() {
+		fs.index[s] = f
+	}
 }

--- a/cli/flag_set_test.go
+++ b/cli/flag_set_test.go
@@ -94,10 +94,10 @@ func TestPut(t *testing.T) {
 	fs.put(&Flag{Name: "profile", Shorthand: 'p'})
 	assert.Len(t, fs.flags, 1)
 	fs.put(&Flag{Name: "profile", Shorthand: 'r'})
-	assert.Len(t, fs.flags, 1)
-	assert.Equal(t, 'r', fs.flags[0].Shorthand)
-	fs.put(&Flag{Name: "profil", Shorthand: 'a'})
 	assert.Len(t, fs.flags, 2)
+	assert.Equal(t, 'p', fs.flags[0].Shorthand)
+	fs.put(&Flag{Name: "profil", Shorthand: 'a'})
+	assert.Len(t, fs.flags, 3)
 }
 
 func TestMergeWith(t *testing.T) {


### PR DESCRIPTION
Recall the revise of function ```(fs *FlagSet) put(f *Flag)``` at flag_set.go