### PR TITLE
Fix typo in error message and enhance flag parsing logic for command line arguments

### DIFF
--- a/cli/parser.go
+++ b/cli/parser.go
@@ -143,14 +143,20 @@ func (p *Parser) parseCommandArg(s string) (flag *Flag, value string, err error)
 		value = v
 	}
 
-	if strings.HasPrefix(prefix, "--") {
-		if len(prefix) > 2 {
-			flag, err = p.detector.detectFlag(prefix[2:])
-		} else {
-			err = fmt.Errorf("not support '--' in command line")
-		}
-	} else if strings.HasPrefix(prefix, "-") {
-		if len(prefix) == 2 {
+	if strings.HasPrefix(prefix, "-") {
+		// 特殊处理 SSL 证书等以多个连字符开头的情况
+		if strings.HasPrefix(prefix, "---") {
+			// 对于以三个或更多连字符开头的参数，视为值而非 flag
+			value = s
+		} else if strings.HasPrefix(prefix, "--") {
+			// 恰好以两个连字符开头的处理为长格式 flag
+			if len(prefix) > 2 {
+				flag, err = p.detector.detectFlag(prefix[2:])
+			} else {
+				err = fmt.Errorf("not support '--' in command line")
+			}
+		} else if len(prefix) == 2 {
+			// 对于 -x 格式的短 flag
 			flag, err = p.detector.detectFlagByShorthand(rune(prefix[1]))
 		} else {
 			err = fmt.Errorf("not support flag form %s", prefix)

--- a/cli/parser_test.go
+++ b/cli/parser_test.go
@@ -101,6 +101,16 @@ func TestParser1(t *testing.T) {
 	_, _, err = parser.parseCommandArg("-")
 	assert.NotNil(t, err)
 	assert.Equal(t, "not support flag form -", err.Error())
+
+	// more than two dashes, treat as value
+	_, v, err = parser.parseCommandArg("---a")
+	assert.Nil(t, err)
+	assert.Equal(t, "---a", v)
+
+	// contain ==
+	_, v, err = parser.parseCommandArg("----a==2")
+	assert.Nil(t, err)
+	assert.Equal(t, "----a==2", v)
 }
 
 // 2. can parse args and flags

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -304,7 +304,7 @@ func (c *Commando) createInvoker(ctx *cli.Context, productCode string, apiOrMeth
 					style, _ := ctx.Flags().Get("style").GetValue()
 					if style == "" {
 						return nil, cli.NewErrorWithTip(fmt.Errorf("uncheked version %s", version),
-							"Please use --style to speicify API sytle, rpc or restful.")
+							"Please use --style to specify API style, rpc or restful.")
 					}
 					product.ApiStyle = style
 				}


### PR DESCRIPTION
Fix typo in error message and enhance flag parsing logic for command line arguments