### PR TITLE
Add RISC-V Host Support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
+        include:
+         - os: self-hosted  # Add a native RISC-V leg that uses your self-hosted riscv64 runner
+           runs_on: '["self-hosted","Linux","riscv64"]'
     runs-on: ${{ matrix.os }}
     environment: CI
     steps:
@@ -23,8 +26,16 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: "1.23"
+    
+    - name: Install dependencies (for self-hosted only)
+      if: matrix.os == 'self-hosted'
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y make build-essential
 
     - name: Unit Test
+      if: matrix.os != 'self-hosted' 
       run: make test
     - name: Upload coverage infomartion
       uses: codecov/codecov-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,29 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X 'github.com/aliyun/aliyun-cli/v3/cli.Version=${VERSION}'" -o out/aliyun main/main.go
           tar zcvf out/aliyun-cli-linux-${VERSION}-arm64.tgz -C out aliyun
           bash tools/upload_asset.sh ${VERSION} out/aliyun-cli-linux-${VERSION}-arm64.tgz
+  build_for_linux_riscv64:
+   needs: [create_release]
+   name: Native RISC-V Build
+   runs-on: self-hosted
+   env:
+     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+   steps:
+     - uses: actions/checkout@v4
+       with:
+         submodules: true
+         ref: ${{ github.ref }}
+     - name: Set up Go
+       uses: actions/setup-go@v5
+       with:
+         go-version: '1.23'
+     - name: Build
+       run: |
+         TAG=${{ github.ref_name }}
+         VERSION=${TAG#v}
+         # build for Linux riscv64 (native)
+         CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 go build -ldflags "-X 'github.com/aliyun/aliyun-cli/v3/cli.Version=${VERSION}'" -o out/aliyun main/main.go
+         tar zcvf out/aliyun-cli-linux-${VERSION}-riscv64.tgz -C out aliyun
+         bash tools/upload_asset.sh ${VERSION} out/aliyun-cli-linux-${VERSION}-riscv64.tgz
   build_for_windows:
     needs: [create_release]
     name: Build for Windows

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 export VERSION=3.0.0-beta
 export RELEASE_PATH="releases/aliyun-cli-${VERSION}"
+ARCH        ?= $(shell uname -m)
 
 all: build
 publish: build build_mac build_linux build_windows build_linux_arm64 gen_version
@@ -14,7 +15,12 @@ build: deps
 	go build -ldflags "-X 'github.com/aliyun/aliyun-cli/cli.Version=${VERSION}'" -o out/aliyun main/main.go
 
 install: build
-	cp out/aliyun /usr/local/bin
+	@if [ "$(ARCH)" = "riscv64" ]; then \
+		install -d "$(HOME)/.local/bin"; \
+		install -m755 out/aliyun "$(HOME)/.local/bin/aliyun"; \
+	else \
+		install -Dm755 out/aliyun /usr/local/bin/aliyun; \
+	fi
 
 build_mac:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'github.com/aliyun/aliyun-cli/cli.Version=${VERSION}'" -o out/aliyun main/main.go


### PR DESCRIPTION
## TL;DR

Add RISC-V native build and release CI files.  
Tested on [Milk-V Pioneer Box](https://milkv.io/pioneer). Logs are available [here](https://github.com/akifejaz/aliyun-cli/actions/runs/17400914398/job/49393624925).

---

## Details
As this tool is written in go which is already ported on RISC-V so, I had no issue compiling this natively for RISC-V. I've added the build and release CI files in this PR, which I tested on Milk-V Pioneer Box. 
Please review the build logs [here](https://github.com/akifejaz/aliyun-cli/actions/runs/17400914398/job/49393624925)

I'm using GitHub CI Runner from [Cloud-V](https://cloud-v.co/), please see the registration page [here](https://cloud-v.co/github-riscv-runner). 

## Notes
I'm Akif from @[10xEngineers](https://10xengineers.ai/) working as part of official RISC-V Lab Partner ([Cloud-V](https://riscv.org/developers/labs/)). I'm mainly working on increasing the SW support for [RISC-V ](https://github.com/riscv) and with that intention I'm creating this PR, hoping to get this merged and have release from aliyun for RISC-V too.

- Please review the PR and logs
- I can provide access to RISC-V hardware if maintainers would like to enable official releases for riscv64.

