### PR TITLE
fix: add missing source-profile flag

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -63,6 +63,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(NewStsRegionFlag())
 	fs.Add(NewRamRoleNameFlag())
 	fs.Add(NewRamRoleArnFlag())
+	fs.Add(NewSourceProfileFlag())
 	fs.Add(NewRoleSessionNameFlag())
 	fs.Add(NewExternalIdFlag())
 	fs.Add(NewPrivateKeyFlag())
@@ -284,6 +285,17 @@ func NewRamRoleArnFlag() *cli.Flag {
 		Short: i18n.T(
 			"use `--ram-role-arn <RamRoleArn>` to assign RamRoleArn",
 			"使用 `--ram-role-arn <RamRoleArn>` 指定RamRoleArn"),
+	}
+}
+
+func NewSourceProfileFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "config",
+		Name:         SourceProfileFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Short: i18n.T(
+			"use `--source-profile <SourceProfile>` to assign SourceProfile",
+			"使用 `--source-profile <SourceProfile>` 指定SourceProfile"),
 	}
 }
 

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -150,6 +150,24 @@ func TestAddFlag(t *testing.T) {
 			DefaultValue: "",
 			Persistent:   false,
 		}
+		newSourceProfileFlag = &cli.Flag{
+			Category:     "config",
+			Name:         SourceProfileFlagName,
+			AssignedMode: cli.AssignedOnce,
+			Short: i18n.T(
+				"use `--source-profile <SourceProfile>` to assign SourceProfile",
+				"使用 `--source-profile <SourceProfile>` 指定SourceProfile"),
+			Long:         nil,
+			Required:     false,
+			Aliases:      nil,
+			Hidden:       false,
+			Validate:     nil,
+			Fields:       nil,
+			ExcludeWith:  nil,
+			Shorthand:    0,
+			DefaultValue: "",
+			Persistent:   false,
+		}
 		newRoleSessionNameFlag = &cli.Flag{
 			Category:     "config",
 			Name:         RoleSessionNameFlagName,
@@ -392,6 +410,9 @@ func TestAddFlag(t *testing.T) {
 
 	f = NewRamRoleArnFlag()
 	assert.Equal(t, newRamRoleArnFlag, f)
+
+	f = NewSourceProfileFlag()
+	assert.Equal(t, newSourceProfileFlag, f)
 
 	f = NewRoleSessionNameFlag()
 	assert.Equal(t, newRoleSessionNameFlag, f)


### PR DESCRIPTION
The source profile flag was added but not properly initialized so it was not usable in the `aliyun configure set` command
This PR fix this.

@CodeSpaceiiii @JacksonTian @sdk-team Can you have a look  ? 