### PR TITLE
When a reserved variable is set in a parameter, you need to determine whether it is also a query parameter required by the API.

### DIFF
--- a/cli/context.go
+++ b/cli/context.go
@@ -37,13 +37,18 @@ func NewHelpFlag() *Flag {
 
 // CLI Command Context
 type Context struct {
-	help         bool
-	flags        *FlagSet
-	unknownFlags *FlagSet
-	command      *Command
-	completion   *Completion
-	stdout       io.Writer
-	stderr       io.Writer
+	help            bool
+	flags           *FlagSet
+	unknownFlags    *FlagSet
+	command         *Command
+	completion      *Completion
+	stdout          io.Writer
+	stderr          io.Writer
+	inConfigureMode bool
+}
+
+func (ctx *Context) InConfigureMode() bool {
+	return ctx.inConfigureMode
 }
 
 func NewCommandContext(stdout io.Writer, stderr io.Writer) *Context {
@@ -146,4 +151,8 @@ func (ctx *Context) detectFlagByShorthand(ch rune) (*Flag, error) {
 		return flag, nil
 	}
 	return nil, fmt.Errorf("unknown flag -%s", string(ch))
+}
+
+func (ctx *Context) SetInConfigureMode(mode bool) {
+	ctx.inConfigureMode = mode
 }

--- a/cli/context_test.go
+++ b/cli/context_test.go
@@ -128,3 +128,15 @@ func TestDetectFlagByShorthand(t *testing.T) {
 	assert.Nil(t, f)
 	assert.EqualError(t, err, "unknown flag -c")
 }
+
+func TestSetInConfigureMode(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(w, stderr)
+
+	ctx.SetInConfigureMode(true)
+	assert.True(t, ctx.InConfigureMode())
+
+	ctx.SetInConfigureMode(false)
+	assert.False(t, ctx.InConfigureMode())
+}

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -144,7 +144,10 @@ func LoadProfileWithContext(ctx *cli.Context) (profile Profile, err error) {
 	}
 
 	// Load from flags
-	profile.OverwriteWithFlags(ctx)
+	if ctx.InConfigureMode() {
+		// If not in configure mode, we will not overwrite the profile with flags
+		profile.OverwriteWithFlags(ctx)
+	}
 	err = profile.Validate()
 	return
 }

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -284,6 +284,7 @@ func TestLoadProfileWithContextWhenIGNORE_PROFILE(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.SetInConfigureMode(true)
 	AddFlags(ctx.Flags())
 	ctx.Flags().Get("access-key-id").SetAssigned(true)
 	ctx.Flags().Get("access-key-id").SetValue("test-ak-id")

--- a/main/main.go
+++ b/main/main.go
@@ -63,6 +63,7 @@ func Main(args []string) {
 	ctx := cli.NewCommandContext(stdout, stderr)
 	ctx.EnterCommand(rootCmd)
 	ctx.SetCompletion(cli.ParseCompletionForShell())
+	ctx.SetInConfigureMode(openapi.DetectInConfigureMode(ctx.Flags()))
 
 	rootCmd.AddSubCommand(config.NewConfigureCommand())
 	rootCmd.AddSubCommand(lib.NewOssCommand())

--- a/openapi/library.go
+++ b/openapi/library.go
@@ -46,6 +46,11 @@ func (a *Library) GetApi(productCode string, version string, apiName string) (me
 	return a.builtinRepo.GetApi(productCode, version, apiName)
 }
 
+func (a *Library) GetApiByPath(productCode string, version string, method string, path string) (meta.Api, bool) {
+	return a.builtinRepo.GetApiByPath(productCode, version, method, path)
+
+}
+
 func (a *Library) GetStyle(productCode string, version string) (string, bool) {
 	return a.builtinRepo.GetStyle(productCode, version)
 }


### PR DESCRIPTION
When a reserved variable is set in a parameter, you need to determine whether it is also a query parameter required by the API.