### PR TITLE
<fix>: load current configuration error

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -85,6 +85,9 @@ func LoadProfile(path string, w io.Writer, name string) (Profile, error) {
 	if err != nil {
 		return p, fmt.Errorf("init config failed %v", err)
 	}
+	if len(config.Profiles) == 0 {
+		config = NewConfiguration()
+	}
 	if name == "" {
 		name = config.CurrentProfile
 	}


### PR DESCRIPTION
1 when current config has no profiles, cli cannot run normly
