### PR TITLE
fix broken link in Installation Guide section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you have installed `brew` in your computer, you can use it to install Alibaba
 brew install aliyun-cli
 ```
 
-If you need detailed installation steps or compile the installation steps, please visit [Installation Guide](https://www.alibabacloud.com/help/doc-detail/110343.htm?spm=a2c63.p38356.b99.4.56416f39SuRUr3).
+If you need detailed installation steps or compile the installation steps, please visit [Installation Guide](https://www.alibabacloud.com/help/doc-detail/121510.htm?spm=a2c63.p38356.b99.4.5cbe77039gtvbW).
 
 ## Configure
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you need detailed installation steps or compile the installation steps, pleas
 
 ## Configure
 
-For detailed configuration instructions, please visit the official website [Configuration Alibaba Cloud CLI](https://www.alibabacloud.com/help/doc-detail/110341.htm?spm=a2c63.p38356.b99.12.77d468f5YJVFg1).
+For detailed configuration instructions, please visit the official website [Configuration Alibaba Cloud CLI](https://www.alibabacloud.com/help/zh/doc-detail/121988.html).
 
 Before using Alibaba Cloud CLI to invoke the services, you need to configure the credential information, region, language, etc.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ If you have installed `brew` in your computer, you can use it to install Alibaba
 brew install aliyun-cli
 ```
 
-If you need detailed installation steps or compile the installation steps, please visit [Installation Guide](https://www.alibabacloud.com/help/doc-detail/121510.htm?spm=a2c63.p38356.b99.4.5cbe77039gtvbW).
+If you need detailed installation steps or compile the installation steps, please visit [Installation Guide](https://www.alibabacloud.com/help/zh/doc-detail/121988.html).
 
 ## Configure
 
-For detailed configuration instructions, please visit the official website [Configuration Alibaba Cloud CLI](https://www.alibabacloud.com/help/zh/doc-detail/121988.html).
+For detailed configuration instructions, please visit the official website [Configuration Alibaba Cloud CLI](https://www.alibabacloud.com/help/doc-detail/110341.htm?spm=a2c63.p38356.b99.12.77d468f5YJVFg1).
 
 Before using Alibaba Cloud CLI to invoke the services, you need to configure the credential information, region, language, etc.
 


### PR DESCRIPTION
**Problem**
I saw this link broken like this
![image](https://user-images.githubusercontent.com/18477492/141651690-04ec9010-0af7-4dde-949c-23e07391ab5d.png)

**Solution**
I change the link to [Installation Guide]( https://www.alibabacloud.com/help/doc-detail/121510.htm?spm=a2c63.p38356.b99.4.5cbe77039gtvbW) 
![image](https://user-images.githubusercontent.com/18477492/141651748-d11620d8-9693-4b5e-840d-4c11e9586a05.png)


