### PR TITLE
fix issue: Use `--force` flag call unknown product always got MissingAction.

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -275,7 +275,7 @@ func (c *Commando) createInvoker(ctx *cli.Context, productCode string, apiOrMeth
 		} else {
 			return &ForceRpcInvoker{
 				basicInvoker,
-				method,
+				apiOrMethod,
 			}, nil
 			// c.InvokeRpcForce(ctx, &product, apiOrMethod)
 		}


### PR DESCRIPTION
when use --force flags to call unknown RPC product, always got MissingAction error.