### PR TITLE
Modify GetAccessSecret to GetAccessKeySecret

### DIFF
--- a/oss/lib/cli_bridge.go
+++ b/oss/lib/cli_bridge.go
@@ -193,11 +193,11 @@ func getSessionCredential(profile *config.Profile) (string, string, string, erro
 		return "", "", "", err
 	}
 	var lastErr error
-	accessKeyID, err := credential.GetAccessKeyID()
+	accessKeyID, err := credential.GetAccessKeyId()
 	if err != nil {
 		lastErr = err
 	}
-	accessSecret, err := credential.GetAccessSecret()
+	accessSecret, err := credential.GetAccessKeySecret()
 	if err != nil {
 		lastErr = err
 	}


### PR DESCRIPTION
This is due to:
https://github.com/aliyun/credentials-go/pull/14

It is a fix so that aliyun-cli can compile against credentials-go release v0.0.3:
https://github.com/aliyun/credentials-go/releases/tag/v0.0.3
