### PR TITLE
{Utils} Update mac runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   build_for_macosx:
     needs: [create_release]
     name: Build for MacOSX
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
     steps:


### PR DESCRIPTION
As stated in [actions](https://github.com/aliyun/aliyun-cli/actions/runs/20094933489/job/57651667776), macOS 13 Ventura based runner images are fully unsupported by December 8th, 2025 for [GitHub Actions](https://github.com/actions/runner-images/issues/13046).