### PR TITLE
{Mcp-proxy} Add access control for MCP servers

### DIFF
--- a/mcpproxy/command.go
+++ b/mcpproxy/command.go
@@ -162,7 +162,6 @@ func runMCPProxy(ctx *cli.Context) error {
 	allowedServersStr := ctx.Flags().Get("allowed-servers").GetStringOrDefault("")
 	blockedServersStr := ctx.Flags().Get("blocked-servers").GetStringOrDefault("")
 
-	// 解析允许的服务器列表
 	var allowedServers []string
 	if allowedServersStr != "" {
 		parts := strings.Split(allowedServersStr, ",")
@@ -174,7 +173,6 @@ func runMCPProxy(ctx *cli.Context) error {
 		}
 	}
 
-	// 解析禁止的服务器列表
 	var blockedServers []string
 	if blockedServersStr != "" {
 		parts := strings.Split(blockedServersStr, ",")
@@ -292,14 +290,17 @@ func printProxyInfo(ctx *cli.Context, proxy *MCPProxy) {
 
 	cli.Println(ctx.Stdout(), "\nAvailable Servers:")
 	for _, server := range proxy.ExistMcpServers {
-		isAllowed := proxy.isServerAllowed(server)
 		isBlocked := proxy.isServerBlocked(server)
 
 		status := ""
 		if isBlocked {
 			status = " (blocked)"
-		} else if !isAllowed && len(proxy.AllowedServers) > 0 {
-			status = " (not in whitelist)"
+		} else if len(proxy.AllowedServers) > 0 {
+			// 只有在没有被阻止的情况下才检查白名单
+			isAllowed := proxy.isServerAllowed(server)
+			if !isAllowed {
+				status = " (not in whitelist)"
+			}
 		}
 
 		cli.Printf(ctx.Stdout(), "  - %s%s\n", server.Name, status)

--- a/mcpproxy/mcp_server.go
+++ b/mcpproxy/mcp_server.go
@@ -594,11 +594,6 @@ func (p *MCPProxy) isPathBlocked(requestPath string) bool {
 }
 
 func (p *MCPProxy) isServerAllowed(server MCPServerInfo) bool {
-	// 先检查黑名单（优先级最高）
-	if p.isServerBlocked(server) {
-		return false
-	}
-
 	// 如果白名单为空，允许所有服务器
 	if len(p.AllowedServers) == 0 {
 		return true
@@ -631,11 +626,6 @@ func (p *MCPProxy) isServerAllowed(server MCPServerInfo) bool {
 }
 
 func (p *MCPProxy) isPathAllowed(requestPath string) bool {
-	// 先检查黑名单（优先级最高）
-	if p.isPathBlocked(requestPath) {
-		return false
-	}
-
 	// 如果白名单为空，允许所有路径
 	if len(p.AllowedServers) == 0 {
 		return true


### PR DESCRIPTION
**Related command**

`aliyun mcp-proxy`

**Description**

Add whitelist and blacklist access control features to MCP Proxy, allowing administrators to restrict which MCP servers can be accessed through the proxy. This feature is particularly useful for enterprise deployments and multi-tenant scenarios where fine-grained access control is required.

**Key Features**

1. Add Whitelist Support (`--allowed-servers`)
2. Add Blacklist Support (`--blocked-servers`)
3. Flexible Matching Modes
    **Path Prefix Matching**: Match by URL path prefix (e.g., `/mcp/server1`)
    **Server Name Matching**: Match by server name (e.g., `server1`)
    **Server ID Matching**: Match by server ID (e.g., `server-id-123`)
