### PR TITLE
Fix hardcoded path for uname utility in install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ fi
 
 if [[ -n "${CLI_ON_LINUX-}" ]]
 then
-  UNAME_MACHINE="$(/usr/bin/uname -m)"
+  UNAME_MACHINE="$(uname -m)"
   if [[ "${UNAME_MACHINE}" == "arm64" || "${UNAME_MACHINE}" == "aarch64" ]]
   then
     curl -O -fsSL https://aliyuncli.alicdn.com/aliyun-cli-linux-"$VERSION"-arm64.tgz


### PR DESCRIPTION
I faced this issue when installing aliyun-cli in my docker image

```
sh: /usr/bin/uname: not found
```

This is because `uname` is installed on `/bin/uname`, contrary to what the script assume.