### PR TITLE
test(openapi): fix commando_test

### DIFF
--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -90,7 +90,7 @@ func Test_main(t *testing.T) {
 	args = []string{"ecs", "DescribeRegions"}
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "SDK.ServerError\nErrorCode: InvalidAction.NotFound\nRecommend: https://error-center.aliyun.com/status/search?Keyword=InvalidAction.NotFound&source=PopGw\nRequestId:"))
+	assert.True(t, strings.Contains(err.Error(), "SDK.ServerError\nErrorCode: InvalidAction.NotFound\nRecommend: https://troubleshoot.api.aliyun.com?q=InvalidAction.NotFound&product=Ecs\nRequestId:"))
 
 	ctx.Flags().Get("force").SetAssigned(false)
 	ctx.Flags().Get("version").SetAssigned(false)


### PR DESCRIPTION
change outdated SDK.ServerError InvalidAction.NotFound Recommend URL

The `err.Error()` is

```
SDK.ServerError
ErrorCode: InvalidAction.NotFound
Recommend: https://troubleshoot.api.aliyun.com?q=InvalidAction.NotFound&product=Ecs
RequestId: ***
Message: Specified api is not found, please check your url and method.
```

and can not pass the `commando_test`

```
=== RUN   Test_main
    commando_test.go:93:
                Error Trace:    commando_test.go:93
                Error:          Should be true
                Test:           Test_main
--- FAIL: Test_main (2.02s)
```

See also: https://github.com/aliyun/aliyun-cli/runs/5686481272?check_suite_focus=true#step:7:15