### PR TITLE
Add --RegionId

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -32,6 +32,7 @@ const (
 	PrivateKeyFlagName      = "private-key"
 	KeyPairNameFlagName     = "key-pair-name"
 	RegionFlagName          = "region"
+	RegionIdFlagName        = "RegionId"
 	LanguageFlagName        = "language"
 	ReadTimeoutFlagName     = "read-timeout"
 	ConnectTimeoutFlagName  = "connect-timeout"
@@ -47,6 +48,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(NewProfileFlag())
 	fs.Add(NewLanguageFlag())
 	fs.Add(NewRegionFlag())
+	fs.Add(NewRegionIdFlag())
 	fs.Add(NewConfigurePathFlag())
 	fs.Add(NewAccessKeyIdFlag())
 	fs.Add(NewAccessKeySecretFlag())
@@ -119,6 +121,10 @@ func KeyPairNameFlag(fs *cli.FlagSet) *cli.Flag {
 
 func RegionFlag(fs *cli.FlagSet) *cli.Flag {
 	return fs.Get(RegionFlagName)
+}
+
+func RegionIdFlag(fs *cli.FlagSet) *cli.Flag {
+	return fs.Get(RegionIdFlagName)
 }
 
 func LanguageFlag(fs *cli.FlagSet) *cli.Flag {
@@ -290,6 +296,14 @@ func NewRegionFlag() *cli.Flag {
 		Short: i18n.T(
 			"use `--region <regionId>` to assign region",
 			"使用 `--region <regionId>` 来指定访问大区")}
+}
+
+func NewRegionIdFlag() *cli.Flag {
+	return &cli.Flag{Category: "config",
+		Name:         RegionIdFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Hidden:       true,
+	}
 }
 
 func NewLanguageFlag() *cli.Flag {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -16,15 +16,15 @@ package openapi
 import (
 	"bytes"
 	"strings"
+	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/aliyun/aliyun-cli/cli"
 	"github.com/aliyun/aliyun-cli/config"
 	"github.com/aliyun/aliyun-cli/i18n"
 	"github.com/aliyun/aliyun-cli/meta"
-	"github.com/stretchr/testify/assert"
-
-	"testing"
 )
 
 func Test_main(t *testing.T) {
@@ -341,6 +341,7 @@ func TestCreateInvoker(t *testing.T) {
 
 	ctx.EnterCommand(&cli.Command{})
 	ctx.Flags().Add(config.NewRegionFlag())
+	ctx.Flags().Add(config.NewRegionIdFlag())
 	AddFlags(ctx.Flags())
 	ctx.Flags().Get("force").SetAssigned(false)
 	ctx.Flags().Get("version").SetAssigned(false)

--- a/openapi/invoker.go
+++ b/openapi/invoker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
+
 	"github.com/aliyun/aliyun-cli/cli"
 	"github.com/aliyun/aliyun-cli/config"
 	"github.com/aliyun/aliyun-cli/meta"
@@ -83,6 +84,8 @@ func (a *BasicInvoker) Init(ctx *cli.Context, product *meta.Product) error {
 
 	a.request.RegionId = a.profile.RegionId
 	if v, ok := config.RegionFlag(ctx.Flags()).GetValue(); ok {
+		a.request.RegionId = v
+	} else if v, ok := config.RegionIdFlag(ctx.Flags()).GetValue(); ok {
 		a.request.RegionId = v
 	}
 

--- a/openapi/invoker_test.go
+++ b/openapi/invoker_test.go
@@ -17,10 +17,11 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/aliyun/aliyun-cli/cli"
 	"github.com/aliyun/aliyun-cli/config"
 	"github.com/aliyun/aliyun-cli/meta"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBasicInvoker_Init(t *testing.T) {
@@ -42,6 +43,7 @@ func TestBasicInvoker_Init(t *testing.T) {
 	regionflag.SetAssigned(true)
 	regionflag.SetValue("cn-hangzhou")
 	ctx.Flags().Add(regionflag)
+	ctx.Flags().Add(config.NewRegionIdFlag())
 
 	endpointflag := NewEndpointFlag()
 	endpointflag.SetAssigned(true)


### PR DESCRIPTION
现在很多产品都会有个参数是 `RegionId` 并写在各个文档里，使用aliyun-cli的时候就会写上 `--RegionId cn-zhangjiakou` 这样子，但此时其实用的是profile里region（往往是cn-hangzhou）得到的endpoint，会查不到结果或者调用报错。
虽然改成用 `--region` 可以规避，但这个参数没什么地方会写（我是翻代码看了逻辑才知道）。
这里把 `--RegionId` 加成 `--region` 的alias，方便刚入手的人使用，且更符合直觉