### PR TITLE
fix command `configure set` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Master
 
+- fix: AccessKeySecret in the `configure set` command is the same as AccessKeyId
+
 ### 3.0.27
 
 - update: meta data

--- a/config/configure_set.go
+++ b/config/configure_set.go
@@ -93,7 +93,7 @@ func doConfigureSet(w io.Writer, flags *cli.FlagSet) {
 		profile.AccessKeySecret = AccessKeySecretFlag(flags).GetStringOrDefault(profile.AccessKeySecret)
 	case StsToken:
 		profile.AccessKeyId = AccessKeyIdFlag(flags).GetStringOrDefault(profile.AccessKeyId)
-		profile.AccessKeySecret = AccessKeyIdFlag(flags).GetStringOrDefault(profile.AccessKeySecret)
+		profile.AccessKeySecret = AccessKeySecretFlag(flags).GetStringOrDefault(profile.AccessKeySecret)
 		profile.StsToken = StsTokenFlag(flags).GetStringOrDefault(profile.StsToken)
 	case RamRoleArn:
 		profile.AccessKeyId = AccessKeyIdFlag(flags).GetStringOrDefault(profile.AccessKeyId)


### PR DESCRIPTION
- fix: AccessKeySecret in the `configure set` command is the same as AccessKeyId