### PR TITLE
{Core} Add `aliyun upgrade` and configurable plugin index source and fix CloudSSO/OAuth one-off CLI flags persisting

### DIFF
--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -18,12 +20,13 @@ import (
 	"time"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/pluginsettings"
 	"golang.org/x/mod/semver"
 )
 
 const (
-	IndexURL        = "https://aliyun-cli-pub.oss-cn-hangzhou.aliyuncs.com/plugins/plugin_pkg_index.json"    // 默认索引地址
-	CommandIndexURL = "https://aliyun-cli-pub.oss-cn-hangzhou.aliyuncs.com/plugins/plugin_search_index.json" // 命令倒排索引地址
+	IndexURL        = "https://aliyuncli.alicdn.com/plugins/plugin_pkg_index.json"    // 默认索引地址
+	CommandIndexURL = "https://aliyuncli.alicdn.com/plugins/plugin_search_index.json" // 命令倒排索引地址
 	EnvPluginsDir   = "ALIBABA_CLOUD_CLI_PLUGINS_DIR"
 	EnvNoCache      = "ALIBABA_CLOUD_CLI_PLUGIN_NO_CACHE"
 
@@ -43,8 +46,9 @@ func (e *ErrPluginNotFound) Error() string {
 
 type Manager struct {
 	rootDir         string
-	indexURL        string // For testing: allows overriding IndexURL
-	commandIndexURL string // For testing: allows overriding CommandIndexURL
+	sourceBase      string // from plugin-settings.json / env; empty = use built-in index URLs
+	indexURL        string // For testing: allows overriding resolved package index URL
+	commandIndexURL string // For testing: allows overriding resolved command index URL
 }
 
 func getHomePath() string {
@@ -86,7 +90,50 @@ func NewManager() (*Manager, error) {
 	if err := os.MkdirAll(rootDir, 0755); err != nil {
 		return nil, err
 	}
-	return &Manager{rootDir: rootDir}, nil
+	sysDir := filepath.Join(getHomePath(), ".aliyun")
+	settings, err := pluginsettings.Load(sysDir)
+	if err != nil {
+		settings = pluginsettings.Default()
+	}
+	base := pluginsettings.EffectiveSourceBase(settings)
+	return &Manager{rootDir: rootDir, sourceBase: base}, nil
+}
+
+func (m *Manager) resolvedPkgIndexURL() string {
+	if m.indexURL != "" {
+		return m.indexURL
+	}
+	if b := strings.TrimRight(strings.TrimSpace(m.sourceBase), "/"); b != "" {
+		return b + "/plugin_pkg_index.json"
+	}
+	return IndexURL
+}
+
+func (m *Manager) resolvedCommandIndexURL() string {
+	if m.commandIndexURL != "" {
+		return m.commandIndexURL
+	}
+	if b := strings.TrimRight(strings.TrimSpace(m.sourceBase), "/"); b != "" {
+		return b + "/plugin_search_index.json"
+	}
+	return CommandIndexURL
+}
+
+// common layout: .../pkgs/{name}/{version}/{basename}.
+func (m *Manager) resolvePackageDownloadURL(origURL, pluginName, version string) string {
+	if strings.TrimSpace(m.sourceBase) == "" {
+		return origURL
+	}
+	u, err := url.Parse(origURL)
+	if err != nil {
+		return origURL
+	}
+	baseName := path.Base(u.Path)
+	if baseName == "" || baseName == "." || baseName == "/" {
+		return origURL
+	}
+	b := strings.TrimRight(strings.TrimSpace(m.sourceBase), "/")
+	return fmt.Sprintf("%s/pkgs/%s/%s/%s", b, pluginName, version, baseName)
 }
 
 func (m *Manager) readCache(cacheFile string, ttl time.Duration, result interface{}) (hit bool, staleAvailable bool) {
@@ -161,10 +208,7 @@ func (m *Manager) fetchWithCache(url, cacheFile string, result interface{}) erro
 }
 
 func (m *Manager) GetIndex() (*Index, error) {
-	indexURL := IndexURL
-	if m.indexURL != "" {
-		indexURL = m.indexURL
-	}
+	indexURL := m.resolvedPkgIndexURL()
 	cacheFile := filepath.Join(m.rootDir, indexCacheFile)
 	var index Index
 	if err := m.fetchWithCache(indexURL, cacheFile, &index); err != nil {
@@ -174,10 +218,7 @@ func (m *Manager) GetIndex() (*Index, error) {
 }
 
 func (m *Manager) GetCommandIndex() (*CommandIndex, error) {
-	commandIndexURL := CommandIndexURL
-	if m.commandIndexURL != "" {
-		commandIndexURL = m.commandIndexURL
-	}
+	commandIndexURL := m.resolvedCommandIndexURL()
 	cacheFile := filepath.Join(m.rootDir, commandCacheFile)
 	var index CommandIndex
 	if err := m.fetchWithCache(commandIndexURL, cacheFile, &index); err != nil {
@@ -678,14 +719,18 @@ func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, vers
 		return err
 	}
 
-	archivePath, err := m.downloadAndVerifyPlugin(ctx, platInfo, actualPluginName, version)
+	downloadURL := m.resolvePackageDownloadURL(platInfo.URL, actualPluginName, version)
+	platForDownload := *platInfo
+	platForDownload.URL = downloadURL
+
+	archivePath, err := m.downloadAndVerifyPlugin(ctx, &platForDownload, actualPluginName, version)
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(filepath.Dir(archivePath))
 
 	extractDir := filepath.Join(m.rootDir, actualPluginName)
-	if err := m.extractPlugin(archivePath, extractDir, platInfo.URL); err != nil {
+	if err := m.extractPlugin(archivePath, extractDir, downloadURL); err != nil {
 		return err
 	}
 

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/pluginsettings"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,6 +29,35 @@ func newTestContext() *cli.Context {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	return cli.NewCommandContext(stdout, stderr)
+}
+
+func TestManager_resolvedIndexURLsWithSourceBase(t *testing.T) {
+	m := &Manager{sourceBase: "https://mirror.example.com/plugins"}
+	assert.Equal(t, "https://mirror.example.com/plugins/plugin_pkg_index.json", m.resolvedPkgIndexURL())
+	assert.Equal(t, "https://mirror.example.com/plugins/plugin_search_index.json", m.resolvedCommandIndexURL())
+}
+
+func TestManager_resolvePackageDownloadURL(t *testing.T) {
+	orig := "https://aliyun-cli-pub.oss-cn-hangzhou.aliyuncs.com/plugins/pkgs/aliyun-cli-acc/0.2.0/aliyun-cli-acc-linux-amd64.tar.gz"
+	m := &Manager{sourceBase: "https://mirror.example.com/plugins"}
+	got := m.resolvePackageDownloadURL(orig, "aliyun-cli-acc", "0.2.0")
+	assert.Equal(t, "https://mirror.example.com/plugins/pkgs/aliyun-cli-acc/0.2.0/aliyun-cli-acc-linux-amd64.tar.gz", got)
+
+	m2 := &Manager{}
+	assert.Equal(t, orig, m2.resolvePackageDownloadURL(orig, "x", "1.0.0"))
+}
+
+func TestNewManager_LoadsSourceBaseFromFile(t *testing.T) {
+	home := t.TempDir()
+	cleanup := setTestHomeDir(t, home)
+	defer cleanup()
+	confDir := filepath.Join(home, ".aliyun")
+	assert.NoError(t, os.MkdirAll(confDir, 0755))
+	data := []byte(`{"source_base":"https://x.example/plugins"}`)
+	assert.NoError(t, os.WriteFile(filepath.Join(confDir, pluginsettings.ConfigFileName), data, 0600))
+	mgr, err := NewManager()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://x.example/plugins", mgr.sourceBase)
 }
 
 func TestNewManager(t *testing.T) {

--- a/cli/upgrade/replace_binary_windows_test.go
+++ b/cli/upgrade/replace_binary_windows_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceBinary_Windows_NoOldFileAfterSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	current := filepath.Join(tmpDir, "aliyun.exe")
+	oldSidecar := current + ".old"
+	newPath := filepath.Join(tmpDir, "aliyun.new.exe")
+	want := []byte("new payload")
+	os.WriteFile(current, []byte("old"), 0755)
+	os.WriteFile(newPath, want, 0755)
+
+	assert.NoError(t, replaceBinary(newPath, current))
+
+	got, err := os.ReadFile(current)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	_, err = os.Stat(oldSidecar)
+	assert.True(t, os.IsNotExist(err), ".old sidecar should be removed after successful replace")
+}

--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -468,14 +468,7 @@ func copyFile(src, dst string, perm os.FileMode) error {
 	return err
 }
 
-func detectInstaller() installerType {
-	execPath, err := os.Executable()
-	if err != nil {
-		return installerDirect
-	}
-	execPath, _ = filepath.EvalSymlinks(execPath)
-	lower := strings.ToLower(execPath)
-
+func installerTypeFromExecPathLower(lower string) installerType {
 	if strings.Contains(lower, "linuxbrew") {
 		return installerLinuxbrew
 	}
@@ -483,6 +476,15 @@ func detectInstaller() installerType {
 		return installerHomebrew
 	}
 	return installerDirect
+}
+
+func detectInstaller() installerType {
+	execPath, err := os.Executable()
+	if err != nil {
+		return installerDirect
+	}
+	execPath, _ = filepath.EvalSymlinks(execPath)
+	return installerTypeFromExecPathLower(strings.ToLower(execPath))
 }
 
 func ensureVPrefix(version string) string {

--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -19,7 +19,6 @@ import (
 	"archive/zip"
 	"bufio"
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,36 +43,21 @@ const (
 )
 
 const (
-	ossBaseURL       = "https://aliyun-cli.oss-cn-hangzhou.aliyuncs.com"
-	ossVersionURL    = ossBaseURL + "/version"
-	githubReleaseURL = "https://api.github.com/repos/aliyun/aliyun-cli/releases/latest"
+	ossBaseURL    = "https://aliyun-cli.oss-accelerate.aliyuncs.com"
+	ossVersionURL = ossBaseURL + "/version"
 )
 
 var (
-	httpClient     = &http.Client{Timeout: 60 * time.Second}
-	stdin          io.Reader = os.Stdin
-	execCommand            = exec.Command // mockable for tests
-	detectInstallerFunc    = detectInstaller
+	httpClient                    = &http.Client{Timeout: 60 * time.Second}
+	stdin               io.Reader = os.Stdin
+	execCommand                   = exec.Command // mockable for tests
+	detectInstallerFunc           = detectInstaller
 )
 
-// upgradeSource holds the resolved version and download info.
 type upgradeSource struct {
 	latestVersion string
 	downloadURL   string
 	assetName     string
-	assetSize     int64 // 0 if unknown (e.g. OSS path without Content-Length)
-}
-
-type githubRelease struct {
-	TagName string        `json:"tag_name"`
-	Name    string        `json:"name"`
-	Assets  []githubAsset `json:"assets"`
-}
-
-type githubAsset struct {
-	Name               string `json:"name"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-	Size               int64  `json:"size"`
 }
 
 func NewUpgradeCommand() *cli.Command {
@@ -123,7 +107,6 @@ func doUpgrade(ctx *cli.Context) error {
 	}
 }
 
-// upgradeViaBrew delegates the upgrade to Homebrew / Linuxbrew.
 func upgradeViaBrew(ctx *cli.Context) error {
 	w := ctx.Stdout()
 	cli.Printf(w, "Detected Homebrew installation, delegating to brew...\n\n")
@@ -148,7 +131,6 @@ func upgradeViaBrew(ctx *cli.Context) error {
 	return nil
 }
 
-// upgradeViaDirect downloads the binary from OSS and replaces it in-place.
 func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 	w := ctx.Stdout()
 
@@ -178,11 +160,7 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 		}
 	}
 
-	sizeHint := ""
-	if source.assetSize > 0 {
-		sizeHint = " (" + formatSize(source.assetSize) + ")"
-	}
-	cli.Printf(w, "Downloading %s%s...\n", source.assetName, sizeHint)
+	cli.Printf(w, "Downloading %s...\n", source.assetName)
 	cli.Printf(w, "  From: %s\n", source.downloadURL)
 
 	tmpDir, err := os.MkdirTemp("", "aliyun-cli-upgrade-*")
@@ -192,7 +170,7 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 	defer os.RemoveAll(tmpDir)
 
 	archivePath := filepath.Join(tmpDir, source.assetName)
-	err = downloadFile(w, source.downloadURL, archivePath, source.assetSize)
+	err = downloadFile(w, source.downloadURL, archivePath)
 	if err != nil {
 		return fmt.Errorf("download failed: %s", err)
 	}
@@ -227,27 +205,7 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 	return nil
 }
 
-// ---------------------------------------------------------------------------
-// Version resolution: OSS primary, GitHub fallback
-// ---------------------------------------------------------------------------
-
 func resolveUpgradeSource() (*upgradeSource, error) {
-	source, ossErr := resolveFromOSS()
-	if ossErr == nil {
-		return source, nil
-	}
-
-	source, ghErr := resolveFromGitHub()
-	if ghErr == nil {
-		return source, nil
-	}
-
-	return nil, fmt.Errorf("OSS: %s; GitHub: %s", ossErr, ghErr)
-}
-
-// resolveFromOSS fetches the latest version from the OSS version file and
-// constructs a deterministic download URL based on OS/arch.
-func resolveFromOSS() (*upgradeSource, error) {
 	version, err := fetchVersionFromOSS()
 	if err != nil {
 		return nil, err
@@ -264,33 +222,6 @@ func resolveFromOSS() (*upgradeSource, error) {
 		assetName:     assetName,
 	}, nil
 }
-
-// resolveFromGitHub queries the GitHub Releases API and still uses the OSS
-// mirror for the actual download (the asset name is identical on both).
-func resolveFromGitHub() (*upgradeSource, error) {
-	release, err := fetchLatestRelease()
-	if err != nil {
-		return nil, err
-	}
-
-	latestVersion := normalizeVersion(release.TagName)
-
-	asset, err := findMatchingAsset(release.Assets)
-	if err != nil {
-		return nil, err
-	}
-
-	return &upgradeSource{
-		latestVersion: latestVersion,
-		downloadURL:   ossBaseURL + "/" + asset.Name,
-		assetName:     asset.Name,
-		assetSize:     asset.Size,
-	}, nil
-}
-
-// ---------------------------------------------------------------------------
-// OSS helpers
-// ---------------------------------------------------------------------------
 
 func fetchVersionFromOSS() (string, error) {
 	resp, err := httpClient.Get(ossVersionURL)
@@ -315,10 +246,6 @@ func fetchVersionFromOSS() (string, error) {
 	return version, nil
 }
 
-// buildAssetName constructs the expected release archive name for the current
-// platform, following the naming convention in local_build.sh:
-//
-//	aliyun-cli-{os}-{version}-{arch}.{tgz|zip}
 func buildAssetName(version string) (string, error) {
 	archName := runtime.GOARCH
 
@@ -334,85 +261,7 @@ func buildAssetName(version string) (string, error) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// GitHub helpers
-// ---------------------------------------------------------------------------
-
-func fetchLatestRelease() (*githubRelease, error) {
-	req, err := http.NewRequest("GET", githubReleaseURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("User-Agent", "aliyun-cli/"+cli.GetVersion())
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("network error: %s", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("failed to parse release info: %s", err)
-	}
-	if release.TagName == "" {
-		return nil, fmt.Errorf("no release tag found")
-	}
-
-	return &release, nil
-}
-
-func findMatchingAsset(assets []githubAsset) (*githubAsset, error) {
-	osName := runtime.GOOS
-	archName := runtime.GOARCH
-
-	osKeywords := map[string][]string{
-		"darwin":  {"macosx", "darwin"},
-		"linux":   {"linux"},
-		"windows": {"windows"},
-	}
-
-	keywords, ok := osKeywords[osName]
-	if !ok {
-		return nil, fmt.Errorf("unsupported operating system: %s", osName)
-	}
-
-	for _, keyword := range keywords {
-		for i := range assets {
-			name := strings.ToLower(assets[i].Name)
-			if strings.Contains(name, keyword) && strings.Contains(name, archName) {
-				return &assets[i], nil
-			}
-		}
-	}
-
-	if osName == "darwin" {
-		for i := range assets {
-			name := strings.ToLower(assets[i].Name)
-			for _, keyword := range keywords {
-				if strings.Contains(name, keyword) && strings.Contains(name, "universal") {
-					return &assets[i], nil
-				}
-			}
-		}
-	}
-
-	return nil, fmt.Errorf(
-		"no compatible binary found for %s/%s.\nAvailable assets: %s",
-		osName, archName, listAssetNames(assets))
-}
-
-// ---------------------------------------------------------------------------
-// Download, extract, replace
-// ---------------------------------------------------------------------------
-
-func downloadFile(w io.Writer, url, destPath string, totalSize int64) error {
+func downloadFile(w io.Writer, url, destPath string) error {
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return err
@@ -423,9 +272,7 @@ func downloadFile(w io.Writer, url, destPath string, totalSize int64) error {
 		return fmt.Errorf("download returned status %d for %s", resp.StatusCode, url)
 	}
 
-	if totalSize == 0 && resp.ContentLength > 0 {
-		totalSize = resp.ContentLength
-	}
+	totalSize := resp.ContentLength
 
 	out, err := os.Create(destPath)
 	if err != nil {
@@ -595,10 +442,6 @@ func copyFile(src, dst string, perm os.FileMode) error {
 	return err
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 func detectInstaller() installerType {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -614,10 +457,6 @@ func detectInstaller() installerType {
 		return installerHomebrew
 	}
 	return installerDirect
-}
-
-func normalizeVersion(tag string) string {
-	return strings.TrimPrefix(tag, "v")
 }
 
 func ensureVPrefix(version string) string {
@@ -650,12 +489,4 @@ func formatSize(bytes int64) string {
 	default:
 		return fmt.Sprintf("%d B", bytes)
 	}
-}
-
-func listAssetNames(assets []githubAsset) string {
-	names := make([]string, len(assets))
-	for i, a := range assets {
-		names[i] = a.Name
-	}
-	return strings.Join(names, ", ")
 }

--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -1,0 +1,661 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"golang.org/x/mod/semver"
+)
+
+type installerType int
+
+const (
+	installerDirect    installerType = iota // binary downloaded directly
+	installerHomebrew                       // macOS / Linux Homebrew
+	installerLinuxbrew                      // Linuxbrew
+)
+
+const (
+	ossBaseURL       = "https://aliyun-cli.oss-cn-hangzhou.aliyuncs.com"
+	ossVersionURL    = ossBaseURL + "/version"
+	githubReleaseURL = "https://api.github.com/repos/aliyun/aliyun-cli/releases/latest"
+)
+
+var (
+	httpClient     = &http.Client{Timeout: 60 * time.Second}
+	stdin          io.Reader = os.Stdin
+	execCommand            = exec.Command // mockable for tests
+	detectInstallerFunc    = detectInstaller
+)
+
+// upgradeSource holds the resolved version and download info.
+type upgradeSource struct {
+	latestVersion string
+	downloadURL   string
+	assetName     string
+	assetSize     int64 // 0 if unknown (e.g. OSS path without Content-Length)
+}
+
+type githubRelease struct {
+	TagName string        `json:"tag_name"`
+	Name    string        `json:"name"`
+	Assets  []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+func NewUpgradeCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name: "upgrade",
+		Short: i18n.T(
+			"upgrade Alibaba Cloud CLI to the latest version",
+			"升级阿里云CLI到最新版本"),
+		Long: i18n.T(
+			"Upgrade Alibaba Cloud CLI to the latest release.\n"+
+				"If installed via Homebrew, delegates to 'brew upgrade'.\n"+
+				"Otherwise downloads from Alibaba Cloud OSS mirror.",
+			"升级阿里云CLI到最新版本。\n"+
+				"如果通过Homebrew安装，自动调用brew upgrade升级。\n"+
+				"否则从阿里云OSS镜像源下载。"),
+		Usage: "upgrade [--yes]",
+		Run: func(ctx *cli.Context, args []string) error {
+			return doUpgrade(ctx)
+		},
+	}
+
+	cmd.Flags().Add(&cli.Flag{
+		Name:      "yes",
+		Shorthand: 'y',
+		Short: i18n.T(
+			"skip confirmation prompt",
+			"跳过确认提示"),
+		AssignedMode: cli.AssignedNone,
+	})
+
+	return cmd
+}
+
+func doUpgrade(ctx *cli.Context) error {
+	w := ctx.Stdout()
+
+	installer := detectInstallerFunc()
+
+	currentVersion := cli.GetVersion()
+	cli.Printf(w, "Current version: %s\n", currentVersion)
+
+	switch installer {
+	case installerHomebrew, installerLinuxbrew:
+		return upgradeViaBrew(ctx)
+	default:
+		return upgradeViaDirect(ctx, currentVersion)
+	}
+}
+
+// upgradeViaBrew delegates the upgrade to Homebrew / Linuxbrew.
+func upgradeViaBrew(ctx *cli.Context) error {
+	w := ctx.Stdout()
+	cli.Printf(w, "Detected Homebrew installation, delegating to brew...\n\n")
+
+	cli.Printf(w, "==> brew update\n")
+	update := execCommand("brew", "update")
+	update.Stdout = w
+	update.Stderr = ctx.Stderr()
+	if err := update.Run(); err != nil {
+		return fmt.Errorf("brew update failed: %s", err)
+	}
+
+	cli.Printf(w, "\n==> brew upgrade aliyun-cli\n")
+	upgrade := execCommand("brew", "upgrade", "aliyun-cli")
+	upgrade.Stdout = w
+	upgrade.Stderr = ctx.Stderr()
+	if err := upgrade.Run(); err != nil {
+		return fmt.Errorf("brew upgrade failed: %s", err)
+	}
+
+	cli.PrintfWithColor(w, cli.Green, "\nHomebrew upgrade complete!\n")
+	return nil
+}
+
+// upgradeViaDirect downloads the binary from OSS and replaces it in-place.
+func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
+	w := ctx.Stdout()
+
+	cli.Printf(w, "Checking for latest version...\n")
+
+	source, err := resolveUpgradeSource()
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %s", err)
+	}
+
+	cli.Printf(w, "Latest version:  %s\n\n", source.latestVersion)
+
+	if !isNewer(currentVersion, source.latestVersion) {
+		cli.PrintfWithColor(w, cli.Green, "You are already using the latest version.\n")
+		return nil
+	}
+
+	yesFlag := ctx.Flags().Get("yes")
+	if yesFlag == nil || !yesFlag.IsAssigned() {
+		cli.Printf(w, "Upgrade from %s to %s? (y/N): ", currentVersion, source.latestVersion)
+		reader := bufio.NewReader(stdin)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(strings.ToLower(input))
+		if input != "y" && input != "yes" {
+			cli.Printf(w, "Upgrade cancelled.\n")
+			return nil
+		}
+	}
+
+	sizeHint := ""
+	if source.assetSize > 0 {
+		sizeHint = " (" + formatSize(source.assetSize) + ")"
+	}
+	cli.Printf(w, "Downloading %s%s...\n", source.assetName, sizeHint)
+	cli.Printf(w, "  From: %s\n", source.downloadURL)
+
+	tmpDir, err := os.MkdirTemp("", "aliyun-cli-upgrade-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, source.assetName)
+	err = downloadFile(w, source.downloadURL, archivePath, source.assetSize)
+	if err != nil {
+		return fmt.Errorf("download failed: %s", err)
+	}
+
+	binaryName := "aliyun"
+	if runtime.GOOS == "windows" {
+		binaryName = "aliyun.exe"
+	}
+	extractedPath := filepath.Join(tmpDir, binaryName)
+	err = extractBinary(archivePath, extractedPath, binaryName)
+	if err != nil {
+		return fmt.Errorf("extraction failed: %s", err)
+	}
+
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %s", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %s", err)
+	}
+
+	cli.Printf(w, "Installing new version to %s ...\n", execPath)
+	err = replaceBinary(extractedPath, execPath)
+	if err != nil {
+		return fmt.Errorf("installation failed: %s\nYou may need to run with elevated privileges (sudo)", err)
+	}
+
+	cli.PrintfWithColor(w, cli.Green,
+		"\nSuccessfully upgraded Alibaba Cloud CLI from %s to %s!\n", currentVersion, source.latestVersion)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Version resolution: OSS primary, GitHub fallback
+// ---------------------------------------------------------------------------
+
+func resolveUpgradeSource() (*upgradeSource, error) {
+	source, ossErr := resolveFromOSS()
+	if ossErr == nil {
+		return source, nil
+	}
+
+	source, ghErr := resolveFromGitHub()
+	if ghErr == nil {
+		return source, nil
+	}
+
+	return nil, fmt.Errorf("OSS: %s; GitHub: %s", ossErr, ghErr)
+}
+
+// resolveFromOSS fetches the latest version from the OSS version file and
+// constructs a deterministic download URL based on OS/arch.
+func resolveFromOSS() (*upgradeSource, error) {
+	version, err := fetchVersionFromOSS()
+	if err != nil {
+		return nil, err
+	}
+
+	assetName, err := buildAssetName(version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &upgradeSource{
+		latestVersion: version,
+		downloadURL:   ossBaseURL + "/" + assetName,
+		assetName:     assetName,
+	}, nil
+}
+
+// resolveFromGitHub queries the GitHub Releases API and still uses the OSS
+// mirror for the actual download (the asset name is identical on both).
+func resolveFromGitHub() (*upgradeSource, error) {
+	release, err := fetchLatestRelease()
+	if err != nil {
+		return nil, err
+	}
+
+	latestVersion := normalizeVersion(release.TagName)
+
+	asset, err := findMatchingAsset(release.Assets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &upgradeSource{
+		latestVersion: latestVersion,
+		downloadURL:   ossBaseURL + "/" + asset.Name,
+		assetName:     asset.Name,
+		assetSize:     asset.Size,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// OSS helpers
+// ---------------------------------------------------------------------------
+
+func fetchVersionFromOSS() (string, error) {
+	resp, err := httpClient.Get(ossVersionURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to reach OSS: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OSS version file returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64))
+	if err != nil {
+		return "", err
+	}
+
+	version := strings.TrimSpace(string(body))
+	if version == "" {
+		return "", fmt.Errorf("empty version from OSS")
+	}
+	return version, nil
+}
+
+// buildAssetName constructs the expected release archive name for the current
+// platform, following the naming convention in local_build.sh:
+//
+//	aliyun-cli-{os}-{version}-{arch}.{tgz|zip}
+func buildAssetName(version string) (string, error) {
+	archName := runtime.GOARCH
+
+	switch runtime.GOOS {
+	case "darwin":
+		return fmt.Sprintf("aliyun-cli-macosx-%s-%s.tgz", version, archName), nil
+	case "linux":
+		return fmt.Sprintf("aliyun-cli-linux-%s-%s.tgz", version, archName), nil
+	case "windows":
+		return fmt.Sprintf("aliyun-cli-windows-%s-%s.zip", version, archName), nil
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GitHub helpers
+// ---------------------------------------------------------------------------
+
+func fetchLatestRelease() (*githubRelease, error) {
+	req, err := http.NewRequest("GET", githubReleaseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "aliyun-cli/"+cli.GetVersion())
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("network error: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to parse release info: %s", err)
+	}
+	if release.TagName == "" {
+		return nil, fmt.Errorf("no release tag found")
+	}
+
+	return &release, nil
+}
+
+func findMatchingAsset(assets []githubAsset) (*githubAsset, error) {
+	osName := runtime.GOOS
+	archName := runtime.GOARCH
+
+	osKeywords := map[string][]string{
+		"darwin":  {"macosx", "darwin"},
+		"linux":   {"linux"},
+		"windows": {"windows"},
+	}
+
+	keywords, ok := osKeywords[osName]
+	if !ok {
+		return nil, fmt.Errorf("unsupported operating system: %s", osName)
+	}
+
+	for _, keyword := range keywords {
+		for i := range assets {
+			name := strings.ToLower(assets[i].Name)
+			if strings.Contains(name, keyword) && strings.Contains(name, archName) {
+				return &assets[i], nil
+			}
+		}
+	}
+
+	if osName == "darwin" {
+		for i := range assets {
+			name := strings.ToLower(assets[i].Name)
+			for _, keyword := range keywords {
+				if strings.Contains(name, keyword) && strings.Contains(name, "universal") {
+					return &assets[i], nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"no compatible binary found for %s/%s.\nAvailable assets: %s",
+		osName, archName, listAssetNames(assets))
+}
+
+// ---------------------------------------------------------------------------
+// Download, extract, replace
+// ---------------------------------------------------------------------------
+
+func downloadFile(w io.Writer, url, destPath string, totalSize int64) error {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned status %d for %s", resp.StatusCode, url)
+	}
+
+	if totalSize == 0 && resp.ContentLength > 0 {
+		totalSize = resp.ContentLength
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	var downloaded int64
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := out.Write(buf[:n]); writeErr != nil {
+				return writeErr
+			}
+			downloaded += int64(n)
+			if totalSize > 0 {
+				pct := float64(downloaded) / float64(totalSize) * 100
+				cli.Printf(w, "\r  Progress: %.1f%% (%s / %s)", pct, formatSize(downloaded), formatSize(totalSize))
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return readErr
+		}
+	}
+
+	cli.Printf(w, "\r  Download complete.                                  \n")
+	return nil
+}
+
+func extractBinary(archivePath, destPath, binaryName string) error {
+	lower := strings.ToLower(archivePath)
+	if strings.HasSuffix(lower, ".tgz") || strings.HasSuffix(lower, ".tar.gz") {
+		return extractFromTarGz(archivePath, destPath, binaryName)
+	}
+	if strings.HasSuffix(lower, ".zip") {
+		return extractFromZip(archivePath, destPath, binaryName)
+	}
+	return fmt.Errorf("unsupported archive format: %s", filepath.Base(archivePath))
+}
+
+func extractFromTarGz(archivePath, destPath, binaryName string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if filepath.Base(header.Name) == binaryName && header.Typeflag == tar.TypeReg {
+			out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				return err
+			}
+			_, err = io.Copy(out, tr)
+			closeErr := out.Close()
+			if err != nil {
+				return err
+			}
+			return closeErr
+		}
+	}
+
+	return fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func extractFromZip(archivePath, destPath, binaryName string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if filepath.Base(f.Name) == binaryName {
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+
+			out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				rc.Close()
+				return err
+			}
+
+			_, err = io.Copy(out, rc)
+			rc.Close()
+			closeErr := out.Close()
+			if err != nil {
+				return err
+			}
+			return closeErr
+		}
+	}
+
+	return fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func replaceBinary(newPath, currentPath string) error {
+	info, err := os.Stat(currentPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat current binary: %s", err)
+	}
+
+	dir := filepath.Dir(currentPath)
+
+	if runtime.GOOS == "windows" {
+		oldPath := currentPath + ".old"
+		os.Remove(oldPath)
+
+		if err := os.Rename(currentPath, oldPath); err != nil {
+			return fmt.Errorf("failed to move current binary: %s", err)
+		}
+		if err := copyFile(newPath, currentPath, info.Mode()); err != nil {
+			os.Rename(oldPath, currentPath)
+			return err
+		}
+		os.Remove(oldPath)
+	} else {
+		tmpPath := filepath.Join(dir, ".aliyun.upgrade.tmp")
+		if err := copyFile(newPath, tmpPath, info.Mode()); err != nil {
+			os.Remove(tmpPath)
+			return err
+		}
+		if err := os.Rename(tmpPath, currentPath); err != nil {
+			os.Remove(tmpPath)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	dest, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer dest.Close()
+
+	_, err = io.Copy(dest, source)
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func detectInstaller() installerType {
+	execPath, err := os.Executable()
+	if err != nil {
+		return installerDirect
+	}
+	execPath, _ = filepath.EvalSymlinks(execPath)
+	lower := strings.ToLower(execPath)
+
+	if strings.Contains(lower, "linuxbrew") {
+		return installerLinuxbrew
+	}
+	if strings.Contains(lower, "homebrew") || strings.Contains(lower, "/cellar/") {
+		return installerHomebrew
+	}
+	return installerDirect
+}
+
+func normalizeVersion(tag string) string {
+	return strings.TrimPrefix(tag, "v")
+}
+
+func ensureVPrefix(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		return "v" + version
+	}
+	return version
+}
+
+func isNewer(current, latest string) bool {
+	cv := ensureVPrefix(current)
+	lv := ensureVPrefix(latest)
+
+	if !semver.IsValid(cv) || !semver.IsValid(lv) {
+		return current != latest
+	}
+	return semver.Compare(cv, lv) < 0
+}
+
+func formatSize(bytes int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+	)
+	switch {
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+func listAssetNames(assets []githubAsset) string {
+	names := make([]string, len(assets))
+	for i, a := range assets {
+		names[i] = a.Name
+	}
+	return strings.Join(names, ", ")
+}

--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -42,16 +42,18 @@ const (
 	installerLinuxbrew                      // Linuxbrew
 )
 
-const (
+var (
 	ossBaseURL    = "https://aliyuncli.alicdn.com"
 	ossVersionURL = ossBaseURL + "/version"
 )
 
 var (
-	httpClient                    = &http.Client{Timeout: 60 * time.Second}
-	stdin               io.Reader = os.Stdin
-	execCommand                   = exec.Command // mockable for tests
-	detectInstallerFunc           = detectInstaller
+	httpClient          = &http.Client{Timeout: 60 * time.Second}
+	stdin     io.Reader = os.Stdin
+
+	execCommand         = exec.Command
+	detectInstallerFunc = detectInstaller
+	resolveExecPathFunc = resolveExecPath
 )
 
 type upgradeSource struct {
@@ -160,7 +162,7 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 		return err
 	}
 
-	execPath, err := resolveExecPath()
+	execPath, err := resolveExecPathFunc()
 	if err != nil {
 		return err
 	}

--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -54,6 +54,9 @@ var (
 	execCommand         = exec.Command
 	detectInstallerFunc = detectInstaller
 	resolveExecPathFunc = resolveExecPath
+
+	osExecutable = os.Executable
+	evalSymlinks = filepath.EvalSymlinks
 )
 
 type upgradeSource struct {
@@ -216,11 +219,11 @@ func downloadAndExtract(w io.Writer, downloadURL, assetName string) (binaryPath 
 }
 
 func resolveExecPath() (string, error) {
-	execPath, err := os.Executable()
+	execPath, err := osExecutable()
 	if err != nil {
 		return "", fmt.Errorf("failed to get executable path: %s", err)
 	}
-	execPath, err = filepath.EvalSymlinks(execPath)
+	execPath, err = evalSymlinks(execPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve executable path: %s", err)
 	}
@@ -479,11 +482,11 @@ func installerTypeFromExecPathLower(lower string) installerType {
 }
 
 func detectInstaller() installerType {
-	execPath, err := os.Executable()
+	execPath, err := osExecutable()
 	if err != nil {
 		return installerDirect
 	}
-	execPath, _ = filepath.EvalSymlinks(execPath)
+	execPath, _ = evalSymlinks(execPath)
 	return installerTypeFromExecPathLower(strings.ToLower(execPath))
 }
 

--- a/cli/upgrade/upgrade.go
+++ b/cli/upgrade/upgrade.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	ossBaseURL    = "https://aliyun-cli.oss-accelerate.aliyuncs.com"
+	ossBaseURL    = "https://aliyuncli.alicdn.com"
 	ossVersionURL = ossBaseURL + "/version"
 )
 
@@ -135,12 +135,10 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 	w := ctx.Stdout()
 
 	cli.Printf(w, "Checking for latest version...\n")
-
 	source, err := resolveUpgradeSource()
 	if err != nil {
 		return fmt.Errorf("failed to check for updates: %s", err)
 	}
-
 	cli.Printf(w, "Latest version:  %s\n\n", source.latestVersion)
 
 	if !isNewer(currentVersion, source.latestVersion) {
@@ -148,31 +146,58 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 		return nil
 	}
 
-	yesFlag := ctx.Flags().Get("yes")
-	if yesFlag == nil || !yesFlag.IsAssigned() {
-		cli.Printf(w, "Upgrade from %s to %s? (y/N): ", currentVersion, source.latestVersion)
-		reader := bufio.NewReader(stdin)
-		input, _ := reader.ReadString('\n')
-		input = strings.TrimSpace(strings.ToLower(input))
-		if input != "y" && input != "yes" {
-			cli.Printf(w, "Upgrade cancelled.\n")
-			return nil
-		}
+	if !confirmUpgrade(ctx, currentVersion, source.latestVersion) {
+		cli.Printf(w, "Upgrade cancelled.\n")
+		return nil
 	}
 
-	cli.Printf(w, "Downloading %s...\n", source.assetName)
-	cli.Printf(w, "  From: %s\n", source.downloadURL)
+	cli.Printf(w, "Downloading %s...\n  From: %s\n", source.assetName, source.downloadURL)
+	extractedBinary, cleanup, err := downloadAndExtract(w, source.downloadURL, source.assetName)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return err
+	}
 
+	execPath, err := resolveExecPath()
+	if err != nil {
+		return err
+	}
+	cli.Printf(w, "Installing new version to %s ...\n", execPath)
+	if err := replaceBinary(extractedBinary, execPath); err != nil {
+		return fmt.Errorf("installation failed: %s\nYou may need to run with elevated privileges (sudo)", err)
+	}
+
+	cli.PrintfWithColor(w, cli.Green,
+		"\nSuccessfully upgraded Alibaba Cloud CLI from %s to %s!\n", currentVersion, source.latestVersion)
+	return nil
+}
+
+func confirmUpgrade(ctx *cli.Context, currentVersion, latestVersion string) bool {
+	yesFlag := ctx.Flags().Get("yes")
+	if yesFlag != nil && yesFlag.IsAssigned() {
+		return true
+	}
+	w := ctx.Stdout()
+	cli.Printf(w, "Upgrade from %s to %s? (y/N): ", currentVersion, latestVersion)
+	reader := bufio.NewReader(stdin)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "y" || input == "yes"
+}
+
+func downloadAndExtract(w io.Writer, downloadURL, assetName string) (binaryPath string, cleanup func(), err error) {
 	tmpDir, err := os.MkdirTemp("", "aliyun-cli-upgrade-*")
 	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %s", err)
+		return "", nil, fmt.Errorf("failed to create temp directory: %s", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	cleanup = func() { os.RemoveAll(tmpDir) }
 
-	archivePath := filepath.Join(tmpDir, source.assetName)
-	err = downloadFile(w, source.downloadURL, archivePath)
-	if err != nil {
-		return fmt.Errorf("download failed: %s", err)
+	archivePath := filepath.Join(tmpDir, assetName)
+	if err := downloadFile(w, downloadURL, archivePath); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("download failed: %s", err)
 	}
 
 	binaryName := "aliyun"
@@ -180,29 +205,24 @@ func upgradeViaDirect(ctx *cli.Context, currentVersion string) error {
 		binaryName = "aliyun.exe"
 	}
 	extractedPath := filepath.Join(tmpDir, binaryName)
-	err = extractBinary(archivePath, extractedPath, binaryName)
-	if err != nil {
-		return fmt.Errorf("extraction failed: %s", err)
+	if err := extractBinary(archivePath, extractedPath, binaryName); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("extraction failed: %s", err)
 	}
 
+	return extractedPath, cleanup, nil
+}
+
+func resolveExecPath() (string, error) {
 	execPath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("failed to get executable path: %s", err)
+		return "", fmt.Errorf("failed to get executable path: %s", err)
 	}
 	execPath, err = filepath.EvalSymlinks(execPath)
 	if err != nil {
-		return fmt.Errorf("failed to resolve executable path: %s", err)
+		return "", fmt.Errorf("failed to resolve executable path: %s", err)
 	}
-
-	cli.Printf(w, "Installing new version to %s ...\n", execPath)
-	err = replaceBinary(extractedPath, execPath)
-	if err != nil {
-		return fmt.Errorf("installation failed: %s\nYou may need to run with elevated privileges (sudo)", err)
-	}
-
-	cli.PrintfWithColor(w, cli.Green,
-		"\nSuccessfully upgraded Alibaba Cloud CLI from %s to %s!\n", currentVersion, source.latestVersion)
-	return nil
+	return execPath, nil
 }
 
 func resolveUpgradeSource() (*upgradeSource, error) {
@@ -281,7 +301,8 @@ func downloadFile(w io.Writer, url, destPath string) error {
 	defer out.Close()
 
 	var downloaded int64
-	buf := make([]byte, 32*1024)
+	var lastPct int64 = -1
+	buf := make([]byte, 256*1024)
 	for {
 		n, readErr := resp.Body.Read(buf)
 		if n > 0 {
@@ -290,8 +311,11 @@ func downloadFile(w io.Writer, url, destPath string) error {
 			}
 			downloaded += int64(n)
 			if totalSize > 0 {
-				pct := float64(downloaded) / float64(totalSize) * 100
-				cli.Printf(w, "\r  Progress: %.1f%% (%s / %s)", pct, formatSize(downloaded), formatSize(totalSize))
+				pct := downloaded * 100 / totalSize
+				if pct != lastPct {
+					lastPct = pct
+					cli.Printf(w, "\r  Progress: %d%% (%s / %s)", pct, formatSize(downloaded), formatSize(totalSize))
+				}
 			}
 		}
 		if readErr != nil {

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -178,6 +178,117 @@ func TestDoUpgrade_DirectWhenNotBrew(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// upgradeViaDirect end-to-end
+// ---------------------------------------------------------------------------
+
+func TestUpgradeViaDirect_FullFlow(t *testing.T) {
+	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
+	archive := createTarGzInMemory(t, "aliyun", binaryContent)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("99.0.0\n"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", archive.Len()))
+		w.Write(archive.Bytes())
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	origClient := httpClient
+	origOSSBase := ossBaseURL
+	origOSSVer := ossVersionURL
+	origStdin := stdin
+	origResolve := resolveExecPathFunc
+	defer func() {
+		httpClient = origClient
+		ossBaseURL = origOSSBase
+		ossVersionURL = origOSSVer
+		stdin = origStdin
+		resolveExecPathFunc = origResolve
+	}()
+
+	httpClient = server.Client()
+	ossBaseURL = server.URL
+	ossVersionURL = server.URL + "/version"
+	stdin = strings.NewReader("y\n")
+
+	targetBinary := filepath.Join(t.TempDir(), "aliyun")
+	os.WriteFile(targetBinary, []byte("old"), 0755)
+	resolveExecPathFunc = func() (string, error) { return targetBinary, nil }
+
+	ctx := newTestContext()
+	err := upgradeViaDirect(ctx, "3.0.0")
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(targetBinary)
+	assert.NoError(t, err)
+	assert.Equal(t, binaryContent, got, "binary should be replaced with new content")
+}
+
+func TestUpgradeViaDirect_AlreadyLatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("3.0.0\n"))
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	origOSSBase := ossBaseURL
+	origOSSVer := ossVersionURL
+	defer func() {
+		httpClient = origClient
+		ossBaseURL = origOSSBase
+		ossVersionURL = origOSSVer
+	}()
+
+	httpClient = server.Client()
+	ossBaseURL = server.URL
+	ossVersionURL = server.URL + "/version"
+
+	ctx := newTestContext()
+	var stdout bytes.Buffer
+	ctx = cli.NewCommandContext(&stdout, &bytes.Buffer{})
+	ctx.EnterCommand(NewUpgradeCommand())
+
+	err := upgradeViaDirect(ctx, "3.0.0")
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), "already using the latest version")
+}
+
+func TestUpgradeViaDirect_UserCancels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("99.0.0\n"))
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	origOSSBase := ossBaseURL
+	origOSSVer := ossVersionURL
+	origStdin := stdin
+	defer func() {
+		httpClient = origClient
+		ossBaseURL = origOSSBase
+		ossVersionURL = origOSSVer
+		stdin = origStdin
+	}()
+
+	httpClient = server.Client()
+	ossBaseURL = server.URL
+	ossVersionURL = server.URL + "/version"
+	stdin = strings.NewReader("n\n")
+
+	ctx := newTestContext()
+	var stdout bytes.Buffer
+	ctx = cli.NewCommandContext(&stdout, &bytes.Buffer{})
+	ctx.EnterCommand(NewUpgradeCommand())
+
+	err := upgradeViaDirect(ctx, "3.0.0")
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Upgrade cancelled")
+}
+
+// ---------------------------------------------------------------------------
 // confirmUpgrade
 // ---------------------------------------------------------------------------
 

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -331,6 +331,9 @@ func TestConfirmUpgrade_StdinEmpty(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDownloadAndExtract_Success(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test on non-linux platform")
+	}
 	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
 	archiveBuf := createTarGzInMemory(t, "aliyun", binaryContent)
 

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -257,8 +257,10 @@ func TestExtractFromTarGz(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, binaryContent, got)
 
-	info, _ := os.Stat(destPath)
-	assert.True(t, info.Mode()&0100 != 0, "binary should be executable")
+	if runtime.GOOS != "windows" {
+		info, _ := os.Stat(destPath)
+		assert.True(t, info.Mode()&0100 != 0, "binary should be executable")
+	}
 }
 
 func TestExtractFromTarGz_NotFound(t *testing.T) {
@@ -342,8 +344,10 @@ func TestCopyFile(t *testing.T) {
 	got, _ := os.ReadFile(dstPath)
 	assert.Equal(t, content, got)
 
-	info, _ := os.Stat(dstPath)
-	assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		info, _ := os.Stat(dstPath)
+		assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -177,6 +178,121 @@ func TestDoUpgrade_DirectWhenNotBrew(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// confirmUpgrade
+// ---------------------------------------------------------------------------
+
+func TestConfirmUpgrade_YesFlag(t *testing.T) {
+	ctx := newTestContext()
+	ctx.Flags().Get("yes").SetAssigned(true)
+
+	assert.True(t, confirmUpgrade(ctx, "3.0.0", "3.1.0"))
+}
+
+func TestConfirmUpgrade_StdinYes(t *testing.T) {
+	origStdin := stdin
+	defer func() { stdin = origStdin }()
+	stdin = strings.NewReader("y\n")
+
+	ctx := newTestContext()
+	assert.True(t, confirmUpgrade(ctx, "3.0.0", "3.1.0"))
+}
+
+func TestConfirmUpgrade_StdinNo(t *testing.T) {
+	origStdin := stdin
+	defer func() { stdin = origStdin }()
+	stdin = strings.NewReader("n\n")
+
+	ctx := newTestContext()
+	assert.False(t, confirmUpgrade(ctx, "3.0.0", "3.1.0"))
+}
+
+func TestConfirmUpgrade_StdinEmpty(t *testing.T) {
+	origStdin := stdin
+	defer func() { stdin = origStdin }()
+	stdin = strings.NewReader("\n")
+
+	ctx := newTestContext()
+	assert.False(t, confirmUpgrade(ctx, "3.0.0", "3.1.0"))
+}
+
+// ---------------------------------------------------------------------------
+// downloadAndExtract
+// ---------------------------------------------------------------------------
+
+func TestDownloadAndExtract_Success(t *testing.T) {
+	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
+	archiveBuf := createTarGzInMemory(t, "aliyun", binaryContent)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", archiveBuf.Len()))
+		w.Write(archiveBuf.Bytes())
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	var out bytes.Buffer
+	binaryPath, cleanup, err := downloadAndExtract(&out, server.URL+"/aliyun-cli-linux-3.4.0-amd64.tgz", "aliyun-cli-linux-3.4.0-amd64.tgz")
+	assert.NoError(t, err)
+	assert.NotNil(t, cleanup)
+	defer cleanup()
+
+	got, err := os.ReadFile(binaryPath)
+	assert.NoError(t, err)
+	assert.Equal(t, binaryContent, got)
+}
+
+func TestDownloadAndExtract_DownloadFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	var out bytes.Buffer
+	_, cleanup, err := downloadAndExtract(&out, server.URL+"/missing.tgz", "missing.tgz")
+	assert.Error(t, err)
+	assert.Nil(t, cleanup)
+	assert.Contains(t, err.Error(), "download failed")
+}
+
+func TestDownloadAndExtract_ExtractFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not a valid archive"))
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	var out bytes.Buffer
+	_, cleanup, err := downloadAndExtract(&out, server.URL+"/bad.tgz", "bad.tgz")
+	assert.Error(t, err)
+	assert.Nil(t, cleanup)
+	assert.Contains(t, err.Error(), "extraction failed")
+}
+
+// ---------------------------------------------------------------------------
+// resolveExecPath
+// ---------------------------------------------------------------------------
+
+func TestResolveExecPath(t *testing.T) {
+	p, err := resolveExecPath()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, p)
+
+	info, err := os.Stat(p)
+	assert.NoError(t, err)
+	assert.False(t, info.IsDir())
+}
+
+// ---------------------------------------------------------------------------
 // Build asset name (OSS path)
 // ---------------------------------------------------------------------------
 
@@ -234,7 +350,7 @@ func TestResolveFromOSS_BuildsCorrectURL(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedURL := ossBaseURL + "/" + assetName
-	assert.True(t, strings.HasPrefix(expectedURL, "https://aliyun-cli.oss-accelerate.aliyuncs.com/aliyun-cli-"))
+	assert.True(t, strings.HasPrefix(expectedURL, ossBaseURL+"/aliyun-cli-"))
 	assert.Contains(t, expectedURL, version)
 }
 
@@ -435,4 +551,18 @@ func createTestZip(t *testing.T, archivePath, fileName string, content []byte) {
 
 	w, _ := zw.Create(fileName)
 	w.Write(content)
+}
+
+func createTarGzInMemory(t *testing.T, fileName string, content []byte) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	tw.WriteHeader(&tar.Header{
+		Name: fileName, Size: int64(len(content)), Mode: 0755, Typeflag: tar.TypeReg,
+	})
+	tw.Write(content)
+	tw.Close()
+	gw.Close()
+	return &buf
 }

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -1,0 +1,572 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Version helpers
+// ---------------------------------------------------------------------------
+
+func TestNormalizeVersion(t *testing.T) {
+	assert.Equal(t, "3.0.1", normalizeVersion("v3.0.1"))
+	assert.Equal(t, "3.0.1", normalizeVersion("3.0.1"))
+	assert.Equal(t, "3.0.1-beta", normalizeVersion("v3.0.1-beta"))
+}
+
+func TestEnsureVPrefix(t *testing.T) {
+	assert.Equal(t, "v3.0.1", ensureVPrefix("3.0.1"))
+	assert.Equal(t, "v3.0.1", ensureVPrefix("v3.0.1"))
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		current  string
+		latest   string
+		expected bool
+	}{
+		{"3.0.1", "3.0.2", true},
+		{"3.0.2", "3.0.2", false},
+		{"3.0.3", "3.0.2", false},
+		{"3.0.0", "3.1.0", true},
+		{"2.9.9", "3.0.0", true},
+		{"3.0.0-beta", "3.0.0", true},
+		{"3.0.0", "3.0.0-beta", false},
+		{"3.0.0-alpha", "3.0.0-beta", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.current+"_vs_"+tt.latest, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isNewer(tt.current, tt.latest))
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	assert.Equal(t, "0 B", formatSize(0))
+	assert.Equal(t, "512 B", formatSize(512))
+	assert.Equal(t, "1.0 KB", formatSize(1024))
+	assert.Equal(t, "1.5 KB", formatSize(1536))
+	assert.Equal(t, "1.0 MB", formatSize(1024*1024))
+	assert.Equal(t, "10.5 MB", formatSize(11010048))
+}
+
+// ---------------------------------------------------------------------------
+// Installer detection
+// ---------------------------------------------------------------------------
+
+func TestDetectInstaller_Default(t *testing.T) {
+	result := detectInstaller()
+	// In a test environment the binary is in a temp dir, not Homebrew
+	assert.Equal(t, installerDirect, result)
+}
+
+// ---------------------------------------------------------------------------
+// Brew upgrade (mock exec)
+// ---------------------------------------------------------------------------
+
+func TestUpgradeViaBrew_Success(t *testing.T) {
+	origExec := execCommand
+	defer func() { execCommand = origExec }()
+
+	var calls [][]string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		return exec.Command("echo", "ok")
+	}
+
+	ctx := newTestContext()
+	err := upgradeViaBrew(ctx)
+	assert.NoError(t, err)
+
+	assert.Len(t, calls, 2)
+	assert.Equal(t, []string{"brew", "update"}, calls[0])
+	assert.Equal(t, []string{"brew", "upgrade", "aliyun-cli"}, calls[1])
+}
+
+func TestUpgradeViaBrew_UpdateFails(t *testing.T) {
+	origExec := execCommand
+	defer func() { execCommand = origExec }()
+
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+
+	ctx := newTestContext()
+	err := upgradeViaBrew(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "brew update failed")
+}
+
+func TestUpgradeViaBrew_UpgradeFails(t *testing.T) {
+	origExec := execCommand
+	defer func() { execCommand = origExec }()
+
+	callCount := 0
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		callCount++
+		if callCount == 1 {
+			return exec.Command("echo", "ok") // brew update succeeds
+		}
+		return exec.Command("false") // brew upgrade fails
+	}
+
+	ctx := newTestContext()
+	err := upgradeViaBrew(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "brew upgrade failed")
+}
+
+func TestDoUpgrade_DelegatesToBrew(t *testing.T) {
+	origDetect := detectInstallerFunc
+	origExec := execCommand
+	defer func() {
+		detectInstallerFunc = origDetect
+		execCommand = origExec
+	}()
+
+	detectInstallerFunc = func() installerType { return installerHomebrew }
+
+	var calls [][]string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		return exec.Command("echo", "ok")
+	}
+
+	ctx := newTestContext()
+	err := doUpgrade(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, calls, 2)
+	assert.Equal(t, "brew", calls[0][0])
+}
+
+func TestDoUpgrade_DirectWhenNotBrew(t *testing.T) {
+	origDetect := detectInstallerFunc
+	origExec := execCommand
+	origStdin := stdin
+	defer func() {
+		detectInstallerFunc = origDetect
+		execCommand = origExec
+		stdin = origStdin
+	}()
+
+	detectInstallerFunc = func() installerType { return installerDirect }
+
+	brewCalled := false
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "brew" {
+			brewCalled = true
+		}
+		return exec.Command("echo", "ok")
+	}
+
+	// Provide "n" to the confirmation prompt so it cancels gracefully
+	stdin = strings.NewReader("n\n")
+
+	ctx := newTestContext()
+	_ = doUpgrade(ctx)
+	assert.False(t, brewCalled, "brew should not be called for direct installer")
+}
+
+// ---------------------------------------------------------------------------
+// Build asset name (OSS path)
+// ---------------------------------------------------------------------------
+
+func TestBuildAssetName(t *testing.T) {
+	name, err := buildAssetName("3.3.4")
+	assert.NoError(t, err)
+
+	switch runtime.GOOS {
+	case "darwin":
+		assert.Equal(t, "aliyun-cli-macosx-3.3.4-"+runtime.GOARCH+".tgz", name)
+	case "linux":
+		assert.Equal(t, "aliyun-cli-linux-3.3.4-"+runtime.GOARCH+".tgz", name)
+	case "windows":
+		assert.Equal(t, "aliyun-cli-windows-3.3.4-"+runtime.GOARCH+".zip", name)
+	}
+}
+
+func TestBuildAssetName_VersionWithPrerelease(t *testing.T) {
+	name, err := buildAssetName("3.4.0-beta.1")
+	assert.NoError(t, err)
+	assert.Contains(t, name, "3.4.0-beta.1")
+}
+
+// ---------------------------------------------------------------------------
+// OSS version fetch
+// ---------------------------------------------------------------------------
+
+func TestFetchVersionFromOSS(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("3.3.4\n"))
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	resp, err := httpClient.Get(server.URL)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	buf := make([]byte, 64)
+	n, _ := resp.Body.Read(buf)
+	version := strings.TrimSpace(string(buf[:n]))
+	assert.Equal(t, "3.3.4", version)
+}
+
+// ---------------------------------------------------------------------------
+// resolveFromOSS / resolveFromGitHub integration
+// ---------------------------------------------------------------------------
+
+func TestResolveFromOSS_BuildsCorrectURL(t *testing.T) {
+	version := "3.3.4"
+	assetName, err := buildAssetName(version)
+	assert.NoError(t, err)
+
+	expectedURL := ossBaseURL + "/" + assetName
+	assert.True(t, strings.HasPrefix(expectedURL, "https://aliyun-cli.oss-cn-hangzhou.aliyuncs.com/aliyun-cli-"))
+	assert.Contains(t, expectedURL, version)
+}
+
+func TestResolveFromGitHub_UsesOSSDownloadURL(t *testing.T) {
+	release := githubRelease{
+		TagName: "v3.3.4",
+		Assets: []githubAsset{
+			{Name: "aliyun-cli-linux-3.3.4-amd64.tgz", BrowserDownloadURL: "https://github.com/download/linux.tgz", Size: 20000000},
+			{Name: "aliyun-cli-linux-3.3.4-arm64.tgz", BrowserDownloadURL: "https://github.com/download/linux-arm.tgz", Size: 19000000},
+			{Name: "aliyun-cli-macosx-3.3.4-arm64.tgz", BrowserDownloadURL: "https://github.com/download/mac-arm.tgz", Size: 22000000},
+			{Name: "aliyun-cli-macosx-3.3.4-amd64.tgz", BrowserDownloadURL: "https://github.com/download/mac-amd.tgz", Size: 22000000},
+			{Name: "aliyun-cli-macosx-3.3.4-universal.tgz", BrowserDownloadURL: "https://github.com/download/mac-uni.tgz", Size: 44000000},
+			{Name: "aliyun-cli-windows-3.3.4-amd64.zip", BrowserDownloadURL: "https://github.com/download/win.zip", Size: 21000000},
+		},
+	}
+
+	asset, err := findMatchingAsset(release.Assets)
+	assert.NoError(t, err)
+
+	downloadURL := ossBaseURL + "/" + asset.Name
+	assert.True(t, strings.HasPrefix(downloadURL, ossBaseURL))
+	assert.NotContains(t, downloadURL, "github.com")
+}
+
+// ---------------------------------------------------------------------------
+// Asset matching (GitHub fallback path)
+// ---------------------------------------------------------------------------
+
+func TestFindMatchingAsset(t *testing.T) {
+	assets := []githubAsset{
+		{Name: "aliyun-cli-linux-3.0.1-amd64.tgz", Size: 1000},
+		{Name: "aliyun-cli-linux-3.0.1-arm64.tgz", Size: 1000},
+		{Name: "aliyun-cli-macosx-3.0.1-amd64.tgz", Size: 1000},
+		{Name: "aliyun-cli-macosx-3.0.1-arm64.tgz", Size: 1000},
+		{Name: "aliyun-cli-macosx-3.0.1-universal.tgz", Size: 1000},
+		{Name: "aliyun-cli-windows-3.0.1-amd64.zip", Size: 1000},
+	}
+
+	asset, err := findMatchingAsset(assets)
+	assert.NoError(t, err)
+	assert.NotNil(t, asset)
+
+	name := strings.ToLower(asset.Name)
+	switch runtime.GOOS {
+	case "darwin":
+		assert.True(t, strings.Contains(name, "macosx") || strings.Contains(name, "darwin"))
+		assert.True(t, strings.Contains(name, runtime.GOARCH) || strings.Contains(name, "universal"))
+	default:
+		assert.Contains(t, name, runtime.GOOS)
+		assert.Contains(t, name, runtime.GOARCH)
+	}
+}
+
+func TestFindMatchingAsset_UniversalFallback(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only test")
+	}
+
+	assets := []githubAsset{
+		{Name: "aliyun-cli-macosx-3.0.1-universal.tgz", Size: 1000},
+		{Name: "aliyun-cli-linux-3.0.1-amd64.tgz", Size: 1000},
+	}
+
+	asset, err := findMatchingAsset(assets)
+	assert.NoError(t, err)
+	assert.Contains(t, asset.Name, "universal")
+}
+
+func TestFindMatchingAsset_NoMatch(t *testing.T) {
+	assets := []githubAsset{
+		{Name: "aliyun-cli-freebsd-3.0.1-amd64.tgz", Size: 1000},
+	}
+
+	if runtime.GOOS != "freebsd" {
+		_, err := findMatchingAsset(assets)
+		assert.Error(t, err)
+	}
+}
+
+func TestListAssetNames(t *testing.T) {
+	assets := []githubAsset{{Name: "a.tgz"}, {Name: "b.zip"}}
+	assert.Equal(t, "a.tgz, b.zip", listAssetNames(assets))
+}
+
+// ---------------------------------------------------------------------------
+// GitHub release parsing
+// ---------------------------------------------------------------------------
+
+func TestGitHubReleaseParsing(t *testing.T) {
+	release := githubRelease{
+		TagName: "v3.1.0",
+		Name:    "Release 3.1.0",
+		Assets: []githubAsset{
+			{Name: "aliyun-cli-linux-3.1.0-amd64.tgz", BrowserDownloadURL: "https://github.com/download/x", Size: 5000},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	var got githubRelease
+	err = json.NewDecoder(resp.Body).Decode(&got)
+	assert.NoError(t, err)
+	assert.Equal(t, "v3.1.0", got.TagName)
+	assert.Len(t, got.Assets, 1)
+}
+
+// ---------------------------------------------------------------------------
+// Extract: tar.gz
+// ---------------------------------------------------------------------------
+
+func TestExtractFromTarGz(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	binaryContent := []byte("#!/bin/sh\necho hello\n")
+	archivePath := filepath.Join(tmpDir, "test.tgz")
+	createTestTarGz(t, archivePath, "aliyun", binaryContent)
+
+	destPath := filepath.Join(tmpDir, "aliyun")
+	err := extractFromTarGz(archivePath, destPath, "aliyun")
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(destPath)
+	assert.NoError(t, err)
+	assert.Equal(t, binaryContent, got)
+
+	info, _ := os.Stat(destPath)
+	assert.True(t, info.Mode()&0100 != 0, "binary should be executable")
+}
+
+func TestExtractFromTarGz_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.tgz")
+	createTestTarGz(t, archivePath, "other-binary", []byte("content"))
+
+	err := extractFromTarGz(archivePath, filepath.Join(tmpDir, "aliyun"), "aliyun")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in archive")
+}
+
+// ---------------------------------------------------------------------------
+// Extract: zip
+// ---------------------------------------------------------------------------
+
+func TestExtractFromZip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	binaryContent := []byte("MZ fake exe content")
+	archivePath := filepath.Join(tmpDir, "test.zip")
+	createTestZip(t, archivePath, "aliyun.exe", binaryContent)
+
+	destPath := filepath.Join(tmpDir, "aliyun.exe")
+	err := extractFromZip(archivePath, destPath, "aliyun.exe")
+	assert.NoError(t, err)
+
+	got, _ := os.ReadFile(destPath)
+	assert.Equal(t, binaryContent, got)
+}
+
+func TestExtractFromZip_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.zip")
+	createTestZip(t, archivePath, "other.exe", []byte("content"))
+
+	err := extractFromZip(archivePath, filepath.Join(tmpDir, "aliyun.exe"), "aliyun.exe")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in archive")
+}
+
+func TestExtractBinary_UnsupportedFormat(t *testing.T) {
+	err := extractBinary("/tmp/test.rar", "/tmp/out", "aliyun")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported archive format")
+}
+
+// ---------------------------------------------------------------------------
+// Binary replacement
+// ---------------------------------------------------------------------------
+
+func TestReplaceBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oldPath := filepath.Join(tmpDir, "aliyun")
+	os.WriteFile(oldPath, []byte("old binary"), 0755)
+
+	newPath := filepath.Join(tmpDir, "aliyun.new")
+	newContent := []byte("new binary")
+	os.WriteFile(newPath, newContent, 0755)
+
+	err := replaceBinary(newPath, oldPath)
+	assert.NoError(t, err)
+
+	got, _ := os.ReadFile(oldPath)
+	assert.Equal(t, newContent, got)
+}
+
+func TestCopyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := []byte("test content")
+	srcPath := filepath.Join(tmpDir, "src")
+	dstPath := filepath.Join(tmpDir, "dst")
+
+	os.WriteFile(srcPath, content, 0644)
+
+	err := copyFile(srcPath, dstPath, 0755)
+	assert.NoError(t, err)
+
+	got, _ := os.ReadFile(dstPath)
+	assert.Equal(t, content, got)
+
+	info, _ := os.Stat(dstPath)
+	assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+func TestDownloadFile(t *testing.T) {
+	content := bytes.Repeat([]byte("x"), 1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.Write(content)
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "download.tgz")
+
+	var buf bytes.Buffer
+	err := downloadFile(&buf, server.URL+"/test.tgz", destPath, 1024)
+	assert.NoError(t, err)
+
+	got, _ := os.ReadFile(destPath)
+	assert.Equal(t, content, got)
+}
+
+func TestDownloadFile_UsesContentLength(t *testing.T) {
+	content := bytes.Repeat([]byte("y"), 2048)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "2048")
+		w.Write(content)
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "download.tgz")
+
+	var buf bytes.Buffer
+	err := downloadFile(&buf, server.URL+"/test.tgz", destPath, 0)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Download complete")
+}
+
+// ---------------------------------------------------------------------------
+// Command struct
+// ---------------------------------------------------------------------------
+
+func TestNewUpgradeCommand(t *testing.T) {
+	cmd := NewUpgradeCommand()
+	assert.Equal(t, "upgrade", cmd.Name)
+	assert.NotNil(t, cmd.Short)
+	assert.NotNil(t, cmd.Long)
+	assert.NotNil(t, cmd.Run)
+
+	yesFlag := cmd.Flags().Get("yes")
+	assert.NotNil(t, yesFlag)
+	assert.Equal(t, 'y', rune(yesFlag.Shorthand))
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func newTestContext() *cli.Context {
+	var stdout, stderr bytes.Buffer
+	ctx := cli.NewCommandContext(&stdout, &stderr)
+	cmd := NewUpgradeCommand()
+	ctx.EnterCommand(cmd)
+	return ctx
+}
+
+func createTestTarGz(t *testing.T, archivePath, fileName string, content []byte) {
+	t.Helper()
+	f, err := os.Create(archivePath)
+	assert.NoError(t, err)
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	tw.WriteHeader(&tar.Header{
+		Name: fileName, Size: int64(len(content)), Mode: 0755, Typeflag: tar.TypeReg,
+	})
+	tw.Write(content)
+}
+
+func createTestZip(t *testing.T, archivePath, fileName string, content []byte) {
+	t.Helper()
+	f, err := os.Create(archivePath)
+	assert.NoError(t, err)
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	w, _ := zw.Create(fileName)
+	w.Write(content)
+}

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -223,6 +224,9 @@ func TestDoUpgrade_DirectWhenNotBrew(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUpgradeViaDirect_FullFlow(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test on non-linux platform")
+	}
 	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
 	archive := createTarGzInMemory(t, "aliyun", binaryContent)
 
@@ -447,6 +451,38 @@ func TestResolveExecPath(t *testing.T) {
 	assert.False(t, info.IsDir())
 }
 
+func TestResolveExecPath_ExecutableError(t *testing.T) {
+	orig := osExecutable
+	defer func() { osExecutable = orig }()
+	osExecutable = func() (string, error) { return "", fmt.Errorf("no executable") }
+
+	_, err := resolveExecPath()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get executable path")
+}
+
+func TestResolveExecPath_EvalSymlinksError(t *testing.T) {
+	origExe, origEval := osExecutable, evalSymlinks
+	defer func() {
+		osExecutable = origExe
+		evalSymlinks = origEval
+	}()
+	osExecutable = func() (string, error) { return "/fake/aliyun", nil }
+	evalSymlinks = func(string) (string, error) { return "", fmt.Errorf("symlink error") }
+
+	_, err := resolveExecPath()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve executable path")
+}
+
+func TestDetectInstaller_ExecutableError(t *testing.T) {
+	orig := osExecutable
+	defer func() { osExecutable = orig }()
+	osExecutable = func() (string, error) { return "", fmt.Errorf("no executable") }
+
+	assert.Equal(t, installerDirect, detectInstaller())
+}
+
 // ---------------------------------------------------------------------------
 // Build asset name (OSS path)
 // ---------------------------------------------------------------------------
@@ -493,6 +529,82 @@ func TestFetchVersionFromOSS(t *testing.T) {
 	n, _ := resp.Body.Read(buf)
 	version := strings.TrimSpace(string(buf[:n]))
 	assert.Equal(t, "3.3.4", version)
+}
+
+func TestFetchVersionFromOSS_HTTPGetFails(t *testing.T) {
+	origClient, origURL := httpClient, ossVersionURL
+	defer func() {
+		httpClient = origClient
+		ossVersionURL = origURL
+	}()
+
+	httpClient = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("connection refused")
+	})}
+	ossVersionURL = "http://127.0.0.1:9/version"
+
+	_, err := fetchVersionFromOSS()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to reach OSS")
+}
+
+func TestFetchVersionFromOSS_StatusNotOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	origClient, origURL := httpClient, ossVersionURL
+	defer func() {
+		httpClient = origClient
+		ossVersionURL = origURL
+	}()
+	httpClient = server.Client()
+	ossVersionURL = server.URL + "/version"
+
+	_, err := fetchVersionFromOSS()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+}
+
+func TestFetchVersionFromOSS_EmptyBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	origClient, origURL := httpClient, ossVersionURL
+	defer func() {
+		httpClient = origClient
+		ossVersionURL = origURL
+	}()
+	httpClient = server.Client()
+	ossVersionURL = server.URL + "/version"
+
+	_, err := fetchVersionFromOSS()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty version from OSS")
+}
+
+func TestFetchVersionFromOSS_ReadBodyFails(t *testing.T) {
+	origClient, origURL := httpClient, ossVersionURL
+	defer func() {
+		httpClient = origClient
+		ossVersionURL = origURL
+	}()
+
+	httpClient = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(failingReader{}),
+			Request:    &http.Request{},
+		}, nil
+	})}
+	ossVersionURL = "http://unused.example/version"
+
+	_, err := fetchVersionFromOSS()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated body read failure")
 }
 
 // ---------------------------------------------------------------------------
@@ -695,6 +807,44 @@ func TestDownloadFile(t *testing.T) {
 	assert.Contains(t, buf.String(), "Download complete")
 }
 
+func TestDownloadFile_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "missing.tgz")
+	var buf bytes.Buffer
+
+	err := downloadFile(&buf, server.URL+"/missing.tgz", destPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestDownloadFile_CreateFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("x"))
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	httpClient = server.Client()
+	defer func() { httpClient = origClient }()
+
+	tmpDir := t.TempDir()
+	destPath := tmpDir
+
+	var buf bytes.Buffer
+	err := downloadFile(&buf, server.URL+"/file.tgz", destPath)
+	assert.Error(t, err)
+}
+
 // ---------------------------------------------------------------------------
 // Command struct
 // ---------------------------------------------------------------------------
@@ -767,3 +917,13 @@ func createTarGzInMemory(t *testing.T, fileName string, content []byte) *bytes.B
 	gw.Close()
 	return &buf
 }
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, fmt.Errorf("simulated body read failure") }

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -51,6 +51,26 @@ func TestIsNewer(t *testing.T) {
 	}
 }
 
+func TestIsNewer_InvalidSemverStringFallback(t *testing.T) {
+	tests := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"custom-build-1", "custom-build-2", true},
+		{"custom-build-1", "custom-build-1", false},
+		{"same-opaque", "same-opaque", false},
+		{"3.0.0", "dev-channel", true},
+		{"dev", "3.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.current+"_vs_"+tt.latest, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNewer(tt.current, tt.latest),
+				"non-semver path should use raw string inequality")
+		})
+	}
+}
+
 func TestFormatSize(t *testing.T) {
 	assert.Equal(t, "0 B", formatSize(0))
 	assert.Equal(t, "512 B", formatSize(512))
@@ -68,6 +88,27 @@ func TestDetectInstaller_Default(t *testing.T) {
 	result := detectInstaller()
 	// In a test environment the binary is in a temp dir, not Homebrew
 	assert.Equal(t, installerDirect, result)
+}
+
+func TestInstallerTypeFromExecPathLower(t *testing.T) {
+	tests := []struct {
+		path string
+		want installerType
+	}{
+		{"/opt/homebrew/opt/aliyun-cli/bin/aliyun", installerHomebrew},
+		{"/usr/local/homebrew/bin/aliyun", installerHomebrew},
+		{"/usr/local/Cellar/aliyun-cli/3.0.0/bin/aliyun", installerHomebrew},
+		{"/home/linuxbrew/.linuxbrew/bin/aliyun", installerLinuxbrew},
+		{"/tmp/aliyun", installerDirect},
+		{"/linuxbrew/prefix/homebrew/name", installerLinuxbrew},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			lower := strings.ToLower(tt.path)
+			assert.Equal(t, tt.want, installerTypeFromExecPathLower(lower))
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -5,7 +5,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,12 +21,6 @@ import (
 // ---------------------------------------------------------------------------
 // Version helpers
 // ---------------------------------------------------------------------------
-
-func TestNormalizeVersion(t *testing.T) {
-	assert.Equal(t, "3.0.1", normalizeVersion("v3.0.1"))
-	assert.Equal(t, "3.0.1", normalizeVersion("3.0.1"))
-	assert.Equal(t, "3.0.1-beta", normalizeVersion("v3.0.1-beta"))
-}
 
 func TestEnsureVPrefix(t *testing.T) {
 	assert.Equal(t, "v3.0.1", ensureVPrefix("3.0.1"))
@@ -232,7 +225,7 @@ func TestFetchVersionFromOSS(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// resolveFromOSS / resolveFromGitHub integration
+// OSS resolution
 // ---------------------------------------------------------------------------
 
 func TestResolveFromOSS_BuildsCorrectURL(t *testing.T) {
@@ -241,119 +234,8 @@ func TestResolveFromOSS_BuildsCorrectURL(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedURL := ossBaseURL + "/" + assetName
-	assert.True(t, strings.HasPrefix(expectedURL, "https://aliyun-cli.oss-cn-hangzhou.aliyuncs.com/aliyun-cli-"))
+	assert.True(t, strings.HasPrefix(expectedURL, "https://aliyun-cli.oss-accelerate.aliyuncs.com/aliyun-cli-"))
 	assert.Contains(t, expectedURL, version)
-}
-
-func TestResolveFromGitHub_UsesOSSDownloadURL(t *testing.T) {
-	release := githubRelease{
-		TagName: "v3.3.4",
-		Assets: []githubAsset{
-			{Name: "aliyun-cli-linux-3.3.4-amd64.tgz", BrowserDownloadURL: "https://github.com/download/linux.tgz", Size: 20000000},
-			{Name: "aliyun-cli-linux-3.3.4-arm64.tgz", BrowserDownloadURL: "https://github.com/download/linux-arm.tgz", Size: 19000000},
-			{Name: "aliyun-cli-macosx-3.3.4-arm64.tgz", BrowserDownloadURL: "https://github.com/download/mac-arm.tgz", Size: 22000000},
-			{Name: "aliyun-cli-macosx-3.3.4-amd64.tgz", BrowserDownloadURL: "https://github.com/download/mac-amd.tgz", Size: 22000000},
-			{Name: "aliyun-cli-macosx-3.3.4-universal.tgz", BrowserDownloadURL: "https://github.com/download/mac-uni.tgz", Size: 44000000},
-			{Name: "aliyun-cli-windows-3.3.4-amd64.zip", BrowserDownloadURL: "https://github.com/download/win.zip", Size: 21000000},
-		},
-	}
-
-	asset, err := findMatchingAsset(release.Assets)
-	assert.NoError(t, err)
-
-	downloadURL := ossBaseURL + "/" + asset.Name
-	assert.True(t, strings.HasPrefix(downloadURL, ossBaseURL))
-	assert.NotContains(t, downloadURL, "github.com")
-}
-
-// ---------------------------------------------------------------------------
-// Asset matching (GitHub fallback path)
-// ---------------------------------------------------------------------------
-
-func TestFindMatchingAsset(t *testing.T) {
-	assets := []githubAsset{
-		{Name: "aliyun-cli-linux-3.0.1-amd64.tgz", Size: 1000},
-		{Name: "aliyun-cli-linux-3.0.1-arm64.tgz", Size: 1000},
-		{Name: "aliyun-cli-macosx-3.0.1-amd64.tgz", Size: 1000},
-		{Name: "aliyun-cli-macosx-3.0.1-arm64.tgz", Size: 1000},
-		{Name: "aliyun-cli-macosx-3.0.1-universal.tgz", Size: 1000},
-		{Name: "aliyun-cli-windows-3.0.1-amd64.zip", Size: 1000},
-	}
-
-	asset, err := findMatchingAsset(assets)
-	assert.NoError(t, err)
-	assert.NotNil(t, asset)
-
-	name := strings.ToLower(asset.Name)
-	switch runtime.GOOS {
-	case "darwin":
-		assert.True(t, strings.Contains(name, "macosx") || strings.Contains(name, "darwin"))
-		assert.True(t, strings.Contains(name, runtime.GOARCH) || strings.Contains(name, "universal"))
-	default:
-		assert.Contains(t, name, runtime.GOOS)
-		assert.Contains(t, name, runtime.GOARCH)
-	}
-}
-
-func TestFindMatchingAsset_UniversalFallback(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("macOS-only test")
-	}
-
-	assets := []githubAsset{
-		{Name: "aliyun-cli-macosx-3.0.1-universal.tgz", Size: 1000},
-		{Name: "aliyun-cli-linux-3.0.1-amd64.tgz", Size: 1000},
-	}
-
-	asset, err := findMatchingAsset(assets)
-	assert.NoError(t, err)
-	assert.Contains(t, asset.Name, "universal")
-}
-
-func TestFindMatchingAsset_NoMatch(t *testing.T) {
-	assets := []githubAsset{
-		{Name: "aliyun-cli-freebsd-3.0.1-amd64.tgz", Size: 1000},
-	}
-
-	if runtime.GOOS != "freebsd" {
-		_, err := findMatchingAsset(assets)
-		assert.Error(t, err)
-	}
-}
-
-func TestListAssetNames(t *testing.T) {
-	assets := []githubAsset{{Name: "a.tgz"}, {Name: "b.zip"}}
-	assert.Equal(t, "a.tgz, b.zip", listAssetNames(assets))
-}
-
-// ---------------------------------------------------------------------------
-// GitHub release parsing
-// ---------------------------------------------------------------------------
-
-func TestGitHubReleaseParsing(t *testing.T) {
-	release := githubRelease{
-		TagName: "v3.1.0",
-		Name:    "Release 3.1.0",
-		Assets: []githubAsset{
-			{Name: "aliyun-cli-linux-3.1.0-amd64.tgz", BrowserDownloadURL: "https://github.com/download/x", Size: 5000},
-		},
-	}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(release)
-	}))
-	defer server.Close()
-
-	resp, err := http.Get(server.URL)
-	assert.NoError(t, err)
-	defer resp.Body.Close()
-
-	var got githubRelease
-	err = json.NewDecoder(resp.Body).Decode(&got)
-	assert.NoError(t, err)
-	assert.Equal(t, "v3.1.0", got.TagName)
-	assert.Len(t, got.Assets, 1)
 }
 
 // ---------------------------------------------------------------------------
@@ -484,31 +366,11 @@ func TestDownloadFile(t *testing.T) {
 	destPath := filepath.Join(tmpDir, "download.tgz")
 
 	var buf bytes.Buffer
-	err := downloadFile(&buf, server.URL+"/test.tgz", destPath, 1024)
+	err := downloadFile(&buf, server.URL+"/test.tgz", destPath)
 	assert.NoError(t, err)
 
 	got, _ := os.ReadFile(destPath)
 	assert.Equal(t, content, got)
-}
-
-func TestDownloadFile_UsesContentLength(t *testing.T) {
-	content := bytes.Repeat([]byte("y"), 2048)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Length", "2048")
-		w.Write(content)
-	}))
-	defer server.Close()
-
-	origClient := httpClient
-	httpClient = server.Client()
-	defer func() { httpClient = origClient }()
-
-	tmpDir := t.TempDir()
-	destPath := filepath.Join(tmpDir, "download.tgz")
-
-	var buf bytes.Buffer
-	err := downloadFile(&buf, server.URL+"/test.tgz", destPath, 0)
-	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Download complete")
 }
 

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -559,6 +559,52 @@ func TestReplaceBinary(t *testing.T) {
 	assert.Equal(t, newContent, got)
 }
 
+func TestReplaceBinary_CurrentMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	current := filepath.Join(tmpDir, "missing-binary")
+	newPath := filepath.Join(tmpDir, "new")
+	os.WriteFile(newPath, []byte("x"), 0644)
+
+	err := replaceBinary(newPath, current)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to stat current binary")
+}
+
+func TestReplaceBinary_NewMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	current := filepath.Join(tmpDir, "aliyun")
+	os.WriteFile(current, []byte("old"), 0755)
+	newPath := filepath.Join(tmpDir, "does-not-exist")
+
+	err := replaceBinary(newPath, current)
+	assert.Error(t, err)
+
+	got, errRead := os.ReadFile(current)
+	assert.NoError(t, errRead)
+	assert.Equal(t, []byte("old"), got, "current binary should be unchanged on failure")
+}
+
+func TestReplaceBinary_Unix_NoStaleTempFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-Windows replace path uses .aliyun.upgrade.tmp")
+	}
+	tmpDir := t.TempDir()
+	current := filepath.Join(tmpDir, "aliyun")
+	newPath := filepath.Join(tmpDir, "aliyun.new")
+	want := []byte("replaced")
+	os.WriteFile(current, []byte("before"), 0755)
+	os.WriteFile(newPath, want, 0755)
+
+	tmpArtifact := filepath.Join(tmpDir, ".aliyun.upgrade.tmp")
+	assert.NoError(t, replaceBinary(newPath, current))
+
+	_, err := os.Stat(tmpArtifact)
+	assert.True(t, os.IsNotExist(err), "temp swap file should be removed after success")
+
+	got, _ := os.ReadFile(current)
+	assert.Equal(t, want, got)
+}
+
 func TestCopyFile(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/config/configure.go
+++ b/config/configure.go
@@ -173,6 +173,7 @@ func NewConfigureCommand() *cli.Command {
 	c.AddSubCommand(NewConfigureSwitchCommand())
 	c.AddSubCommand(NewConfigureSafetyPolicyCommand())
 	c.AddSubCommand(NewConfigureAiModeCommand())
+	c.AddSubCommand(NewConfigurePluginSettingsCommand())
 	return c
 }
 

--- a/config/configure_plugin_settings.go
+++ b/config/configure_plugin_settings.go
@@ -27,7 +27,8 @@ import (
 
 func NewConfigurePluginSettingsCommand() *cli.Command {
 	cmd := &cli.Command{
-		Name: "plugin-settings",
+		Name:                   "plugin-settings",
+		DisablePersistentFlags: true,
 		Short: i18n.T(
 			"manage global plugin system settings",
 			"管理插件系统全局设置"),
@@ -46,16 +47,6 @@ func NewConfigurePluginSettingsCommand() *cli.Command {
 			return doPluginSettingsShow(ctx, configDir, cfg)
 		},
 	}
-
-	cmd.Flags().Add(&cli.Flag{
-		Category:     "plugin-settings",
-		Name:         "source-base",
-		AssignedMode: cli.AssignedOnce,
-		Persistent:   true,
-		Short: i18n.T(
-			"plugins tree base URL for set (e.g. https://example.com/plugins)",
-			"set 命令使用的插件源 URL（例如 https://example.com/plugins）"),
-	})
 
 	cmd.AddSubCommand(newPluginSettingsShowCommand())
 	cmd.AddSubCommand(newPluginSettingsSetCommand())
@@ -91,7 +82,7 @@ func newPluginSettingsShowCommand() *cli.Command {
 }
 
 func newPluginSettingsSetCommand() *cli.Command {
-	return &cli.Command{
+	cmd := &cli.Command{
 		Name:  "set",
 		Usage: "set --source-base <url>",
 		Short: i18n.T("set plugins tree source base URL", "设置插件源根地址"),
@@ -119,11 +110,18 @@ func newPluginSettingsSetCommand() *cli.Command {
 			if err := pluginsettings.Save(configDir, cfg); err != nil {
 				return err
 			}
-			w := ctx.Stdout()
-			cli.Printf(w, "Saved plugin settings to %s\n", pluginsettings.GetConfigFilePath(configDir))
 			return doPluginSettingsShow(ctx, configDir, cfg)
 		},
 	}
+	cmd.Flags().Add(&cli.Flag{
+		Category:     "plugin-settings",
+		Name:         "source-base",
+		AssignedMode: cli.AssignedOnce,
+		Short: i18n.T(
+			"plugins tree base URL for set (e.g. https://example.com/plugins)",
+			"set 命令使用的插件源 URL（例如 https://example.com/plugins）"),
+	})
+	return cmd
 }
 
 func newPluginSettingsClearCommand() *cli.Command {
@@ -143,7 +141,6 @@ func newPluginSettingsClearCommand() *cli.Command {
 			if err := pluginsettings.Save(configDir, cfg); err != nil {
 				return err
 			}
-			cli.Printf(ctx.Stdout(), "Cleared plugin settings in %s\n", pluginsettings.GetConfigFilePath(configDir))
 			return doPluginSettingsShow(ctx, configDir, cfg)
 		},
 	}
@@ -155,9 +152,8 @@ func doPluginSettingsShow(ctx *cli.Context, configDir string, cfg *pluginsetting
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(map[string]any{
-		"config_dir":            configDir,
 		"config_file":           pluginsettings.GetConfigFilePath(configDir),
-		"source_base_file":      strings.TrimSpace(cfg.SourceBase),
+		"source_base":           strings.TrimSpace(cfg.SourceBase),
 		"source_base_effective": effective,
 		"env_override":          strings.TrimSpace(os.Getenv(pluginsettings.EnvSourceBase)),
 	})

--- a/config/configure_plugin_settings.go
+++ b/config/configure_plugin_settings.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/pluginsettings"
+)
+
+func NewConfigurePluginSettingsCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name: "plugin-settings",
+		Short: i18n.T(
+			"manage global plugin system settings",
+			"管理插件系统全局设置"),
+		Usage: "plugin-settings [command]",
+		Long: i18n.T(
+			`Configure plugin system settings. When source-base is set, the CLI loads plugins from that base.`,
+			`配置插件系统设置。设置 source-base 后，CLI 从该地址获取插件。`),
+		Run: func(ctx *cli.Context, args []string) error {
+			if len(args) > 0 {
+				return cli.NewInvalidCommandError(args[0], ctx)
+			}
+			configDir, cfg, err := loadPluginSettings()
+			if err != nil {
+				return err
+			}
+			return doPluginSettingsShow(ctx, configDir, cfg)
+		},
+	}
+
+	cmd.Flags().Add(&cli.Flag{
+		Category:     "plugin-settings",
+		Name:         "source-base",
+		AssignedMode: cli.AssignedOnce,
+		Persistent:   true,
+		Short: i18n.T(
+			"plugins tree base URL for set (e.g. https://example.com/plugins)",
+			"set 命令使用的插件源 URL（例如 https://example.com/plugins）"),
+	})
+
+	cmd.AddSubCommand(newPluginSettingsShowCommand())
+	cmd.AddSubCommand(newPluginSettingsSetCommand())
+	cmd.AddSubCommand(newPluginSettingsClearCommand())
+	return cmd
+}
+
+func loadPluginSettings() (configDir string, cfg *pluginsettings.PluginSettings, err error) {
+	configDir = GetConfigPath()
+	cfg, err = pluginsettings.Load(configDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("load plugin-settings failed: %w", err)
+	}
+	return configDir, cfg, nil
+}
+
+func newPluginSettingsShowCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "show",
+		Usage: "show",
+		Short: i18n.T("display plugin system settings", "显示插件系统设置"),
+		Run: func(ctx *cli.Context, args []string) error {
+			if len(args) > 0 {
+				return cli.NewInvalidCommandError(args[0], ctx)
+			}
+			configDir, cfg, err := loadPluginSettings()
+			if err != nil {
+				return err
+			}
+			return doPluginSettingsShow(ctx, configDir, cfg)
+		},
+	}
+}
+
+func newPluginSettingsSetCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "set",
+		Usage: "set --source-base <url>",
+		Short: i18n.T("set plugins tree source base URL", "设置插件源根地址"),
+		Run: func(ctx *cli.Context, args []string) error {
+			if len(args) > 0 {
+				return cli.NewInvalidCommandError(args[0], ctx)
+			}
+			flag := ctx.Flags().Get("source-base")
+			if flag == nil || !flag.IsAssigned() {
+				return fmt.Errorf("missing --source-base <url>")
+			}
+			v, _ := flag.GetValue()
+			v = strings.TrimSpace(v)
+			if v == "" {
+				return fmt.Errorf("source-base must not be empty (use 'configure plugin-settings clear' to reset)")
+			}
+			if !strings.HasPrefix(strings.ToLower(v), "http://") && !strings.HasPrefix(strings.ToLower(v), "https://") {
+				return fmt.Errorf("source-base must start with http:// or https://")
+			}
+			configDir, cfg, err := loadPluginSettings()
+			if err != nil {
+				return err
+			}
+			cfg.SourceBase = strings.TrimRight(v, "/")
+			if err := pluginsettings.Save(configDir, cfg); err != nil {
+				return err
+			}
+			w := ctx.Stdout()
+			cli.Printf(w, "Saved plugin settings to %s\n", pluginsettings.GetConfigFilePath(configDir))
+			return doPluginSettingsShow(ctx, configDir, cfg)
+		},
+	}
+}
+
+func newPluginSettingsClearCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "clear",
+		Usage: "clear",
+		Short: i18n.T("remove custom source base (use built-in default)", "清除自定义插件源根地址（恢复内置默认）"),
+		Run: func(ctx *cli.Context, args []string) error {
+			if len(args) > 0 {
+				return cli.NewInvalidCommandError(args[0], ctx)
+			}
+			configDir, _, err := loadPluginSettings()
+			if err != nil {
+				return err
+			}
+			cfg := pluginsettings.Default()
+			if err := pluginsettings.Save(configDir, cfg); err != nil {
+				return err
+			}
+			cli.Printf(ctx.Stdout(), "Cleared plugin settings in %s\n", pluginsettings.GetConfigFilePath(configDir))
+			return doPluginSettingsShow(ctx, configDir, cfg)
+		},
+	}
+}
+
+func doPluginSettingsShow(ctx *cli.Context, configDir string, cfg *pluginsettings.PluginSettings) error {
+	w := ctx.Stdout()
+	effective := pluginsettings.EffectiveSourceBase(cfg)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(map[string]any{
+		"config_dir":            configDir,
+		"config_file":           pluginsettings.GetConfigFilePath(configDir),
+		"source_base_file":      strings.TrimSpace(cfg.SourceBase),
+		"source_base_effective": effective,
+		"env_override":          strings.TrimSpace(os.Getenv(pluginsettings.EnvSourceBase)),
+	})
+	return nil
+}

--- a/config/configure_plugin_settings_test.go
+++ b/config/configure_plugin_settings_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/pluginsettings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPluginSettingsIsolatedHome(t *testing.T) (ctx *cli.Context, stdout *bytes.Buffer, aliyunDir string) {
+	t.Helper()
+	home := t.TempDir()
+	// These tests do not use t.Parallel(); t.Setenv restores env after the test (Go 1.17+).
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
+	}
+	aliyunDir = filepath.Join(home, ".aliyun")
+	stdout = new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx = cli.NewCommandContext(stdout, stderr)
+	return ctx, stdout, aliyunDir
+}
+
+func TestConfigurePluginSettings_Show_Default(t *testing.T) {
+	ctx, w, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	show := root.GetSubCommand("show")
+	require.NotNil(t, show)
+	ctx.EnterCommand(show)
+	require.NoError(t, show.Run(ctx, nil))
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(w.Bytes(), &m))
+	assert.Equal(t, "", m["source_base_file"])
+}
+
+func TestConfigurePluginSettings_Set_ViaCommand(t *testing.T) {
+	ctx, _, aliyunDir := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	f := ctx.Flags().Get("source-base")
+	require.NotNil(t, f)
+	f.SetAssigned(true)
+	f.SetValue("https://mirror.example.com/plugins")
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
+	require.NoError(t, set.Run(ctx, nil))
+
+	cfg, err := pluginsettings.Load(aliyunDir)
+	require.NoError(t, err)
+	assert.Equal(t, "https://mirror.example.com/plugins", cfg.SourceBase)
+}
+
+func TestConfigurePluginSettings_Clear(t *testing.T) {
+	ctx, _, aliyunDir := testPluginSettingsIsolatedHome(t)
+	require.NoError(t, os.MkdirAll(aliyunDir, 0755))
+	require.NoError(t, pluginsettings.Save(aliyunDir, &pluginsettings.PluginSettings{
+		SourceBase: "https://old.example/plugins",
+	}))
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	clear := root.GetSubCommand("clear")
+	require.NotNil(t, clear)
+	ctx.EnterCommand(clear)
+	require.NoError(t, clear.Run(ctx, nil))
+	cfg, err := pluginsettings.Load(aliyunDir)
+	require.NoError(t, err)
+	assert.Equal(t, "", cfg.SourceBase)
+}
+
+func TestConfigurePluginSettings_Set_MissingFlag(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	ctx.EnterCommand(set)
+	err := set.Run(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--source-base")
+}
+
+func TestConfigurePluginSettings_ParentRun_Shows(t *testing.T) {
+	ctx, w, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	require.NoError(t, root.Run(ctx, nil))
+	assert.Contains(t, w.String(), "source_base")
+}

--- a/config/configure_plugin_settings_test.go
+++ b/config/configure_plugin_settings_test.go
@@ -31,6 +31,14 @@ func testPluginSettingsIsolatedHome(t *testing.T) (ctx *cli.Context, stdout *byt
 	return ctx, stdout, aliyunDir
 }
 
+func TestConfigurePluginSettings_SourceBaseFlagOnSetOnly(t *testing.T) {
+	root := NewConfigurePluginSettingsCommand()
+	assert.Nil(t, root.Flags().Get("source-base"))
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	assert.NotNil(t, set.Flags().Get("source-base"))
+}
+
 func TestConfigurePluginSettings_Show_Default(t *testing.T) {
 	ctx, w, _ := testPluginSettingsIsolatedHome(t)
 	root := NewConfigurePluginSettingsCommand()
@@ -41,20 +49,20 @@ func TestConfigurePluginSettings_Show_Default(t *testing.T) {
 	require.NoError(t, show.Run(ctx, nil))
 	var m map[string]any
 	require.NoError(t, json.Unmarshal(w.Bytes(), &m))
-	assert.Equal(t, "", m["source_base_file"])
+	assert.Equal(t, "", m["source_base"])
 }
 
 func TestConfigurePluginSettings_Set_ViaCommand(t *testing.T) {
 	ctx, _, aliyunDir := testPluginSettingsIsolatedHome(t)
 	root := NewConfigurePluginSettingsCommand()
 	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
 	f := ctx.Flags().Get("source-base")
 	require.NotNil(t, f)
 	f.SetAssigned(true)
 	f.SetValue("https://mirror.example.com/plugins")
-	set := root.GetSubCommand("set")
-	require.NotNil(t, set)
-	ctx.EnterCommand(set)
 	require.NoError(t, set.Run(ctx, nil))
 
 	cfg, err := pluginsettings.Load(aliyunDir)
@@ -96,4 +104,117 @@ func TestConfigurePluginSettings_ParentRun_Shows(t *testing.T) {
 	ctx.EnterCommand(root)
 	require.NoError(t, root.Run(ctx, nil))
 	assert.Contains(t, w.String(), "source_base")
+}
+
+func TestConfigurePluginSettings_Root_InvalidArg(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	err := root.Run(ctx, []string{"nope"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nope")
+	assert.Contains(t, err.Error(), "not a vaild command")
+}
+
+func TestConfigurePluginSettings_Show_InvalidArg(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	show := root.GetSubCommand("show")
+	require.NotNil(t, show)
+	ctx.EnterCommand(show)
+	err := show.Run(ctx, []string{"extra"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "extra")
+	assert.Contains(t, err.Error(), "not a vaild command")
+}
+
+func TestConfigurePluginSettings_Set_InvalidArg(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
+	err := set.Run(ctx, []string{"junk"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "junk")
+	assert.Contains(t, err.Error(), "not a vaild command")
+}
+
+func TestConfigurePluginSettings_Set_EmptySourceBase(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
+	f := ctx.Flags().Get("source-base")
+	require.NotNil(t, f)
+	f.SetAssigned(true)
+	f.SetValue("")
+	err := set.Run(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestConfigurePluginSettings_Set_WhitespaceSourceBase(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
+	f := ctx.Flags().Get("source-base")
+	require.NotNil(t, f)
+	f.SetAssigned(true)
+	f.SetValue("   \t  ")
+	err := set.Run(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestConfigurePluginSettings_Set_SourceBaseNotHTTP(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
+	f := ctx.Flags().Get("source-base")
+	require.NotNil(t, f)
+	f.SetAssigned(true)
+	f.SetValue("ftp://mirror.example/plugins")
+	err := set.Run(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http://")
+}
+
+func TestConfigurePluginSettings_Set_SourceBaseBareHost(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	set := root.GetSubCommand("set")
+	require.NotNil(t, set)
+	ctx.EnterCommand(set)
+	f := ctx.Flags().Get("source-base")
+	require.NotNil(t, f)
+	f.SetAssigned(true)
+	f.SetValue("mirror.example/plugins")
+	err := set.Run(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http://")
+}
+
+func TestConfigurePluginSettings_Clear_InvalidArg(t *testing.T) {
+	ctx, _, _ := testPluginSettingsIsolatedHome(t)
+	root := NewConfigurePluginSettingsCommand()
+	ctx.EnterCommand(root)
+	clear := root.GetSubCommand("clear")
+	require.NotNil(t, clear)
+	ctx.EnterCommand(clear)
+	err := clear.Run(ctx, []string{"oops"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "oops")
+	assert.Contains(t, err.Error(), "not a vaild command")
 }

--- a/config/profile.go
+++ b/config/profile.go
@@ -328,6 +328,20 @@ func getSTSEndpoint(regionId string) string {
 	return "sts.aliyuncs.com"
 }
 
+// mergeProfileAfterCredentialRefresh persists STS / OAuth token fields from the in-memory profile onto the on-disk profile.
+// in-memory profile may include one-off CLI overrides(e.g. --endpoint) merged via OverwriteWithFlags; those must not overwrite stored settings.
+func mergeProfileAfterCredentialRefresh(disk Profile, cp *Profile) Profile {
+	out := disk
+	out.AccessKeyId = cp.AccessKeyId
+	out.AccessKeySecret = cp.AccessKeySecret
+	out.StsToken = cp.StsToken
+	out.StsExpiration = cp.StsExpiration
+	out.OAuthAccessToken = cp.OAuthAccessToken
+	out.OAuthRefreshToken = cp.OAuthRefreshToken
+	out.OAuthAccessTokenExpire = cp.OAuthAccessTokenExpire
+	return out
+}
+
 func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred credentialsv2.Credential, err error) {
 	config := new(credentialsv2.Config)
 	// The AK, StsToken are direct credential
@@ -572,7 +586,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			}
 			for i, profile := range conf.Profiles {
 				if profile.Name == cp.Name {
-					conf.Profiles[i] = *cp
+					conf.Profiles[i] = mergeProfileAfterCredentialRefresh(profile, cp)
 					break
 				}
 			}
@@ -608,7 +622,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			}
 			for i, profile := range conf.Profiles {
 				if profile.Name == cp.Name {
-					conf.Profiles[i] = *cp
+					conf.Profiles[i] = mergeProfileAfterCredentialRefresh(profile, cp)
 					break
 				}
 			}

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -216,6 +216,34 @@ func TestGetParent(t *testing.T) {
 	assert.Nil(t, p)
 }
 
+func TestMergeProfileAfterCredentialRefresh_KeepsStoredNonCredentialFields(t *testing.T) {
+	disk := Profile{
+		Name:     "p",
+		Mode:     CloudSSO,
+		RegionId: "cn-hangzhou",
+		Endpoint: "https://from-file.example.com",
+	}
+	cp := disk
+	cp.Endpoint = "https://from-cli.example.com"
+	cp.AccessKeyId = "sts-ak"
+	cp.AccessKeySecret = "sts-sk"
+	cp.StsToken = "sts-token"
+	cp.StsExpiration = 999999
+	cp.OAuthAccessToken = "oat"
+	cp.OAuthRefreshToken = "ort"
+	cp.OAuthAccessTokenExpire = 8888
+
+	got := mergeProfileAfterCredentialRefresh(disk, &cp)
+	assert.Equal(t, "https://from-file.example.com", got.Endpoint)
+	assert.Equal(t, "sts-ak", got.AccessKeyId)
+	assert.Equal(t, "sts-sk", got.AccessKeySecret)
+	assert.Equal(t, "sts-token", got.StsToken)
+	assert.Equal(t, int64(999999), got.StsExpiration)
+	assert.Equal(t, "oat", got.OAuthAccessToken)
+	assert.Equal(t, "ort", got.OAuthRefreshToken)
+	assert.Equal(t, int64(8888), got.OAuthAccessTokenExpire)
+}
+
 func TestOverwriteWithFlags(t *testing.T) {
 	buf := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/main/main.go
+++ b/main/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/oss/lib"
 	"github.com/aliyun/aliyun-cli/v3/ossutil"
 	"github.com/aliyun/aliyun-cli/v3/otsutil"
+	"github.com/aliyun/aliyun-cli/v3/cli/upgrade"
 )
 
 func Main(args []string) {
@@ -88,6 +89,8 @@ func Main(args []string) {
 	rootCmd.AddSubCommand(otsutil.NewOtsutilCommand())
 	// plugin command
 	rootCmd.AddSubCommand(plugin.NewPluginCommand())
+	// upgrade command
+	rootCmd.AddSubCommand(upgrade.NewUpgradeCommand())
 	if os.Getenv("GENERATE_METADATA") == "YES" {
 		generateMetadata(rootCmd)
 	} else {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -775,6 +775,7 @@ func (c *Commando) help(ctx *cli.Context, args []string) error {
 	if len(args) == 0 {
 		cmd.PrintHead(ctx)
 		cmd.PrintUsage(ctx)
+		cmd.PrintSubCommands(ctx)
 		cmd.PrintFlags(ctx)
 		cmd.PrintSample(ctx)
 		c.printProducts(ctx)

--- a/sysconfig/pluginsettings/config.go
+++ b/sysconfig/pluginsettings/config.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pluginsettings holds global (non-profile) plugin system settings,
+// stored next to config.json (same directory as ai-mode.json).
+package pluginsettings
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aliyun/aliyun-cli/v3/util"
+)
+
+const ConfigFileName = "plugin-settings.json"
+
+const EnvSourceBase = "ALIBABA_CLOUD_CLI_PLUGIN_SOURCE_BASE"
+
+type PluginSettings struct {
+	// SourceBase is the URL prefix for the plugins tree, e.g. https://example.com/plugins
+	// Index: {SourceBase}/plugin_pkg_index.json, {SourceBase}/plugin_search_index.json
+	// Packages: {SourceBase}/pkgs/{name}/{version}/{filename}
+	SourceBase string `json:"source_base,omitempty"`
+}
+
+func Default() *PluginSettings {
+	return &PluginSettings{}
+}
+
+func GetConfigFilePath(configDir string) string {
+	return filepath.Join(configDir, ConfigFileName)
+}
+
+func Load(configDir string) (*PluginSettings, error) {
+	path := GetConfigFilePath(configDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Default(), nil
+		}
+		return nil, err
+	}
+	var c PluginSettings
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Default(), nil
+	}
+	c.SourceBase = strings.TrimSpace(c.SourceBase)
+	return &c, nil
+}
+
+func Save(configDir string, c *PluginSettings) error {
+	if c == nil {
+		c = Default()
+	}
+	path := GetConfigFilePath(configDir)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c, "", "\t")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func EffectiveSourceBase(c *PluginSettings) string {
+	if v := strings.TrimSpace(util.GetFromEnv(EnvSourceBase)); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	if c == nil {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimSpace(c.SourceBase), "/")
+}

--- a/sysconfig/pluginsettings/config_test.go
+++ b/sysconfig/pluginsettings/config_test.go
@@ -1,0 +1,57 @@
+package pluginsettings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoad_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Load(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "", c.SourceBase)
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	err := Save(dir, &PluginSettings{SourceBase: "https://mirror.example.com/plugins"})
+	assert.NoError(t, err)
+
+	c, err := Load(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://mirror.example.com/plugins", c.SourceBase)
+}
+
+func TestEffectiveSourceBase_EnvOverrides(t *testing.T) {
+	dir := t.TempDir()
+	_ = Save(dir, &PluginSettings{SourceBase: "https://from-file.example/plugins"})
+	t.Setenv(EnvSourceBase, "https://from-env.example/plugins")
+	c, err := Load(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://from-env.example/plugins", EffectiveSourceBase(c))
+}
+
+func TestEffectiveSourceBase_FromFile(t *testing.T) {
+	t.Setenv(EnvSourceBase, "")
+	dir := t.TempDir()
+	assert.NoError(t, Save(dir, &PluginSettings{SourceBase: "  https://x.example/plugins/  "}))
+	c, err := Load(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://x.example/plugins", EffectiveSourceBase(c))
+}
+
+func TestGetConfigFilePath(t *testing.T) {
+	p := GetConfigFilePath("/tmp/cfg")
+	assert.Equal(t, filepath.Join("/tmp/cfg", ConfigFileName), p)
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, ConfigFileName), []byte("{"), 0600))
+	c, err := Load(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "", c.SourceBase)
+}


### PR DESCRIPTION
**Description**

Introduce `aliyun upgrade` to update the CLI (Homebrew path vs direct download from the official mirror, with optional --yes), so the CLI can update itself to the latest release without a separate installer.

Add `aliyun configure plugin-settings` with `show / set / clear` for a global source_base, and wires the plugin manager to use that base for plugin index and package URLs.

CloudSSO/OAuth STS refresh used to save the full in-memory profile, so flags merged for a single run (e.g. `--endpoint`, `--region`) could be written to `config.json`. Refresh now updates only STS / OAuth token fields onto the existing on-disk profile.
