### PR TITLE
{Core} Add `plugin install --package` and `plugin show`

### DIFF
--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -14,6 +14,34 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/i18n"
 )
 
+func addPluginSourceBaseFlag(cmd *cli.Command) {
+	cmd.Flags().Add(&cli.Flag{
+		Category: "remote",
+		Name:     "source-base",
+		Short: i18n.T(
+			"Override plugins tree base URL for this command only (e.g. https://example.com/plugins)",
+			"仅本次命令覆盖插件源根地址（例如 https://example.com/plugins）"),
+		AssignedMode: cli.AssignedOnce,
+		DefaultValue: "",
+	})
+}
+
+func newManagerWithOptionalSourceBase(ctx *cli.Context) (*Manager, error) {
+	mgr, err := NewManager()
+	if err != nil {
+		return nil, err
+	}
+	f := ctx.Flags().Get("source-base")
+	if f == nil || !f.IsAssigned() {
+		return mgr, nil
+	}
+	v, _ := f.GetValue()
+	if err := mgr.ApplySourceBaseOverride(v); err != nil {
+		return nil, err
+	}
+	return mgr, nil
+}
+
 func NewPluginCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:                   "plugin",
@@ -74,12 +102,12 @@ func newListCommand() *cli.Command {
 }
 
 func newListRemoteCommand() *cli.Command {
-	return &cli.Command{
+	cmd := &cli.Command{
 		Name:  "list-remote",
 		Short: i18n.T("List available plugins from remote index", "列出远程索引中可用的插件"),
-		Usage: "list-remote",
+		Usage: "list-remote [--source-base <url>]",
 		Run: func(ctx *cli.Context, args []string) error {
-			mgr, err := NewManager()
+			mgr, err := newManagerWithOptionalSourceBase(ctx)
 			if err != nil {
 				return err
 			}
@@ -97,17 +125,21 @@ func newListRemoteCommand() *cli.Command {
 			return displayRemotePlugins(ctx, index, localManifest)
 		},
 	}
+	addPluginSourceBaseFlag(cmd)
+	return cmd
 }
 
 func newSearchCommand() *cli.Command {
-	return &cli.Command{
+	cmd := &cli.Command{
 		Name:  "search",
 		Short: i18n.T("Search plugin by command name", "根据命令名搜索插件"),
-		Usage: "search <command-name>",
+		Usage: "search [--source-base <url>] <command-name>",
 		Run: func(ctx *cli.Context, args []string) error {
 			return runSearch(ctx, args)
 		},
 	}
+	addPluginSourceBaseFlag(cmd)
+	return cmd
 }
 
 func runSearch(ctx *cli.Context, args []string) error {
@@ -120,7 +152,7 @@ func runSearch(ctx *cli.Context, args []string) error {
 		return fmt.Errorf("command name cannot be empty")
 	}
 
-	mgr, err := NewManager()
+	mgr, err := newManagerWithOptionalSourceBase(ctx)
 	if err != nil {
 		return err
 	}
@@ -235,7 +267,7 @@ func newInstallCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:  "install",
 		Short: i18n.T("Install a plugin (from remote index or local archive)", "安装插件（远程索引或本地包）"),
-		Usage: "install --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install --source <path-to-archive> [--version <version>]",
+		Usage: "install [--source-base <url>] --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install [--source-base <url>] --source <path-to-archive> [--version <version>]",
 		Run: func(ctx *cli.Context, args []string) error {
 			names, source, version, enablePre, err := parseInstallArgs(ctx)
 			if err != nil {
@@ -278,6 +310,7 @@ func newInstallCommand() *cli.Command {
 		DefaultValue: "",
 	})
 
+	addPluginSourceBaseFlag(cmd)
 	return cmd
 }
 
@@ -285,10 +318,10 @@ func newInstallAllCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:   "install-all",
 		Short:  i18n.T("Install all available plugins", "安装所有可用的插件"),
-		Usage:  "install-all [--enable-pre]",
+		Usage:  "install-all [--source-base <url>] [--enable-pre]",
 		Hidden: true, // 不推荐使用
 		Run: func(ctx *cli.Context, args []string) error {
-			mgr, err := NewManager()
+			mgr, err := newManagerWithOptionalSourceBase(ctx)
 			if err != nil {
 				return err
 			}
@@ -308,6 +341,7 @@ func newInstallAllCommand() *cli.Command {
 		AssignedMode: cli.AssignedNone,
 	})
 
+	addPluginSourceBaseFlag(cmd)
 	return cmd
 }
 
@@ -348,9 +382,9 @@ func newUpdateCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:  "update",
 		Short: i18n.T("Update plugin(s)", "更新插件"),
-		Usage: "plugin update [--name <plugin_name>] [--enable-pre]",
+		Usage: "update [--source-base <url>] [--name <plugin_name>] [--enable-pre]",
 		Run: func(ctx *cli.Context, args []string) error {
-			mgr, err := NewManager()
+			mgr, err := newManagerWithOptionalSourceBase(ctx)
 			if err != nil {
 				return err
 			}
@@ -386,6 +420,7 @@ func newUpdateCommand() *cli.Command {
 		AssignedMode: cli.AssignedNone,
 	})
 
+	addPluginSourceBaseFlag(cmd)
 	return cmd
 }
 
@@ -434,7 +469,7 @@ func validateInstallArgs(names []string, source string) ([]string, error) {
 }
 
 func executeInstall(ctx *cli.Context, names []string, source, version string, enablePre bool) error {
-	mgr, err := NewManager()
+	mgr, err := newManagerWithOptionalSourceBase(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -1,8 +1,13 @@
 package plugin
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -23,6 +28,7 @@ func NewPluginCommand() *cli.Command {
 	cmd.AddSubCommand(newListCommand())
 	cmd.AddSubCommand(newListRemoteCommand())
 	cmd.AddSubCommand(newSearchCommand())
+	cmd.AddSubCommand(newShowCommand())
 	cmd.AddSubCommand(newInstallCommand())
 	cmd.AddSubCommand(newInstallAllCommand())
 	cmd.AddSubCommand(newUninstallCommand())
@@ -131,23 +137,117 @@ func runSearch(ctx *cli.Context, args []string) error {
 	return displaySearchResults(ctx, mgr, commandName, results)
 }
 
+func newShowCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name:  "show",
+		Short: i18n.T("Show details of an installed plugin", "显示已安装插件的详细信息"),
+		Usage: "show --name <plugin_name>",
+		Run: func(ctx *cli.Context, args []string) error {
+			name := ""
+			if v, ok := ctx.Flags().GetValue("name"); ok {
+				name = v
+			}
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("plugin name is required (use --name)")
+			}
+
+			mgr, err := NewManager()
+			if err != nil {
+				return err
+			}
+
+			actualName, p, err := mgr.findLocalPlugin(name)
+			if err != nil {
+				return err
+			}
+
+			return displayInstalledPluginDetails(ctx, actualName, p)
+		},
+	}
+
+	cmd.Flags().Add(&cli.Flag{
+		Name:         "name",
+		Short:        i18n.T("Installed plugin name", "已安装的插件名称"),
+		AssignedMode: cli.AssignedOnce,
+	})
+
+	return cmd
+}
+
+func displayInstalledPluginDetails(ctx *cli.Context, canonicalName string, p *LocalPlugin) error {
+	out := ctx.Stdout()
+	fmt.Fprintf(out, "Name:\t%s\n", canonicalName)
+	fmt.Fprintf(out, "Version:\t%s\n", p.Version)
+	if pc := strings.TrimSpace(p.ProductCode); pc != "" {
+		fmt.Fprintf(out, "Product code:\t%s\n", pc)
+	}
+	// fmt.Fprintf(out, "Path:\t%s\n", p.Path)
+	if p.Command != "" {
+		fmt.Fprintf(out, "Command:\t%s\n", p.Command)
+	}
+	if p.ShortDescription != "" {
+		fmt.Fprintf(out, "Short description:\t%s\n", p.ShortDescription)
+	}
+	if p.Description != "" {
+		fmt.Fprintf(out, "Description:\t%s\n", p.Description)
+	}
+	if av, err := readPluginAPIVersionsFromDir(p.Path); err == nil && apiVersionsPresent(av) {
+		writePluginAPIVersionsSection(out, av)
+	}
+	if p.Inner {
+		fmt.Fprintf(out, "Inner:\t%v\n", p.Inner)
+	}
+	return nil
+}
+
+func readPluginAPIVersionsFromDir(pluginDir string) (*PluginAPIVersions, error) {
+	path := filepath.Join(pluginDir, "manifest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var wrapper struct {
+		APIVersions *PluginAPIVersions `json:"apiVersions"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.APIVersions, nil
+}
+
+func apiVersionsPresent(v *PluginAPIVersions) bool {
+	if v == nil {
+		return false
+	}
+	return v.Default != "" || len(v.Supported) > 0
+}
+
+func writePluginAPIVersionsSection(out io.Writer, v *PluginAPIVersions) {
+	if v.Default != "" {
+		fmt.Fprintf(out, "API default:\t%s\n", v.Default)
+	}
+	if len(v.Supported) > 0 {
+		fmt.Fprintf(out, "API supported:\t%s\n", strings.Join(v.Supported, ", "))
+	}
+}
+
 func newInstallCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:  "install",
-		Short: i18n.T("Install a plugin", "安装插件"),
-		Usage: "install --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre]",
+		Short: i18n.T("Install a plugin (from remote index or local archive)", "安装插件（远程索引或本地包）"),
+		Usage: "install --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install --source <path-to-archive> [--version <version>]",
 		Run: func(ctx *cli.Context, args []string) error {
-			names, version, enablePre, err := parseInstallArgs(ctx)
+			names, source, version, enablePre, err := parseInstallArgs(ctx)
 			if err != nil {
 				return err
 			}
 
-			validatedNames, err := validateInstallArgs(names)
+			validatedNames, err := validateInstallArgs(names, source)
 			if err != nil {
 				return err
 			}
 
-			return executeInstall(ctx, validatedNames, version, enablePre)
+			return executeInstall(ctx, validatedNames, source, version, enablePre)
 		},
 	}
 
@@ -160,7 +260,7 @@ func newInstallCommand() *cli.Command {
 
 	cmd.Flags().Add(&cli.Flag{
 		Name:         "version",
-		Short:        i18n.T("Specify plugin version", "指定插件版本"),
+		Short:        i18n.T("Specify plugin version (remote) or must match manifest when using --source", "指定插件版本（远程）；与 --source 连用时须与 manifest 一致"),
 		AssignedMode: cli.AssignedOnce,
 		DefaultValue: "",
 	})
@@ -169,6 +269,13 @@ func newInstallCommand() *cli.Command {
 		Name:         "enable-pre",
 		Short:        i18n.T("Allow installing pre-release versions", "允许安装预发布版本"),
 		AssignedMode: cli.AssignedNone,
+	})
+
+	cmd.Flags().Add(&cli.Flag{
+		Name:         "source",
+		Short:        i18n.T("Install from a local plugin archive (.zip, .tar.gz, .tgz)", "从本地插件包安装（.zip、.tar.gz、.tgz）"),
+		AssignedMode: cli.AssignedOnce,
+		DefaultValue: "",
 	})
 
 	return cmd
@@ -282,9 +389,13 @@ func newUpdateCommand() *cli.Command {
 	return cmd
 }
 
-func parseInstallArgs(ctx *cli.Context) (names []string, version string, enablePre bool, err error) {
+func parseInstallArgs(ctx *cli.Context) (names []string, source string, version string, enablePre bool, err error) {
 	if namesFlag := ctx.Flags().Get("names"); namesFlag != nil && namesFlag.IsAssigned() {
 		names = namesFlag.GetValues()
+	}
+
+	if v, ok := ctx.Flags().GetValue("source"); ok {
+		source = v
 	}
 
 	if v, ok := ctx.Flags().GetValue("version"); ok {
@@ -295,12 +406,19 @@ func parseInstallArgs(ctx *cli.Context) (names []string, version string, enableP
 		enablePre = true
 	}
 
-	return names, version, enablePre, nil
+	return names, source, version, enablePre, nil
 }
 
-func validateInstallArgs(names []string) ([]string, error) {
+func validateInstallArgs(names []string, source string) ([]string, error) {
+	if strings.TrimSpace(source) != "" {
+		if len(names) > 0 {
+			return nil, fmt.Errorf("--names cannot be used together with --source")
+		}
+		return nil, nil
+	}
+
 	if len(names) == 0 {
-		return nil, fmt.Errorf("--names flag is required")
+		return nil, fmt.Errorf("either --names or --source is required")
 	}
 
 	validNames := []string{}
@@ -315,10 +433,14 @@ func validateInstallArgs(names []string) ([]string, error) {
 	return validNames, nil
 }
 
-func executeInstall(ctx *cli.Context, names []string, version string, enablePre bool) error {
+func executeInstall(ctx *cli.Context, names []string, source, version string, enablePre bool) error {
 	mgr, err := NewManager()
 	if err != nil {
 		return err
+	}
+
+	if strings.TrimSpace(source) != "" {
+		return mgr.InstallFromLocalFile(ctx, source, version)
 	}
 
 	if len(names) == 1 {

--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -212,10 +212,6 @@ func displayInstalledPluginDetails(ctx *cli.Context, canonicalName string, p *Lo
 	if pc := strings.TrimSpace(p.ProductCode); pc != "" {
 		fmt.Fprintf(out, "Product code:\t%s\n", pc)
 	}
-	// fmt.Fprintf(out, "Path:\t%s\n", p.Path)
-	if p.Command != "" {
-		fmt.Fprintf(out, "Command:\t%s\n", p.Command)
-	}
 	if p.ShortDescription != "" {
 		fmt.Fprintf(out, "Short description:\t%s\n", p.ShortDescription)
 	}

--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -266,7 +266,7 @@ func newInstallCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:  "install",
 		Short: i18n.T("Install a plugin (from remote index or package file/URL)", "安装插件（远程索引或指定包文件/URL）"),
-		Usage: "install [--source-base <url>] --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install [--source-base <url>] --package <path-or-url> [--version <version>]",
+		Usage: "install [--source-base <url>] --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install --package <path-or-url>",
 		Run: func(ctx *cli.Context, args []string) error {
 			names, pkgRef, version, enablePre, err := parseInstallArgs(ctx)
 			if err != nil {
@@ -476,7 +476,7 @@ func executeInstall(ctx *cli.Context, names []string, pkgRef, version string, en
 	}
 
 	if strings.TrimSpace(pkgRef) != "" {
-		return mgr.InstallFromPackage(ctx, pkgRef, version)
+		return mgr.InstallFromPackage(ctx, pkgRef)
 	}
 
 	if len(names) == 1 {

--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -287,7 +287,7 @@ func newInstallCommand() *cli.Command {
 
 	cmd.Flags().Add(&cli.Flag{
 		Name:         "version",
-		Short:        i18n.T("Specify plugin version (remote) or must match manifest when using --package", "指定插件版本（远程）；与 --package 连用时须与 manifest 一致"),
+		Short:        i18n.T("Specify plugin version when installing from the remote index (--names)", "使用 --names 从远程索引安装时指定插件版本"),
 		AssignedMode: cli.AssignedOnce,
 		DefaultValue: "",
 	})

--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -16,8 +16,7 @@ import (
 
 func addPluginSourceBaseFlag(cmd *cli.Command) {
 	cmd.Flags().Add(&cli.Flag{
-		Category: "remote",
-		Name:     "source-base",
+		Name: "source-base",
 		Short: i18n.T(
 			"Override plugins tree base URL for this command only (e.g. https://example.com/plugins)",
 			"仅本次命令覆盖插件源根地址（例如 https://example.com/plugins）"),

--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -266,20 +266,20 @@ func writePluginAPIVersionsSection(out io.Writer, v *PluginAPIVersions) {
 func newInstallCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:  "install",
-		Short: i18n.T("Install a plugin (from remote index or local archive)", "安装插件（远程索引或本地包）"),
-		Usage: "install [--source-base <url>] --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install [--source-base <url>] --source <path-to-archive> [--version <version>]",
+		Short: i18n.T("Install a plugin (from remote index or package file/URL)", "安装插件（远程索引或指定包文件/URL）"),
+		Usage: "install [--source-base <url>] --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install [--source-base <url>] --package <path-or-url> [--version <version>]",
 		Run: func(ctx *cli.Context, args []string) error {
-			names, source, version, enablePre, err := parseInstallArgs(ctx)
+			names, pkgRef, version, enablePre, err := parseInstallArgs(ctx)
 			if err != nil {
 				return err
 			}
 
-			validatedNames, err := validateInstallArgs(names, source)
+			validatedNames, err := validateInstallArgs(names, pkgRef)
 			if err != nil {
 				return err
 			}
 
-			return executeInstall(ctx, validatedNames, source, version, enablePre)
+			return executeInstall(ctx, validatedNames, pkgRef, version, enablePre)
 		},
 	}
 
@@ -292,7 +292,7 @@ func newInstallCommand() *cli.Command {
 
 	cmd.Flags().Add(&cli.Flag{
 		Name:         "version",
-		Short:        i18n.T("Specify plugin version (remote) or must match manifest when using --source", "指定插件版本（远程）；与 --source 连用时须与 manifest 一致"),
+		Short:        i18n.T("Specify plugin version (remote) or must match manifest when using --package", "指定插件版本（远程）；与 --package 连用时须与 manifest 一致"),
 		AssignedMode: cli.AssignedOnce,
 		DefaultValue: "",
 	})
@@ -304,8 +304,8 @@ func newInstallCommand() *cli.Command {
 	})
 
 	cmd.Flags().Add(&cli.Flag{
-		Name:         "source",
-		Short:        i18n.T("Install from a local plugin archive (.zip, .tar.gz, .tgz)", "从本地插件包安装（.zip、.tar.gz、.tgz）"),
+		Name:         "package",
+		Short:        i18n.T("Path or http(s) URL of the plugin package file (.zip, .tar.gz, .tgz)", "插件包文件的路径或 http(s) URL（.zip、.tar.gz、.tgz）"),
 		AssignedMode: cli.AssignedOnce,
 		DefaultValue: "",
 	})
@@ -424,13 +424,15 @@ func newUpdateCommand() *cli.Command {
 	return cmd
 }
 
-func parseInstallArgs(ctx *cli.Context) (names []string, source string, version string, enablePre bool, err error) {
+func parseInstallArgs(ctx *cli.Context) (names []string, pkgRef string, version string, enablePre bool, err error) {
 	if namesFlag := ctx.Flags().Get("names"); namesFlag != nil && namesFlag.IsAssigned() {
 		names = namesFlag.GetValues()
 	}
 
-	if v, ok := ctx.Flags().GetValue("source"); ok {
-		source = v
+	if f := ctx.Flags().Get("package"); f != nil && f.IsAssigned() {
+		if v, ok := f.GetValue(); ok {
+			pkgRef = strings.TrimSpace(v)
+		}
 	}
 
 	if v, ok := ctx.Flags().GetValue("version"); ok {
@@ -441,19 +443,19 @@ func parseInstallArgs(ctx *cli.Context) (names []string, source string, version 
 		enablePre = true
 	}
 
-	return names, source, version, enablePre, nil
+	return names, pkgRef, version, enablePre, nil
 }
 
-func validateInstallArgs(names []string, source string) ([]string, error) {
-	if strings.TrimSpace(source) != "" {
+func validateInstallArgs(names []string, pkgRef string) ([]string, error) {
+	if strings.TrimSpace(pkgRef) != "" {
 		if len(names) > 0 {
-			return nil, fmt.Errorf("--names cannot be used together with --source")
+			return nil, fmt.Errorf("--names cannot be used together with --package")
 		}
 		return nil, nil
 	}
 
 	if len(names) == 0 {
-		return nil, fmt.Errorf("either --names or --source is required")
+		return nil, fmt.Errorf("either --names or --package is required")
 	}
 
 	validNames := []string{}
@@ -468,14 +470,14 @@ func validateInstallArgs(names []string, source string) ([]string, error) {
 	return validNames, nil
 }
 
-func executeInstall(ctx *cli.Context, names []string, source, version string, enablePre bool) error {
+func executeInstall(ctx *cli.Context, names []string, pkgRef, version string, enablePre bool) error {
 	mgr, err := newManagerWithOptionalSourceBase(ctx)
 	if err != nil {
 		return err
 	}
 
-	if strings.TrimSpace(source) != "" {
-		return mgr.InstallFromLocalFile(ctx, source, version)
+	if strings.TrimSpace(pkgRef) != "" {
+		return mgr.InstallFromPackage(ctx, pkgRef, version)
 	}
 
 	if len(names) == 1 {

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -25,6 +25,7 @@ func TestNewPluginCommand(t *testing.T) {
 	assert.NotNil(t, cmd.GetSubCommand("install"), "Should have install subcommand")
 	assert.NotNil(t, cmd.GetSubCommand("install-all"), "Should have install-all subcommand")
 	assert.NotNil(t, cmd.GetSubCommand("uninstall"), "Should have uninstall subcommand")
+	assert.NotNil(t, cmd.GetSubCommand("show"), "Should have show subcommand")
 	assert.NotNil(t, cmd.GetSubCommand("update"), "Should have update subcommand")
 }
 
@@ -261,6 +262,10 @@ func TestNewInstallCommand(t *testing.T) {
 	versionFlag := flags.Get("version")
 	assert.NotNil(t, versionFlag)
 	assert.False(t, versionFlag.Required)
+
+	sourceFlag := flags.Get("source")
+	assert.NotNil(t, sourceFlag)
+	assert.False(t, sourceFlag.Required)
 }
 
 func TestNewInstallCommand_Run(t *testing.T) {
@@ -347,7 +352,68 @@ func TestNewInstallCommand_Run_WithVersionFlagOnly(t *testing.T) {
 
 	err := cmd.Run(ctx, []string{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "names flag is required")
+	assert.Contains(t, err.Error(), "either --names or --source is required")
+}
+
+func TestNewInstallCommand_Run_NamesAndSourceConflict(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	namesFlag := ctx.Flags().Get("names")
+	assert.NotNil(t, namesFlag)
+	namesFlag.SetAssigned(true)
+	namesFlag.SetValues([]string{"some-plugin"})
+
+	sourceFlag := ctx.Flags().Get("source")
+	assert.NotNil(t, sourceFlag)
+	sourceFlag.SetAssigned(true)
+	sourceFlag.SetValue("/tmp/x.zip")
+
+	err := cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--names cannot be used together with --source")
+}
+
+func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	archiveBody := createTestPluginArchive(t, "cli-local-cmd-test", "1.2.3", "x")
+	archivePath := filepath.Join(t.TempDir(), "plugin-local-cmd.tar.gz")
+	assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	sourceFlag := ctx.Flags().Get("source")
+	assert.NotNil(t, sourceFlag)
+	sourceFlag.SetAssigned(true)
+	sourceFlag.SetValue(archivePath)
+
+	err := cmd.Run(ctx, []string{})
+	assert.NoError(t, err)
+
+	mgr, err := NewManager()
+	assert.NoError(t, err)
+	manifest, err := mgr.GetLocalManifest()
+	assert.NoError(t, err)
+	p, ok := manifest.Plugins["cli-local-cmd-test"]
+	assert.True(t, ok)
+	assert.Equal(t, "1.2.3", p.Version)
+	assert.Contains(t, stdout.String(), "Installing plugin from")
 }
 
 func TestNewInstallCommand_Run_WithNamesAndEnablePreFlags(t *testing.T) {
@@ -475,6 +541,144 @@ func TestNewUninstallCommand(t *testing.T) {
 	nameFlag := flags.Get("name")
 	assert.NotNil(t, nameFlag)
 	assert.False(t, nameFlag.Required)
+}
+
+func TestNewShowCommand(t *testing.T) {
+	cmd := newShowCommand()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "show", cmd.Name)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Usage)
+
+	flags := cmd.Flags()
+	nameFlag := flags.Get("name")
+	assert.NotNil(t, nameFlag)
+	assert.False(t, nameFlag.Required)
+}
+
+func TestNewShowCommand_Run_MissingName(t *testing.T) {
+	cmd := newShowCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	err := cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--name")
+}
+
+func TestNewShowCommand_Run_NotInstalled(t *testing.T) {
+	cmd := newShowCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	manifestPath := filepath.Join(testHome, ".aliyun", "plugins", "manifest.json")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(manifestPath), 0755))
+	manifest := LocalManifest{Plugins: map[string]LocalPlugin{}}
+	manifestJSON, err := json.Marshal(manifest)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(manifestPath, manifestJSON, 0644))
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	nameFlag := ctx.Flags().Get("name")
+	assert.NotNil(t, nameFlag)
+	nameFlag.SetAssigned(true)
+	nameFlag.SetValue("missing-plugin")
+
+	err = cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not installed")
+}
+
+func TestNewShowCommand_Run_Success(t *testing.T) {
+	cmd := newShowCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	manifestPath := filepath.Join(testHome, ".aliyun", "plugins", "manifest.json")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(manifestPath), 0755))
+	pluginPath := filepath.Join(testHome, ".aliyun", "plugins", "aliyun-cli-demo")
+	assert.NoError(t, os.MkdirAll(pluginPath, 0755))
+
+	pkgManifest := map[string]interface{}{
+		"name":         "aliyun-cli-demo",
+		"version":      "2.0.0",
+		"productCode":  "demo-product",
+		"apiVersions": map[string]interface{}{
+			"default": "2017-06-13",
+			"supported": []string{
+				"2019-08-16",
+				"2017-06-13",
+			},
+			"versionInfo": map[string]interface{}{
+				"2017-06-13": map[string]interface{}{
+					"deprecated": false, "recommended": true, "description": "stable line",
+				},
+				"2019-08-16": map[string]interface{}{
+					"deprecated": false, "recommended": false, "description": "newer line",
+				},
+			},
+		},
+	}
+	pkgJSON, err := json.Marshal(pkgManifest)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(filepath.Join(pluginPath, "manifest.json"), pkgJSON, 0644))
+
+	manifest := LocalManifest{
+		Plugins: map[string]LocalPlugin{
+			"aliyun-cli-demo": {
+				Name:             "aliyun-cli-demo",
+				Version:          "2.0.0",
+				Path:             pluginPath,
+				ProductCode:      "demo-product",
+				Command:          "demo",
+				ShortDescription: "short",
+				Description:      "full description",
+				Inner:            true,
+			},
+		},
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(manifestPath, manifestJSON, 0644))
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	nameFlag := ctx.Flags().Get("name")
+	assert.NotNil(t, nameFlag)
+	nameFlag.SetAssigned(true)
+	nameFlag.SetValue("aliyun-cli-demo")
+
+	err = cmd.Run(ctx, []string{})
+	assert.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "Name:\taliyun-cli-demo")
+	assert.Contains(t, out, "Version:\t2.0.0")
+	assert.Contains(t, out, "Product code:\tdemo-product\n")
+	assert.Contains(t, out, "Command:\tdemo")
+	assert.Contains(t, out, "Short description:\tshort")
+	assert.Contains(t, out, "Description:\tfull description")
+	assert.Contains(t, out, "API default:\t2017-06-13\n")
+	assert.Contains(t, out, "API supported:\t2019-08-16, 2017-06-13\n")
+	assert.Contains(t, out, "Inner:\ttrue")
 }
 
 func TestNewUpdateCommand(t *testing.T) {

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -264,9 +264,9 @@ func TestNewInstallCommand(t *testing.T) {
 	assert.NotNil(t, versionFlag)
 	assert.False(t, versionFlag.Required)
 
-	sourceFlag := flags.Get("source")
-	assert.NotNil(t, sourceFlag)
-	assert.False(t, sourceFlag.Required)
+	packageFlag := flags.Get("package")
+	assert.NotNil(t, packageFlag)
+	assert.False(t, packageFlag.Required)
 
 	sourceBaseFlag := flags.Get("source-base")
 	assert.NotNil(t, sourceBaseFlag)
@@ -357,7 +357,7 @@ func TestNewInstallCommand_Run_WithVersionFlagOnly(t *testing.T) {
 
 	err := cmd.Run(ctx, []string{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "either --names or --source is required")
+	assert.Contains(t, err.Error(), "either --names or --package is required")
 }
 
 func TestNewInstallCommand_Run_WithNamesAndEnablePreFlags(t *testing.T) {

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -641,6 +641,69 @@ func TestNewUpdateCommand(t *testing.T) {
 	assert.NotNil(t, flags.Get("source-base"))
 }
 
+func TestNewManagerWithOptionalSourceBase(t *testing.T) {
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	t.Run("no override when source-base unset", func(t *testing.T) {
+		cmd := newUpdateCommand()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		ctx := cli.NewCommandContext(stdout, stderr)
+		ctx.EnterCommand(cmd)
+		mgr, err := newManagerWithOptionalSourceBase(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, mgr)
+	})
+
+	t.Run("valid override applies trim and trailing slash", func(t *testing.T) {
+		cmd := newUpdateCommand()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		ctx := cli.NewCommandContext(stdout, stderr)
+		ctx.EnterCommand(cmd)
+		f := ctx.Flags().Get("source-base")
+		assert.NotNil(t, f)
+		f.SetAssigned(true)
+		f.SetValue("  https://mirror.example/plugins/  ")
+		mgr, err := newManagerWithOptionalSourceBase(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, mgr)
+		assert.Equal(t, "https://mirror.example/plugins", mgr.sourceBase)
+	})
+
+	t.Run("invalid scheme returns ApplySourceBaseOverride error", func(t *testing.T) {
+		cmd := newUpdateCommand()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		ctx := cli.NewCommandContext(stdout, stderr)
+		ctx.EnterCommand(cmd)
+		f := ctx.Flags().Get("source-base")
+		f.SetAssigned(true)
+		f.SetValue("ftp://mirror.example/plugins")
+		mgr, err := newManagerWithOptionalSourceBase(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, mgr)
+		assert.Contains(t, err.Error(), "source-base must start with http:// or https://")
+	})
+
+	t.Run("whitespace only value returns error", func(t *testing.T) {
+		cmd := newUpdateCommand()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		ctx := cli.NewCommandContext(stdout, stderr)
+		ctx.EnterCommand(cmd)
+		f := ctx.Flags().Get("source-base")
+		f.SetAssigned(true)
+		f.SetValue("   \t  ")
+		mgr, err := newManagerWithOptionalSourceBase(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, mgr)
+		assert.Contains(t, err.Error(), "source-base must not be empty")
+	})
+}
+
 func TestNewUpdateCommand_Run_WithoutName(t *testing.T) {
 	cmd := newUpdateCommand()
 

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -355,67 +355,6 @@ func TestNewInstallCommand_Run_WithVersionFlagOnly(t *testing.T) {
 	assert.Contains(t, err.Error(), "either --names or --source is required")
 }
 
-func TestNewInstallCommand_Run_NamesAndSourceConflict(t *testing.T) {
-	cmd := newInstallCommand()
-
-	testHome := t.TempDir()
-	cleanup := setTestHomeDir(t, testHome)
-	defer cleanup()
-
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	ctx := cli.NewCommandContext(stdout, stderr)
-	ctx.EnterCommand(cmd)
-
-	namesFlag := ctx.Flags().Get("names")
-	assert.NotNil(t, namesFlag)
-	namesFlag.SetAssigned(true)
-	namesFlag.SetValues([]string{"some-plugin"})
-
-	sourceFlag := ctx.Flags().Get("source")
-	assert.NotNil(t, sourceFlag)
-	sourceFlag.SetAssigned(true)
-	sourceFlag.SetValue("/tmp/x.zip")
-
-	err := cmd.Run(ctx, []string{})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "--names cannot be used together with --source")
-}
-
-func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
-	cmd := newInstallCommand()
-
-	testHome := t.TempDir()
-	cleanup := setTestHomeDir(t, testHome)
-	defer cleanup()
-
-	archiveBody := createTestPluginArchive(t, "cli-local-cmd-test", "1.2.3", "x")
-	archivePath := filepath.Join(t.TempDir(), "plugin-local-cmd.tar.gz")
-	assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
-
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	ctx := cli.NewCommandContext(stdout, stderr)
-	ctx.EnterCommand(cmd)
-
-	sourceFlag := ctx.Flags().Get("source")
-	assert.NotNil(t, sourceFlag)
-	sourceFlag.SetAssigned(true)
-	sourceFlag.SetValue(archivePath)
-
-	err := cmd.Run(ctx, []string{})
-	assert.NoError(t, err)
-
-	mgr, err := NewManager()
-	assert.NoError(t, err)
-	manifest, err := mgr.GetLocalManifest()
-	assert.NoError(t, err)
-	p, ok := manifest.Plugins["cli-local-cmd-test"]
-	assert.True(t, ok)
-	assert.Equal(t, "1.2.3", p.Version)
-	assert.Contains(t, stdout.String(), "Installing plugin from")
-}
-
 func TestNewInstallCommand_Run_WithNamesAndEnablePreFlags(t *testing.T) {
 	cmd := newInstallCommand()
 
@@ -615,9 +554,9 @@ func TestNewShowCommand_Run_Success(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(pluginPath, 0755))
 
 	pkgManifest := map[string]interface{}{
-		"name":         "aliyun-cli-demo",
-		"version":      "2.0.0",
-		"productCode":  "demo-product",
+		"name":        "aliyun-cli-demo",
+		"version":     "2.0.0",
+		"productCode": "demo-product",
 		"apiVersions": map[string]interface{}{
 			"default": "2017-06-13",
 			"supported": []string{

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -113,6 +113,7 @@ func TestNewListRemoteCommand(t *testing.T) {
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "list-remote", cmd.Name)
 	assert.NotEmpty(t, cmd.Short)
+	assert.NotNil(t, cmd.Flags().Get("source-base"))
 }
 
 func TestNewListRemoteCommand_Run(t *testing.T) {
@@ -266,6 +267,10 @@ func TestNewInstallCommand(t *testing.T) {
 	sourceFlag := flags.Get("source")
 	assert.NotNil(t, sourceFlag)
 	assert.False(t, sourceFlag.Required)
+
+	sourceBaseFlag := flags.Get("source-base")
+	assert.NotNil(t, sourceBaseFlag)
+	assert.False(t, sourceBaseFlag.Required)
 }
 
 func TestNewInstallCommand_Run(t *testing.T) {
@@ -467,6 +472,7 @@ func TestNewInstallAllCommand(t *testing.T) {
 	assert.Equal(t, "install-all", cmd.Name)
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotEmpty(t, cmd.Usage)
+	assert.NotNil(t, cmd.Flags().Get("source-base"))
 }
 
 func TestNewUninstallCommand(t *testing.T) {
@@ -631,6 +637,8 @@ func TestNewUpdateCommand(t *testing.T) {
 	nameFlag := flags.Get("name")
 	assert.NotNil(t, nameFlag)
 	assert.False(t, nameFlag.Required) // name is optional for update
+
+	assert.NotNil(t, flags.Get("source-base"))
 }
 
 func TestNewUpdateCommand_Run_WithoutName(t *testing.T) {
@@ -1170,6 +1178,7 @@ func TestNewSearchCommand_Integration(t *testing.T) {
 	cmd := newSearchCommand()
 	assert.NotNil(t, cmd)
 	assert.Equal(t, "search", cmd.Name)
+	assert.NotNil(t, cmd.Flags().Get("source-base"))
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -618,7 +618,6 @@ func TestNewShowCommand_Run_Success(t *testing.T) {
 	assert.Contains(t, out, "Name:\taliyun-cli-demo")
 	assert.Contains(t, out, "Version:\t2.0.0")
 	assert.Contains(t, out, "Product code:\tdemo-product\n")
-	assert.Contains(t, out, "Command:\tdemo")
 	assert.Contains(t, out, "Short description:\tshort")
 	assert.Contains(t, out, "Description:\tfull description")
 	assert.Contains(t, out, "API default:\t2017-06-13\n")

--- a/cli/plugin/execution_test.go
+++ b/cli/plugin/execution_test.go
@@ -211,8 +211,8 @@ func TestFindLocalPlugin(t *testing.T) {
 			if tt.wantFound {
 				if plugin == nil {
 					t.Errorf("findLocalPlugin() expected plugin, got nil")
-				} else if plugin.Command != "aliyun-cli-fc" {
-					t.Errorf("findLocalPlugin() got plugin.Command = %q, want %q", plugin.Command, "aliyun-cli-fc")
+				} else if plugin.Name != "aliyun-cli-fc" {
+					t.Errorf("findLocalPlugin() got plugin.Name = %q, want %q", plugin.Name, "aliyun-cli-fc")
 				}
 			} else {
 				if plugin != nil {

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -789,7 +789,25 @@ func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (string,
 	return finalDir, nil
 }
 
-func (m *Manager) InstallFromPackage(ctx *cli.Context, ref, version string) error {
+func (m *Manager) printOverwriteIfPluginInstalled(ctx *cli.Context, pluginName, incomingVersion string) {
+	localManifest, err := m.GetLocalManifest()
+	if err != nil {
+		return
+	}
+	existing, ok := localManifest.Plugins[pluginName]
+	if !ok {
+		return
+	}
+	oldVer := strings.TrimSpace(existing.Version)
+	if oldVer == "" {
+		oldVer = "unknown"
+	}
+	cli.Printf(ctx.Stdout(),
+		"Note: plugin %q is already installed (version %s); continuing will replace it with version %s.\n",
+		pluginName, oldVer, incomingVersion)
+}
+
+func (m *Manager) InstallFromPackage(ctx *cli.Context, ref string) error {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return fmt.Errorf("package path or URL is empty")
@@ -799,12 +817,12 @@ func (m *Manager) InstallFromPackage(ctx *cli.Context, ref, version string) erro
 		if !isRemotePluginPackageRef(ref) {
 			return fmt.Errorf("package URL path must end with .zip, .tar.gz, or .tgz")
 		}
-		return m.installFromRemotePackageURL(ctx, ref, version)
+		return m.installFromRemotePackageURL(ctx, ref)
 	}
-	return m.InstallFromLocalFile(ctx, ref, version)
+	return m.InstallFromLocalFile(ctx, ref)
 }
 
-func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath, version string) error {
+func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath string) error {
 	absPath, err := expandPluginSourcePath(sourcePath)
 	if err != nil {
 		return err
@@ -816,10 +834,10 @@ func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath, version str
 	if st.IsDir() {
 		return fmt.Errorf("package must be a plugin archive file (.zip, .tar.gz, .tgz), not a directory")
 	}
-	return m.installFromPackageFile(ctx, absPath, version, absPath)
+	return m.installFromPackageFile(ctx, absPath, absPath)
 }
 
-func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL, version string) error {
+func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid package URL: %w", err)
@@ -866,10 +884,10 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL, version 
 		return fmt.Errorf("write plugin package: %w", err)
 	}
 
-	return m.installFromPackageFile(ctx, dest, version, rawURL)
+	return m.installFromPackageFile(ctx, dest, rawURL)
 }
 
-func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, version, userFacing string) error {
+func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing string) error {
 	if !isPluginArchivePath(absPath) {
 		return fmt.Errorf("unsupported package format (use .zip, .tar.gz, or .tgz): %s", absPath)
 	}
@@ -891,9 +909,8 @@ func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, version, use
 	if err != nil {
 		return err
 	}
-	if version != "" && version != pManifest.Version {
-		return fmt.Errorf("specified version %q does not match package manifest version %q", version, pManifest.Version)
-	}
+
+	m.printOverwriteIfPluginInstalled(ctx, pManifest.Name, pManifest.Version)
 
 	finalDir, err := m.promoteExtractedPlugin(tmpExtract, pManifest.Name)
 	if err != nil {
@@ -949,7 +966,7 @@ func (m *Manager) savePluginToManifest(actualPluginName, version, extractDir str
 	return m.saveLocalManifest(localManifest)
 }
 
-func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, version string, enablePre bool) error {
+func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, version string, enablePre bool, warnIfAlreadyInstalled bool) error {
 	actualPluginName := targetPlugin.Name
 
 	if version == "" {
@@ -979,6 +996,10 @@ func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, vers
 	}
 	defer os.RemoveAll(filepath.Dir(archivePath))
 
+	if warnIfAlreadyInstalled {
+		m.printOverwriteIfPluginInstalled(ctx, actualPluginName, version)
+	}
+
 	extractDir := filepath.Join(m.rootDir, actualPluginName)
 	if err := m.extractPlugin(archivePath, extractDir, downloadURL); err != nil {
 		return err
@@ -1003,7 +1024,7 @@ func (m *Manager) Install(ctx *cli.Context, pluginName, version string, enablePr
 		return err
 	}
 
-	return m.installPlugin(ctx, targetPlugin, version, enablePre)
+	return m.installPlugin(ctx, targetPlugin, version, enablePre, true)
 }
 
 func (m *Manager) Upgrade(ctx *cli.Context, pluginName string, enablePre bool) error {
@@ -1032,7 +1053,7 @@ func (m *Manager) Upgrade(ctx *cli.Context, pluginName string, enablePre bool) e
 	} else {
 		cli.Printf(ctx.Stdout(), "Upgrading plugin %s from %s to %s...\n", actualPluginName, localPlugin.Version, latestVersion)
 	}
-	return m.installPlugin(ctx, targetPlugin, latestVersion, enablePre)
+	return m.installPlugin(ctx, targetPlugin, latestVersion, enablePre, false)
 }
 
 func (m *Manager) Uninstall(ctx *cli.Context, pluginName string) error {
@@ -1111,7 +1132,7 @@ func (m *Manager) UpdateAll(ctx *cli.Context, enablePre bool) error {
 			cli.Printf(ctx.Stdout(), "Updating %s from %s to %s...\n", pluginName, localPlugin.Version, latestVersion)
 		}
 
-		if err := m.installPlugin(ctx, targetPlugin, latestVersion, enablePre); err != nil {
+		if err := m.installPlugin(ctx, targetPlugin, latestVersion, enablePre, false); err != nil {
 			cli.Printf(ctx.Stdout(), "Failed to update %s: %v\n", pluginName, err)
 			failed++
 			continue
@@ -1187,7 +1208,7 @@ func (m *Manager) InstallAll(ctx *cli.Context, enablePre bool) error {
 
 		cli.Printf(ctx.Stdout(), "Installing %s...\n", pluginName)
 
-		if err := m.installPlugin(ctx, &plugin, "", enablePre); err != nil {
+		if err := m.installPlugin(ctx, &plugin, "", enablePre, false); err != nil {
 			cli.Printf(ctx.Stdout(), "Failed to install %s: %v\n", pluginName, err)
 			failed++
 			continue

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -99,6 +99,19 @@ func NewManager() (*Manager, error) {
 	return &Manager{rootDir: rootDir, sourceBase: base}, nil
 }
 
+func (m *Manager) ApplySourceBaseOverride(raw string) error {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return fmt.Errorf("source-base must not be empty")
+	}
+	lower := strings.ToLower(v)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return fmt.Errorf("source-base must start with http:// or https://")
+	}
+	m.sourceBase = strings.TrimRight(v, "/")
+	return nil
+}
+
 func (m *Manager) resolvedPkgIndexURL() string {
 	if m.indexURL != "" {
 		return m.indexURL

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -296,9 +296,6 @@ func matchPluginName(pluginName, userInput string) bool {
 	return false
 }
 
-// FindInstalledPluginInManifest finds an installed plugin when user input
-// matches the plugin package name or the short form (user input equals the package name with the "aliyun-cli-" prefix removed, e.g. fc -> aliyun-cli-fc).
-// Used for plugins installed from a local path or package URL (--package) that are not listed in the remote plugin index.
 func FindInstalledPluginInManifest(manifest *LocalManifest, userInput string) (pluginName string, lp *LocalPlugin, ok bool) {
 	if manifest == nil || manifest.Plugins == nil {
 		return "", nil, false

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -32,8 +32,9 @@ const (
 
 	indexCacheFile   = "plugin_pkg_index_cache.json"
 	commandCacheFile = "plugin_search_index_cache.json"
-	cacheTTL         = 1 * time.Hour
-	fetchTimeout     = 10 * time.Second
+	cacheTTL               = 1 * time.Hour
+	fetchTimeout           = 10 * time.Second
+	pluginArchiveDLTimeout = 15 * time.Minute
 )
 
 type ErrPluginNotFound struct {
@@ -289,7 +290,7 @@ func matchPluginName(pluginName, userInput string) bool {
 
 // FindInstalledPluginInManifest finds an installed plugin when user input
 // matches the plugin package name or the short form (user input equals the package name with the "aliyun-cli-" prefix removed, e.g. fc -> aliyun-cli-fc).
-// Used for plugins installed from a local archive (--source) that are not listed in the remote plugin index.
+// Used for plugins installed from a local path or package URL (--package) that are not listed in the remote plugin index.
 func FindInstalledPluginInManifest(manifest *LocalManifest, userInput string) (pluginName string, lp *LocalPlugin, ok bool) {
 	if manifest == nil || manifest.Plugins == nil {
 		return "", nil, false
@@ -713,6 +714,19 @@ func isPluginArchivePath(absPath string) bool {
 		strings.HasSuffix(lower, ".tgz")
 }
 
+func isRemotePluginPackageRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	lower := strings.ToLower(ref)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return false
+	}
+	u, err := url.Parse(ref)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return isPluginArchivePath(u.Path)
+}
+
 func readPluginManifestFromDir(extractDir string) (*PluginManifest, error) {
 	pluginManifestPath := filepath.Join(extractDir, "manifest.json")
 	pluginManifestFile, err := os.Open(pluginManifestPath)
@@ -775,7 +789,24 @@ func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (string,
 	return finalDir, nil
 }
 
-// InstallFromLocalFile installs a plugin from a local .zip or .tar.gz package (used by `plugin install --source`).
+// InstallFromPackage installs a plugin from a local package path or from an http(s) URL to a .zip / .tar.gz / .tgz file.
+// version, if non-empty, must equal the version declared in manifest.json.
+func (m *Manager) InstallFromPackage(ctx *cli.Context, ref, version string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fmt.Errorf("package path or URL is empty")
+	}
+	lower := strings.ToLower(ref)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		if !isRemotePluginPackageRef(ref) {
+			return fmt.Errorf("package URL path must end with .zip, .tar.gz, or .tgz")
+		}
+		return m.installFromRemotePackageURL(ctx, ref, version)
+	}
+	return m.InstallFromLocalFile(ctx, ref, version)
+}
+
+// InstallFromLocalFile installs a plugin from a local .zip or .tar.gz package (used by `plugin install --package`).
 // version, if non-empty, must equal the version declared in manifest.json.
 func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath, version string) error {
 	absPath, err := expandPluginSourcePath(sourcePath)
@@ -784,16 +815,71 @@ func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath, version str
 	}
 	st, err := os.Stat(absPath)
 	if err != nil {
-		return fmt.Errorf("source file: %w", err)
+		return fmt.Errorf("package file: %w", err)
 	}
 	if st.IsDir() {
-		return fmt.Errorf("source must be a plugin archive file (.zip, .tar.gz, .tgz), not a directory")
+		return fmt.Errorf("package must be a plugin archive file (.zip, .tar.gz, .tgz), not a directory")
 	}
-	if !isPluginArchivePath(absPath) {
-		return fmt.Errorf("unsupported archive format (use .zip, .tar.gz, or .tgz): %s", absPath)
+	return m.installFromPackageFile(ctx, absPath, version, absPath)
+}
+
+func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL, version string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid package URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("package URL must use http or https")
+	}
+	if !isPluginArchivePath(u.Path) {
+		return fmt.Errorf("package URL path must end with .zip, .tar.gz, or .tgz")
 	}
 
-	cli.Printf(ctx.Stdout(), "Installing plugin from %s...\n", absPath)
+	cli.Printf(ctx.Stdout(), "Downloading plugin package from %s...\n", rawURL)
+
+	client := &http.Client{Timeout: pluginArchiveDLTimeout}
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		return fmt.Errorf("download plugin package: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download plugin package: status %d", resp.StatusCode)
+	}
+
+	tmpParent, err := os.MkdirTemp("", "aliyun-plugin-dl-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpParent)
+
+	base := path.Base(u.Path)
+	if base == "." || base == "/" {
+		base = "plugin.tgz"
+	}
+	dest := filepath.Join(tmpParent, base)
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create temp package file: %w", err)
+	}
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		out.Close()
+		return fmt.Errorf("write plugin package: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("write plugin package: %w", err)
+	}
+
+	return m.installFromPackageFile(ctx, dest, version, rawURL)
+}
+
+// installFromPackageFile extracts and installs from a local filesystem path; userFacing is shown in logs (path or URL).
+func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, version, userFacing string) error {
+	if !isPluginArchivePath(absPath) {
+		return fmt.Errorf("unsupported package format (use .zip, .tar.gz, or .tgz): %s", absPath)
+	}
+
+	cli.Printf(ctx.Stdout(), "Installing plugin from %s...\n", userFacing)
 
 	tmpParent, err := os.MkdirTemp("", "aliyun-plugin-local-*")
 	if err != nil {

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -30,11 +30,11 @@ const (
 	EnvPluginsDir   = "ALIBABA_CLOUD_CLI_PLUGINS_DIR"
 	EnvNoCache      = "ALIBABA_CLOUD_CLI_PLUGIN_NO_CACHE"
 
-	indexCacheFile   = "plugin_pkg_index_cache.json"
-	commandCacheFile = "plugin_search_index_cache.json"
+	indexCacheFile         = "plugin_pkg_index_cache.json"
+	commandCacheFile       = "plugin_search_index_cache.json"
 	cacheTTL               = 1 * time.Hour
 	fetchTimeout           = 10 * time.Second
-	pluginArchiveDLTimeout = 15 * time.Minute
+	pluginArchiveDLTimeout = 5 * time.Minute
 )
 
 type ErrPluginNotFound struct {
@@ -789,8 +789,6 @@ func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (string,
 	return finalDir, nil
 }
 
-// InstallFromPackage installs a plugin from a local package path or from an http(s) URL to a .zip / .tar.gz / .tgz file.
-// version, if non-empty, must equal the version declared in manifest.json.
 func (m *Manager) InstallFromPackage(ctx *cli.Context, ref, version string) error {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
@@ -806,8 +804,6 @@ func (m *Manager) InstallFromPackage(ctx *cli.Context, ref, version string) erro
 	return m.InstallFromLocalFile(ctx, ref, version)
 }
 
-// InstallFromLocalFile installs a plugin from a local .zip or .tar.gz package (used by `plugin install --package`).
-// version, if non-empty, must equal the version declared in manifest.json.
 func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath, version string) error {
 	absPath, err := expandPluginSourcePath(sourcePath)
 	if err != nil {
@@ -873,7 +869,6 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL, version 
 	return m.installFromPackageFile(ctx, dest, version, rawURL)
 }
 
-// installFromPackageFile extracts and installs from a local filesystem path; userFacing is shown in logs (path or URL).
 func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, version, userFacing string) error {
 	if !isPluginArchivePath(absPath) {
 		return fmt.Errorf("unsupported package format (use .zip, .tar.gz, or .tgz): %s", absPath)

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -654,10 +654,150 @@ func (m *Manager) extractPlugin(archivePath, extractDir, downloadURL string) err
 		return err
 	}
 
-	if strings.HasSuffix(downloadURL, ".zip") {
+	if strings.HasSuffix(strings.ToLower(downloadURL), ".zip") {
 		return unzip(archivePath, extractDir)
 	}
 	return untar(archivePath, extractDir)
+}
+
+func expandPluginSourcePath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("source path is empty")
+	}
+	if strings.HasPrefix(raw, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		raw = filepath.Join(home, raw[2:])
+	}
+	abs, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve source path: %w", err)
+	}
+	return abs, nil
+}
+
+func isPluginArchivePath(absPath string) bool {
+	lower := strings.ToLower(absPath)
+	return strings.HasSuffix(lower, ".zip") ||
+		strings.HasSuffix(lower, ".tar.gz") ||
+		strings.HasSuffix(lower, ".tgz")
+}
+
+func readPluginManifestFromDir(extractDir string) (*PluginManifest, error) {
+	pluginManifestPath := filepath.Join(extractDir, "manifest.json")
+	pluginManifestFile, err := os.Open(pluginManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid plugin package: manifest.json not found")
+	}
+	defer pluginManifestFile.Close()
+
+	var pManifest PluginManifest
+	if err := json.NewDecoder(pluginManifestFile).Decode(&pManifest); err != nil {
+		return nil, fmt.Errorf("invalid plugin manifest: %w", err)
+	}
+	if strings.TrimSpace(pManifest.Name) == "" {
+		return nil, fmt.Errorf("invalid plugin manifest: name is empty")
+	}
+	if strings.TrimSpace(pManifest.Version) == "" {
+		return nil, fmt.Errorf("invalid plugin manifest: version is empty")
+	}
+	return &pManifest, nil
+}
+
+func copyDirTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode().Perm())
+	})
+}
+
+func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (string, error) {
+	finalDir := filepath.Join(m.rootDir, pluginName)
+	if err := os.RemoveAll(finalDir); err != nil {
+		return "", fmt.Errorf("failed to remove existing plugin directory: %w", err)
+	}
+	if err := os.Rename(tmpExtract, finalDir); err == nil {
+		return finalDir, nil
+	}
+	if err := copyDirTree(tmpExtract, finalDir); err != nil {
+		return "", fmt.Errorf("failed to copy plugin files: %w", err)
+	}
+	if err := os.RemoveAll(tmpExtract); err != nil {
+		return "", fmt.Errorf("failed to remove temporary extract directory: %w", err)
+	}
+	return finalDir, nil
+}
+
+// InstallFromLocalFile installs a plugin from a local .zip or .tar.gz package (used by `plugin install --source`).
+// version, if non-empty, must equal the version declared in manifest.json.
+func (m *Manager) InstallFromLocalFile(ctx *cli.Context, sourcePath, version string) error {
+	absPath, err := expandPluginSourcePath(sourcePath)
+	if err != nil {
+		return err
+	}
+	st, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("source file: %w", err)
+	}
+	if st.IsDir() {
+		return fmt.Errorf("source must be a plugin archive file (.zip, .tar.gz, .tgz), not a directory")
+	}
+	if !isPluginArchivePath(absPath) {
+		return fmt.Errorf("unsupported archive format (use .zip, .tar.gz, or .tgz): %s", absPath)
+	}
+
+	cli.Printf(ctx.Stdout(), "Installing plugin from %s...\n", absPath)
+
+	tmpParent, err := os.MkdirTemp("", "aliyun-plugin-local-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpParent)
+
+	tmpExtract := filepath.Join(tmpParent, "extract")
+	if err := m.extractPlugin(absPath, tmpExtract, absPath); err != nil {
+		return fmt.Errorf("failed to extract plugin package: %w", err)
+	}
+
+	pManifest, err := readPluginManifestFromDir(tmpExtract)
+	if err != nil {
+		return err
+	}
+	if version != "" && version != pManifest.Version {
+		return fmt.Errorf("specified version %q does not match package manifest version %q", version, pManifest.Version)
+	}
+
+	finalDir, err := m.promoteExtractedPlugin(tmpExtract, pManifest.Name)
+	if err != nil {
+		return err
+	}
+
+	if err := m.savePluginToManifest(pManifest.Name, pManifest.Version, finalDir, pManifest); err != nil {
+		return err
+	}
+
+	cli.Printf(ctx.Stdout(), "Plugin %s %s installed successfully!\n", pManifest.Name, pManifest.Version)
+	return nil
 }
 
 func (m *Manager) loadAndValidatePluginManifest(extractDir, expectedName string) (*PluginManifest, error) {
@@ -690,10 +830,12 @@ func (m *Manager) savePluginToManifest(actualPluginName, version, extractDir str
 		Name:             actualPluginName,
 		Version:          version,
 		Path:             extractDir,
+		ProductCode:      pManifest.ProductCode,
 		Command:          pManifest.Command,
 		ShortDescription: pManifest.ShortDescription,
 		Description:      pManifest.Description,
 		CmdNames:         pManifest.CmdNames,
+		Inner:            pManifest.Inner,
 	}
 
 	return m.saveLocalManifest(localManifest)

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -50,6 +50,8 @@ type Manager struct {
 	sourceBase      string // from plugin-settings.json / env; empty = use built-in index URLs
 	indexURL        string // For testing: allows overriding resolved package index URL
 	commandIndexURL string // For testing: allows overriding resolved command index URL
+	// skipPluginIndexCacheForCLI is set when --source-base is used on this command only.
+	skipPluginIndexCacheForCLI bool
 }
 
 func getHomePath() string {
@@ -110,6 +112,7 @@ func (m *Manager) ApplySourceBaseOverride(raw string) error {
 		return fmt.Errorf("source-base must start with http:// or https://")
 	}
 	m.sourceBase = strings.TrimRight(v, "/")
+	m.skipPluginIndexCacheForCLI = true
 	return nil
 }
 
@@ -190,8 +193,13 @@ func noCacheEnabled() bool {
 	return v == "true" || v == "1"
 }
 
+// CLI override avoids stale cross-mirror cache files.
+func (m *Manager) skipPluginIndexCache() bool {
+	return m.skipPluginIndexCacheForCLI
+}
+
 func (m *Manager) fetchWithCache(url, cacheFile string, result interface{}) error {
-	if noCacheEnabled() {
+	if noCacheEnabled() || m.skipPluginIndexCache() {
 		data, err := m.fetchRemote(url)
 		if err != nil {
 			return err

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -274,6 +274,22 @@ func matchPluginName(pluginName, userInput string) bool {
 	return false
 }
 
+// FindInstalledPluginInManifest finds an installed plugin when user input
+// matches the plugin package name or the short form (user input equals the package name with the "aliyun-cli-" prefix removed, e.g. fc -> aliyun-cli-fc).
+// Used for plugins installed from a local archive (--source) that are not listed in the remote plugin index.
+func FindInstalledPluginInManifest(manifest *LocalManifest, userInput string) (pluginName string, lp *LocalPlugin, ok bool) {
+	if manifest == nil || manifest.Plugins == nil {
+		return "", nil, false
+	}
+	for name, p := range manifest.Plugins {
+		if matchPluginName(name, userInput) {
+			pl := p
+			return name, &pl, true
+		}
+	}
+	return "", nil, false
+}
+
 func isDevVersion(version string) bool {
 	if strings.HasPrefix(version, "0.0.") || version == "0.0.1" {
 		return true
@@ -353,10 +369,8 @@ func (m *Manager) findLocalPlugin(userInput string) (string, *LocalPlugin, error
 		return "", nil, fmt.Errorf("failed to read local plugin manifest: %w", err)
 	}
 
-	for pluginName, plugin := range localManifest.Plugins {
-		if matchPluginName(pluginName, userInput) {
-			return pluginName, &plugin, nil
-		}
+	if name, lp, ok := FindInstalledPluginInManifest(localManifest, userInput); ok {
+		return name, lp, nil
 	}
 
 	return "", nil, &ErrPluginNotFound{PluginName: userInput}

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -184,3 +184,22 @@ func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
 	assert.Equal(t, "1.2.3", p.Version)
 	assert.Contains(t, stdout.String(), "Installing plugin from")
 }
+
+func TestFindInstalledPluginInManifest(t *testing.T) {
+	m := &LocalManifest{Plugins: map[string]LocalPlugin{
+		"aliyun-cli-x": {Name: "aliyun-cli-x"},
+	}}
+	n, lp, ok := FindInstalledPluginInManifest(m, "aliyun-cli-x")
+	require.True(t, ok)
+	assert.Equal(t, "aliyun-cli-x", n)
+	assert.Equal(t, "aliyun-cli-x", lp.Name)
+
+	n, _, ok = FindInstalledPluginInManifest(m, "x")
+	require.True(t, ok)
+	assert.Equal(t, "aliyun-cli-x", n)
+
+	_, _, ok = FindInstalledPluginInManifest(m, "nosuch")
+	assert.False(t, ok)
+	_, _, ok = FindInstalledPluginInManifest(nil, "x")
+	assert.False(t, ok)
+}

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,7 +122,7 @@ func TestManager_InstallFromLocalFile(t *testing.T) {
 		ctx := newTestContext()
 		err := mgr.InstallFromLocalFile(ctx, badPath, "")
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported archive format")
+		assert.Contains(t, err.Error(), "unsupported package format")
 	})
 }
 
@@ -141,25 +143,25 @@ func TestNewInstallCommand_Run_NamesAndSourceConflict(t *testing.T) {
 	namesFlag.SetAssigned(true)
 	namesFlag.SetValues([]string{"some-plugin"})
 
-	sourceFlag := ctx.Flags().Get("source")
-	assert.NotNil(t, sourceFlag)
-	sourceFlag.SetAssigned(true)
-	sourceFlag.SetValue("/tmp/x.zip")
+	pkgFlag := ctx.Flags().Get("package")
+	assert.NotNil(t, pkgFlag)
+	pkgFlag.SetAssigned(true)
+	pkgFlag.SetValue("/tmp/x.zip")
 
 	err := cmd.Run(ctx, []string{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "--names cannot be used together with --source")
+	assert.Contains(t, err.Error(), "--names cannot be used together with --package")
 }
 
-func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
+func TestNewInstallCommand_Run_WithPackageFlagSuccess(t *testing.T) {
 	cmd := newInstallCommand()
 
 	testHome := t.TempDir()
 	cleanup := setTestHomeDir(t, testHome)
 	defer cleanup()
 
-	archiveBody := createTestPluginArchive(t, "cli-local-cmd-test", "1.2.3", "x")
-	archivePath := filepath.Join(t.TempDir(), "plugin-local-cmd.tar.gz")
+	archiveBody := createTestPluginArchive(t, "cli-package-flag-test", "4.5.6", "x")
+	archivePath := filepath.Join(t.TempDir(), "plugin-package-cmd.tar.gz")
 	assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
 
 	stdout := new(bytes.Buffer)
@@ -167,10 +169,10 @@ func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
 	ctx := cli.NewCommandContext(stdout, stderr)
 	ctx.EnterCommand(cmd)
 
-	sourceFlag := ctx.Flags().Get("source")
-	assert.NotNil(t, sourceFlag)
-	sourceFlag.SetAssigned(true)
-	sourceFlag.SetValue(archivePath)
+	pkgFlag := ctx.Flags().Get("package")
+	assert.NotNil(t, pkgFlag)
+	pkgFlag.SetAssigned(true)
+	pkgFlag.SetValue(archivePath)
 
 	err := cmd.Run(ctx, []string{})
 	assert.NoError(t, err)
@@ -179,10 +181,44 @@ func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	manifest, err := mgr.GetLocalManifest()
 	assert.NoError(t, err)
-	p, ok := manifest.Plugins["cli-local-cmd-test"]
+	p, ok := manifest.Plugins["cli-package-flag-test"]
 	assert.True(t, ok)
-	assert.Equal(t, "1.2.3", p.Version)
+	assert.Equal(t, "4.5.6", p.Version)
 	assert.Contains(t, stdout.String(), "Installing plugin from")
+}
+
+func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
+	pluginRoot := t.TempDir()
+	mgr := &Manager{rootDir: pluginRoot}
+	archiveBody := createTestPluginArchive(t, "remote-url-plugin", "7.8.9", "x")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(archiveBody)
+	}))
+	defer srv.Close()
+	archiveURL := srv.URL + "/pkgs/remote-url-plugin/7.8.9/plugin.tgz"
+
+	ctx := newTestContext()
+	err := mgr.InstallFromPackage(ctx, archiveURL, "")
+	require.NoError(t, err)
+
+	manifest, err := mgr.GetLocalManifest()
+	require.NoError(t, err)
+	p, ok := manifest.Plugins["remote-url-plugin"]
+	require.True(t, ok)
+	assert.Equal(t, "7.8.9", p.Version)
+	out := ctx.Stdout().(*bytes.Buffer).String()
+	assert.Contains(t, out, "Downloading plugin package from")
+	assert.Contains(t, out, "Installing plugin from")
+}
+
+func TestManager_InstallFromPackage_RemoteURLBadSuffix(t *testing.T) {
+	mgr := &Manager{rootDir: t.TempDir()}
+	ctx := newTestContext()
+	err := mgr.InstallFromPackage(ctx, "https://example.com/plugins/nosuffix", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "package URL path must end")
 }
 
 func TestFindInstalledPluginInManifest(t *testing.T) {

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -1,0 +1,186 @@
+package plugin
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyDirTree(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "nested"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "nested", "b.txt"), []byte("beta"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("alpha"), 0644))
+
+	require.NoError(t, copyDirTree(src, dst))
+
+	b, err := os.ReadFile(filepath.Join(dst, "nested", "b.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "beta", string(b))
+	a, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", string(a))
+}
+
+func TestCopyDirTree_emptyTree(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "empty-out")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "child"), 0755))
+
+	require.NoError(t, copyDirTree(src, dst))
+
+	st, err := os.Stat(filepath.Join(dst, "child"))
+	require.NoError(t, err)
+	assert.True(t, st.IsDir())
+}
+
+func TestCopyDirTree_preservesFilePerm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits differ on Windows")
+	}
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "perm-out")
+	p := filepath.Join(src, "secret")
+	require.NoError(t, os.WriteFile(p, []byte("x"), 0600))
+
+	require.NoError(t, copyDirTree(src, dst))
+
+	st, err := os.Stat(filepath.Join(dst, "secret"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), st.Mode().Perm())
+}
+
+func TestPromoteExtractedPlugin_rename(t *testing.T) {
+	root := t.TempDir()
+	tmpExtract := filepath.Join(root, "_extract_me")
+	require.NoError(t, os.MkdirAll(tmpExtract, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpExtract, "manifest.json"), []byte("{}"), 0644))
+
+	mgr := &Manager{rootDir: root}
+	finalDir, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
+	require.NoError(t, err)
+
+	want := filepath.Join(root, "myplugin")
+	assert.Equal(t, want, finalDir)
+	_, err = os.Stat(filepath.Join(want, "manifest.json"))
+	require.NoError(t, err)
+	_, err = os.Stat(tmpExtract)
+	assert.True(t, os.IsNotExist(err), "temp extract dir should be gone after rename")
+}
+
+func TestManager_InstallFromLocalFile(t *testing.T) {
+	t.Run("Success from tar.gz", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+
+		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
+		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
+		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+		ctx := newTestContext()
+		err := mgr.InstallFromLocalFile(ctx, archivePath, "")
+		assert.NoError(t, err)
+
+		manifest, err := mgr.GetLocalManifest()
+		assert.NoError(t, err)
+		p, ok := manifest.Plugins["local-test-plugin"]
+		assert.True(t, ok)
+		assert.Equal(t, "2.1.0", p.Version)
+		assert.Contains(t, ctx.Stdout().(*bytes.Buffer).String(), "Installing plugin from")
+	})
+
+	t.Run("Version flag must match manifest", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+
+		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
+		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
+		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+		ctx := newTestContext()
+		err := mgr.InstallFromLocalFile(ctx, archivePath, "9.9.9")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match package manifest version")
+	})
+
+	t.Run("Unsupported extension", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+		badPath := filepath.Join(t.TempDir(), "plugin.txt")
+		assert.NoError(t, os.WriteFile(badPath, []byte("x"), 0644))
+
+		ctx := newTestContext()
+		err := mgr.InstallFromLocalFile(ctx, badPath, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported archive format")
+	})
+}
+
+func TestNewInstallCommand_Run_NamesAndSourceConflict(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	namesFlag := ctx.Flags().Get("names")
+	assert.NotNil(t, namesFlag)
+	namesFlag.SetAssigned(true)
+	namesFlag.SetValues([]string{"some-plugin"})
+
+	sourceFlag := ctx.Flags().Get("source")
+	assert.NotNil(t, sourceFlag)
+	sourceFlag.SetAssigned(true)
+	sourceFlag.SetValue("/tmp/x.zip")
+
+	err := cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--names cannot be used together with --source")
+}
+
+func TestNewInstallCommand_Run_WithSourceFlagSuccess(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	archiveBody := createTestPluginArchive(t, "cli-local-cmd-test", "1.2.3", "x")
+	archivePath := filepath.Join(t.TempDir(), "plugin-local-cmd.tar.gz")
+	assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	sourceFlag := ctx.Flags().Get("source")
+	assert.NotNil(t, sourceFlag)
+	sourceFlag.SetAssigned(true)
+	sourceFlag.SetValue(archivePath)
+
+	err := cmd.Run(ctx, []string{})
+	assert.NoError(t, err)
+
+	mgr, err := NewManager()
+	assert.NoError(t, err)
+	manifest, err := mgr.GetLocalManifest()
+	assert.NoError(t, err)
+	p, ok := manifest.Plugins["cli-local-cmd-test"]
+	assert.True(t, ok)
+	assert.Equal(t, "1.2.3", p.Version)
+	assert.Contains(t, stdout.String(), "Installing plugin from")
+}

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -203,3 +203,39 @@ func TestFindInstalledPluginInManifest(t *testing.T) {
 	_, _, ok = FindInstalledPluginInManifest(nil, "x")
 	assert.False(t, ok)
 }
+
+func TestExpandPluginSourcePath(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		_, err := expandPluginSourcePath("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+	t.Run("whitespace_only", func(t *testing.T) {
+		_, err := expandPluginSourcePath("   \t  ")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+	t.Run("tilde_prefix", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+
+		wantFile := filepath.Join(testHome, "my-plugin.tgz")
+		require.NoError(t, os.WriteFile(wantFile, []byte("x"), 0644))
+
+		got, err := expandPluginSourcePath("~/my-plugin.tgz")
+		require.NoError(t, err)
+		want, err := filepath.Abs(wantFile)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+	t.Run("trim_then_abs", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "a.zip")
+		require.NoError(t, os.WriteFile(p, []byte("z"), 0644))
+		want, err := filepath.Abs(p)
+		require.NoError(t, err)
+		got, err := expandPluginSourcePath("  " + p + "  ")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+}

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -90,7 +90,7 @@ func TestManager_InstallFromLocalFile(t *testing.T) {
 		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
 
 		ctx := newTestContext()
-		err := mgr.InstallFromLocalFile(ctx, archivePath, "")
+		err := mgr.InstallFromLocalFile(ctx, archivePath)
 		assert.NoError(t, err)
 
 		manifest, err := mgr.GetLocalManifest()
@@ -101,20 +101,6 @@ func TestManager_InstallFromLocalFile(t *testing.T) {
 		assert.Contains(t, ctx.Stdout().(*bytes.Buffer).String(), "Installing plugin from")
 	})
 
-	t.Run("Version flag must match manifest", func(t *testing.T) {
-		pluginRoot := t.TempDir()
-		mgr := &Manager{rootDir: pluginRoot}
-
-		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
-		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
-		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
-
-		ctx := newTestContext()
-		err := mgr.InstallFromLocalFile(ctx, archivePath, "9.9.9")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "does not match package manifest version")
-	})
-
 	t.Run("Unsupported extension", func(t *testing.T) {
 		pluginRoot := t.TempDir()
 		mgr := &Manager{rootDir: pluginRoot}
@@ -122,9 +108,29 @@ func TestManager_InstallFromLocalFile(t *testing.T) {
 		assert.NoError(t, os.WriteFile(badPath, []byte("x"), 0644))
 
 		ctx := newTestContext()
-		err := mgr.InstallFromLocalFile(ctx, badPath, "")
+		err := mgr.InstallFromLocalFile(ctx, badPath)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported package format")
+	})
+
+	t.Run("Overwrite prints note when same plugin name exists", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+		ctx := newTestContext()
+
+		v1 := createTestPluginArchive(t, "overwrite-test", "1.0.0", "x")
+		p1 := filepath.Join(t.TempDir(), "overwrite-a.tgz")
+		require.NoError(t, os.WriteFile(p1, v1, 0644))
+		require.NoError(t, mgr.InstallFromLocalFile(ctx, p1))
+
+		v2 := createTestPluginArchive(t, "overwrite-test", "2.0.0", "x")
+		p2 := filepath.Join(t.TempDir(), "overwrite-b.tgz")
+		require.NoError(t, os.WriteFile(p2, v2, 0644))
+		require.NoError(t, mgr.InstallFromLocalFile(ctx, p2))
+
+		out := ctx.Stdout().(*bytes.Buffer).String()
+		assert.Contains(t, out, `plugin "overwrite-test" is already installed`)
+		assert.Contains(t, out, "continuing will replace it with version 2.0.0")
 	})
 }
 
@@ -202,7 +208,7 @@ func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
 	archiveURL := srv.URL + "/pkgs/remote-url-plugin/7.8.9/plugin.tgz"
 
 	ctx := newTestContext()
-	err := mgr.InstallFromPackage(ctx, archiveURL, "")
+	err := mgr.InstallFromPackage(ctx, archiveURL)
 	require.NoError(t, err)
 
 	manifest, err := mgr.GetLocalManifest()
@@ -218,7 +224,7 @@ func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
 func TestManager_InstallFromPackage_RemoteURLBadSuffix(t *testing.T) {
 	mgr := &Manager{rootDir: t.TempDir()}
 	ctx := newTestContext()
-	err := mgr.InstallFromPackage(ctx, "https://example.com/plugins/nosuffix", "")
+	err := mgr.InstallFromPackage(ctx, "https://example.com/plugins/nosuffix")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "package URL path must end")
 }
@@ -227,11 +233,11 @@ func TestManager_installFromRemotePackageURL_invalidSchemeAndPath(t *testing.T) 
 	mgr := &Manager{rootDir: t.TempDir()}
 	ctx := newTestContext()
 
-	err := mgr.installFromRemotePackageURL(ctx, "ftp://example.com/pkg.tgz", "")
+	err := mgr.installFromRemotePackageURL(ctx, "ftp://example.com/pkg.tgz")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "package URL must use http or https")
 
-	err = mgr.installFromRemotePackageURL(ctx, "https://example.com/not-an-archive", "")
+	err = mgr.installFromRemotePackageURL(ctx, "https://example.com/not-an-archive")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "package URL path must end with .zip, .tar.gz, or .tgz")
 }
@@ -246,7 +252,7 @@ func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
 		}))
 		base := srv.URL
 		srv.Close()
-		err := mgr.installFromRemotePackageURL(ctx, base+"/plugin.tgz", "")
+		err := mgr.installFromRemotePackageURL(ctx, base+"/plugin.tgz")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "download plugin package:")
 	})
@@ -256,7 +262,7 @@ func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
 			http.NotFound(w, r)
 		}))
 		defer srv.Close()
-		err := mgr.installFromRemotePackageURL(ctx, srv.URL+"/missing.tgz", "")
+		err := mgr.installFromRemotePackageURL(ctx, srv.URL+"/missing.tgz")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "download plugin package: status 404")
 	})
@@ -278,7 +284,7 @@ func TestInstallFromPackageFile_saveLocalManifestFails(t *testing.T) {
 	require.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
 
 	ctx := newTestContext()
-	err := mgr.installFromPackageFile(ctx, archivePath, "", archivePath)
+	err := mgr.installFromPackageFile(ctx, archivePath, archivePath)
 	require.Error(t, err)
 	lowered := strings.ToLower(err.Error())
 	require.True(t,

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -221,6 +222,19 @@ func TestManager_InstallFromPackage_RemoteURLBadSuffix(t *testing.T) {
 	assert.Contains(t, err.Error(), "package URL path must end")
 }
 
+func TestManager_installFromRemotePackageURL_invalidSchemeAndPath(t *testing.T) {
+	mgr := &Manager{rootDir: t.TempDir()}
+	ctx := newTestContext()
+
+	err := mgr.installFromRemotePackageURL(ctx, "ftp://example.com/pkg.tgz", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "package URL must use http or https")
+
+	err = mgr.installFromRemotePackageURL(ctx, "https://example.com/not-an-archive", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "package URL path must end with .zip, .tar.gz, or .tgz")
+}
+
 func TestFindInstalledPluginInManifest(t *testing.T) {
 	m := &LocalManifest{Plugins: map[string]LocalPlugin{
 		"aliyun-cli-x": {Name: "aliyun-cli-x"},
@@ -238,6 +252,85 @@ func TestFindInstalledPluginInManifest(t *testing.T) {
 	assert.False(t, ok)
 	_, _, ok = FindInstalledPluginInManifest(nil, "x")
 	assert.False(t, ok)
+}
+
+func TestIsRemotePluginPackageRef(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"/local/path/plugin.tgz", false},
+		{"file:///tmp/a.tgz", false},
+		{"ftp://example.com/a.tgz", false},
+		{"https://example.com/pkgs/foo.tgz", true},
+		{"HTTP://EXAMPLE.COM/X.ZIP", true},
+		{"https://example.com/nosuffix", false},
+		{"https://example.com/foo.tar.gz", true},
+		{"  https://mirror.example/x.tgz  ", true},
+		{"https:///x.tgz", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%q", tc.ref), func(t *testing.T) {
+			assert.Equal(t, tc.want, isRemotePluginPackageRef(tc.ref), "ref=%q", tc.ref)
+		})
+	}
+}
+
+func TestReadPluginManifestFromDir(t *testing.T) {
+	t.Run("missing manifest", func(t *testing.T) {
+		d := t.TempDir()
+		_, err := readPluginManifestFromDir(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid plugin package: manifest.json not found")
+	})
+	t.Run("invalid json", func(t *testing.T) {
+		d := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(d, "manifest.json"), []byte("{"), 0644))
+		_, err := readPluginManifestFromDir(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid plugin manifest")
+	})
+	t.Run("empty name", func(t *testing.T) {
+		d := t.TempDir()
+		raw := `{"name":"  \t  ","version":"1.0.0"}`
+		require.NoError(t, os.WriteFile(filepath.Join(d, "manifest.json"), []byte(raw), 0644))
+		_, err := readPluginManifestFromDir(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid plugin manifest: name is empty")
+	})
+	t.Run("empty version", func(t *testing.T) {
+		d := t.TempDir()
+		raw := `{"name":"aliyun-cli-test","version":"  "}`
+		require.NoError(t, os.WriteFile(filepath.Join(d, "manifest.json"), []byte(raw), 0644))
+		_, err := readPluginManifestFromDir(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid plugin manifest: version is empty")
+	})
+	t.Run("missing name field", func(t *testing.T) {
+		d := t.TempDir()
+		raw := `{"version":"1.0.0"}`
+		require.NoError(t, os.WriteFile(filepath.Join(d, "manifest.json"), []byte(raw), 0644))
+		_, err := readPluginManifestFromDir(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid plugin manifest: name is empty")
+	})
+	t.Run("missing version field", func(t *testing.T) {
+		d := t.TempDir()
+		raw := `{"name":"aliyun-cli-test"}`
+		require.NoError(t, os.WriteFile(filepath.Join(d, "manifest.json"), []byte(raw), 0644))
+		_, err := readPluginManifestFromDir(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid plugin manifest: version is empty")
+	})
+	t.Run("success", func(t *testing.T) {
+		d := t.TempDir()
+		raw := `{"name":"aliyun-cli-test","version":"1.0.0","command":"test"}`
+		require.NoError(t, os.WriteFile(filepath.Join(d, "manifest.json"), []byte(raw), 0644))
+		pm, err := readPluginManifestFromDir(d)
+		require.NoError(t, err)
+		assert.Equal(t, "aliyun-cli-test", pm.Name)
+		assert.Equal(t, "1.0.0", pm.Version)
+	})
 }
 
 func TestExpandPluginSourcePath(t *testing.T) {

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -233,6 +234,58 @@ func TestManager_installFromRemotePackageURL_invalidSchemeAndPath(t *testing.T) 
 	err = mgr.installFromRemotePackageURL(ctx, "https://example.com/not-an-archive", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "package URL path must end with .zip, .tar.gz, or .tgz")
+}
+
+func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
+	mgr := &Manager{rootDir: t.TempDir()}
+	ctx := newTestContext()
+
+	t.Run("http get fails", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		}))
+		base := srv.URL
+		srv.Close()
+		err := mgr.installFromRemotePackageURL(ctx, base+"/plugin.tgz", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "download plugin package:")
+	})
+
+	t.Run("non-OK status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer srv.Close()
+		err := mgr.installFromRemotePackageURL(ctx, srv.URL+"/missing.tgz", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "download plugin package: status 404")
+	})
+}
+
+func TestInstallFromPackageFile_saveLocalManifestFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only manifest.json via chmod is not reliable on Windows")
+	}
+	root := t.TempDir()
+	mani := filepath.Join(root, "manifest.json")
+	require.NoError(t, os.WriteFile(mani, []byte(`{"plugins":{}}`), 0644))
+	require.NoError(t, os.Chmod(mani, 0444))
+	defer func() { _ = os.Chmod(mani, 0644) }()
+
+	mgr := &Manager{rootDir: root}
+	archiveBody := createTestPluginArchive(t, "save-fail-pl", "2.0.0", "x")
+	archivePath := filepath.Join(t.TempDir(), "save-fail.tgz")
+	require.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+	ctx := newTestContext()
+	err := mgr.installFromPackageFile(ctx, archivePath, "", archivePath)
+	require.Error(t, err)
+	lowered := strings.ToLower(err.Error())
+	require.True(t,
+		strings.Contains(lowered, "permission denied") ||
+			strings.Contains(lowered, "operation not permitted"),
+		"unexpected error from saveLocalManifest: %v", err,
+	)
 }
 
 func TestFindInstalledPluginInManifest(t *testing.T) {

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -1882,7 +1882,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err = mgr.installPlugin(ctx, targetPlugin, "1.0.0", false)
+		err = mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true)
 		assert.NoError(t, err)
 
 		localManifest, err := mgr.GetLocalManifest()
@@ -1899,6 +1899,46 @@ func TestManager_installPlugin(t *testing.T) {
 
 		manifestPath := filepath.Join(pluginDir, "manifest.json")
 		assert.FileExists(t, manifestPath)
+	})
+
+	t.Run("Overwrite note when reinstalling indexed plugin", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mgr := &Manager{rootDir: tmpDir}
+
+		archiveContent := createTestPluginArchive(t, "reinstall-note", "1.0.0", "test")
+		expectedChecksum, err := calculateSHA256FromBytes(archiveContent)
+		if err != nil {
+			t.Fatalf("Failed to calculate checksum: %v", err)
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archiveContent)
+		}))
+		defer server.Close()
+
+		platform := GetCurrentPlatform()
+		targetPlugin := &PluginInfo{
+			Name: "reinstall-note",
+			Versions: map[string]VersionInfo{
+				"1.0.0": {
+					Platforms: map[string]PlatformInfo{
+						platform: {
+							URL:      server.URL,
+							Checksum: expectedChecksum,
+						},
+					},
+				},
+			},
+		}
+
+		ctx := newTestContext()
+		assert.NoError(t, mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true))
+		assert.NoError(t, mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true))
+
+		out := ctx.Stdout().(*bytes.Buffer).String()
+		assert.Contains(t, out, `plugin "reinstall-note" is already installed`)
+		assert.Contains(t, out, "continuing will replace it with version 1.0.0")
 	})
 
 	t.Run("Success - install plugin with empty version (use latest)", func(t *testing.T) {
@@ -1933,7 +1973,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err = mgr.installPlugin(ctx, targetPlugin, "", false)
+		err = mgr.installPlugin(ctx, targetPlugin, "", false, true)
 		assert.NoError(t, err)
 
 		localManifest, err := mgr.GetLocalManifest()
@@ -1958,7 +1998,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err := mgr.installPlugin(ctx, targetPlugin, "999.0.0", false)
+		err := mgr.installPlugin(ctx, targetPlugin, "999.0.0", false, true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "version 999.0.0 not found")
 	})
@@ -1983,7 +2023,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err := mgr.installPlugin(ctx, targetPlugin, "1.0.0", false)
+		err := mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "plugin test-plugin version 1.0.0 not supported on "+platform)
 	})
@@ -2008,7 +2048,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err := mgr.installPlugin(ctx, targetPlugin, "1.0.0", false)
+		err := mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid-url-that-does-not-exist.local")
 	})
@@ -2041,7 +2081,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err := mgr.installPlugin(ctx, targetPlugin, "1.0.0", false)
+		err := mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "checksum verification failed")
 		assert.Contains(t, err.Error(), "Expected: wrong-checksum")
@@ -2079,7 +2119,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err = mgr.installPlugin(ctx, targetPlugin, "1.0.0", false)
+		err = mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "manifest.json not found")
 	})
@@ -2116,7 +2156,7 @@ func TestManager_installPlugin(t *testing.T) {
 		}
 
 		ctx := newTestContext()
-		err = mgr.installPlugin(ctx, targetPlugin, "1.0.0", false)
+		err = mgr.installPlugin(ctx, targetPlugin, "1.0.0", false, true)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "plugin manifest name wrong-plugin-name does not match expected name test-plugin")
 	})

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -383,6 +383,51 @@ func TestManager_GetIndex_Cache(t *testing.T) {
 		// Should have hit remote despite fresh cache
 		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
 	})
+
+	t.Run("CLI --source-base via ApplySourceBaseOverride skips index cache", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		var requestCount int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(validJSON)
+		}))
+		defer server.Close()
+
+		mgr := &Manager{rootDir: tmpDir, indexURL: server.URL}
+		assert.NoError(t, mgr.ApplySourceBaseOverride("https://mirror.example/plugins"))
+
+		_, err := mgr.GetIndex()
+		assert.NoError(t, err)
+		_, err = mgr.GetIndex()
+		assert.NoError(t, err)
+		assert.Equal(t, int32(2), atomic.LoadInt32(&requestCount))
+	})
+
+	t.Run("Persistent source base without CLI override still uses index cache", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		var requestCount int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&requestCount, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(validJSON)
+		}))
+		defer server.Close()
+
+		mgr := &Manager{
+			rootDir:    tmpDir,
+			sourceBase: "https://mirror.example/plugins",
+			indexURL:   server.URL,
+		}
+
+		_, err := mgr.GetIndex()
+		assert.NoError(t, err)
+		_, err = mgr.GetIndex()
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
+	})
 }
 
 func TestManager_findPluginInIndex(t *testing.T) {

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -2112,6 +2112,54 @@ func TestManager_installPlugin(t *testing.T) {
 	})
 }
 
+func TestManager_InstallFromLocalFile(t *testing.T) {
+	t.Run("Success from tar.gz", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+
+		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
+		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
+		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+		ctx := newTestContext()
+		err := mgr.InstallFromLocalFile(ctx, archivePath, "")
+		assert.NoError(t, err)
+
+		manifest, err := mgr.GetLocalManifest()
+		assert.NoError(t, err)
+		p, ok := manifest.Plugins["local-test-plugin"]
+		assert.True(t, ok)
+		assert.Equal(t, "2.1.0", p.Version)
+		assert.Contains(t, ctx.Stdout().(*bytes.Buffer).String(), "Installing plugin from")
+	})
+
+	t.Run("Version flag must match manifest", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+
+		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
+		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
+		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
+
+		ctx := newTestContext()
+		err := mgr.InstallFromLocalFile(ctx, archivePath, "9.9.9")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match package manifest version")
+	})
+
+	t.Run("Unsupported extension", func(t *testing.T) {
+		pluginRoot := t.TempDir()
+		mgr := &Manager{rootDir: pluginRoot}
+		badPath := filepath.Join(t.TempDir(), "plugin.txt")
+		assert.NoError(t, os.WriteFile(badPath, []byte("x"), 0644))
+
+		ctx := newTestContext()
+		err := mgr.InstallFromLocalFile(ctx, badPath, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported archive format")
+	})
+}
+
 func createTestPluginArchive(t *testing.T, pluginName, version, command string) []byte {
 	tmpDir := t.TempDir()
 	archivePath := filepath.Join(tmpDir, "plugin.tar.gz")

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -2112,54 +2112,6 @@ func TestManager_installPlugin(t *testing.T) {
 	})
 }
 
-func TestManager_InstallFromLocalFile(t *testing.T) {
-	t.Run("Success from tar.gz", func(t *testing.T) {
-		pluginRoot := t.TempDir()
-		mgr := &Manager{rootDir: pluginRoot}
-
-		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
-		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
-		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
-
-		ctx := newTestContext()
-		err := mgr.InstallFromLocalFile(ctx, archivePath, "")
-		assert.NoError(t, err)
-
-		manifest, err := mgr.GetLocalManifest()
-		assert.NoError(t, err)
-		p, ok := manifest.Plugins["local-test-plugin"]
-		assert.True(t, ok)
-		assert.Equal(t, "2.1.0", p.Version)
-		assert.Contains(t, ctx.Stdout().(*bytes.Buffer).String(), "Installing plugin from")
-	})
-
-	t.Run("Version flag must match manifest", func(t *testing.T) {
-		pluginRoot := t.TempDir()
-		mgr := &Manager{rootDir: pluginRoot}
-
-		archiveBody := createTestPluginArchive(t, "local-test-plugin", "2.1.0", "local")
-		archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
-		assert.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
-
-		ctx := newTestContext()
-		err := mgr.InstallFromLocalFile(ctx, archivePath, "9.9.9")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "does not match package manifest version")
-	})
-
-	t.Run("Unsupported extension", func(t *testing.T) {
-		pluginRoot := t.TempDir()
-		mgr := &Manager{rootDir: pluginRoot}
-		badPath := filepath.Join(t.TempDir(), "plugin.txt")
-		assert.NoError(t, os.WriteFile(badPath, []byte("x"), 0644))
-
-		ctx := newTestContext()
-		err := mgr.InstallFromLocalFile(ctx, badPath, "")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported archive format")
-	})
-}
-
 func createTestPluginArchive(t *testing.T, pluginName, version, command string) []byte {
 	tmpDir := t.TempDir()
 	archivePath := filepath.Join(tmpDir, "plugin.tar.gz")

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -60,6 +60,16 @@ func TestNewManager_LoadsSourceBaseFromFile(t *testing.T) {
 	assert.Equal(t, "https://x.example/plugins", mgr.sourceBase)
 }
 
+func TestManager_ApplySourceBaseOverride(t *testing.T) {
+	m := &Manager{}
+	assert.ErrorContains(t, m.ApplySourceBaseOverride(""), "must not be empty")
+	assert.ErrorContains(t, m.ApplySourceBaseOverride("   "), "must not be empty")
+	assert.ErrorContains(t, m.ApplySourceBaseOverride("ftp://x.example/plugins"), "http://")
+	assert.NoError(t, m.ApplySourceBaseOverride("  https://mirror.example/plugins/  "))
+	assert.Equal(t, "https://mirror.example/plugins/plugin_pkg_index.json", m.resolvedPkgIndexURL())
+	assert.Equal(t, "https://mirror.example/plugins/plugin_search_index.json", m.resolvedCommandIndexURL())
+}
+
 func TestNewManager(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		testHome := t.TempDir()

--- a/cli/plugin/types.go
+++ b/cli/plugin/types.go
@@ -81,19 +81,36 @@ type LocalManifest struct {
 type LocalPlugin struct {
 	Name             string   `json:"name"`
 	Version          string   `json:"version"`
-	Path             string   `json:"path"`    // 插件目录路径
+	Path             string   `json:"path"` // 插件目录路径
+	ProductCode      string   `json:"productCode,omitempty"`
 	Command          string   `json:"command"` // 触发命令，not used for now
 	CmdNames         []string `json:"cmdNames"`
 	ShortDescription string   `json:"shortDescription"`
 	Description      string   `json:"description"`
+	Inner            bool     `json:"inner,omitempty"` // 内置/产品侧插件（manifest.json inner）
+}
+
+type PluginAPIVersions struct {
+	Default     string                          `json:"default,omitempty"`
+	Supported   []string                        `json:"supported,omitempty"`
+	VersionInfo map[string]PluginAPIVersionInfo `json:"versionInfo,omitempty"`
+}
+
+type PluginAPIVersionInfo struct {
+	Deprecated  bool   `json:"deprecated"`
+	Description string `json:"description,omitempty"`
+	Recommended bool   `json:"recommended"`
 }
 
 type PluginManifest struct {
-	Name             string `json:"name"`
-	Version          string `json:"version"`
-	Command          string `json:"command"`
-	ShortDescription string `json:"shortDescription"`
-	Description      string `json:"description"`
+	Name             string             `json:"name"`
+	Version          string             `json:"version"`
+	ProductCode      string             `json:"productCode,omitempty"`
+	Command          string             `json:"command"`
+	ShortDescription string             `json:"shortDescription"`
+	Description      string             `json:"description"`
+	Inner            bool               `json:"inner,omitempty"`
+	APIVersions      *PluginAPIVersions `json:"apiVersions,omitempty"`
 	Bin              struct {
 		Path string `json:"path"` // 二进制文件相对路径
 	} `json:"bin"`

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -72,6 +72,15 @@ func (c *Commando) loadPlugins() {
 	c.localManifest, _ = mgr.GetLocalManifest()
 }
 
+func (c *Commando) printPluginIndexLoadFailureNote(ctx *cli.Context) {
+	if c.pluginIndexErr == nil {
+		return
+	}
+	cli.PrintfWithColor(ctx.Stderr(), cli.Yellow, "%s: %v\n",
+		i18n.T("Note: Could not load the remote plugin catalog", "提示：未能加载远程插件目录").Text(),
+		c.pluginIndexErr)
+}
+
 func (c *Commando) InitWithCommand(cmd *cli.Command) {
 	cmd.Run = c.main
 	cmd.Help = c.help
@@ -211,6 +220,8 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 						break
 					}
 				}
+			} else if c.pluginIndexErr != nil {
+				c.printPluginIndexLoadFailureNote(ctx)
 			}
 		}
 
@@ -260,6 +271,8 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 								return fmt.Errorf("'%s' is not a valid built-in product.\nA plugin '%s' is available which supports this product.\nRun 'aliyun plugin install --names %s' to install it.", args[0], pInfo.Name, pInfo.Name)
 							}
 						}
+					} else if c.pluginIndexErr != nil {
+						c.printPluginIndexLoadFailureNote(ctx)
 					}
 					var plugins []plugin.PluginInfo
 					if c.pluginIndex != nil {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -40,7 +40,7 @@ type Commando struct {
 	profile        config.Profile
 	library        *Library
 	pluginIndex    *plugin.Index
-	pluginIndexErr error // set when remote plugin index could not be loaded (shown once in help paths)
+	pluginIndexErr error // set when remote plugin index could not be loaded
 	localManifest  *plugin.LocalManifest
 	pluginLoaded   bool
 }

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -37,11 +37,12 @@ import (
 
 // main entrance of aliyun cli
 type Commando struct {
-	profile       config.Profile
-	library       *Library
-	pluginIndex   *plugin.Index
-	localManifest *plugin.LocalManifest
-	pluginLoaded  bool
+	profile        config.Profile
+	library        *Library
+	pluginIndex    *plugin.Index
+	pluginIndexErr error // set when remote plugin index could not be loaded (shown once in help paths)
+	localManifest  *plugin.LocalManifest
+	pluginLoaded   bool
 }
 
 var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*responses.CommonResponse, error) {
@@ -62,11 +63,13 @@ func (c *Commando) loadPlugins() {
 	}
 	c.pluginLoaded = true
 	mgr, err := plugin.NewManager()
-	if err == nil {
-		// Try to fetch remote index (might fail if offline, that's ok)
-		c.pluginIndex, _ = mgr.GetIndex()
-		c.localManifest, _ = mgr.GetLocalManifest()
+	if err != nil {
+		c.pluginIndexErr = err
+		return
 	}
+	// Remote index may fail offline; local manifest still loads for installed plugins.
+	c.pluginIndex, c.pluginIndexErr = mgr.GetIndex()
+	c.localManifest, _ = mgr.GetLocalManifest()
 }
 
 func (c *Commando) InitWithCommand(cmd *cli.Command) {

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -199,7 +199,7 @@ func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error
 			}
 		}
 	}
-	// Locally installed plugin (e.g. plugin install --source) not in remote index
+	// Locally installed plugin (e.g. plugin install --package) not in remote index
 	if pluginName == "" && c.localManifest != nil {
 		if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
 			pluginName = n

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -22,9 +22,37 @@ import (
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/config"
 	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/newmeta"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
 )
+
+func (c *Commando) printPluginIndexLoadHint(ctx *cli.Context) {
+	if c.pluginIndexErr == nil {
+		return
+	}
+	cli.PrintfWithColor(ctx.Stderr(), cli.Yellow, "%s\n",
+		i18n.T("Note: Could not load the remote plugin catalog (network or server). Install-related hints may be incomplete; installed plugins still work.",
+			"提示：未能加载远程插件目录（网络或服务器原因），与安装插件相关的提示可能不完整；已安装的插件不受影响。").Text())
+}
+
+func (c *Commando) printAiModeHelpHint(ctx *cli.Context) {
+	cfg, err := aimode.Load(config.GetConfigDir(ctx))
+	if err != nil || !cfg.Enabled {
+		return
+	}
+	msg := i18n.T(
+		"Note: CLI AI mode is enabled in configuration (`aliyun configure ai-mode`); API requests include the AI User-Agent segment.",
+		"提示：已在配置中开启 CLI AI 模式（`aliyun configure ai-mode`），API 请求会带上 AI UA。",
+	).Text()
+	cli.PrintfWithColor(ctx.Stderr(), cli.Yellow, "%s\n", msg)
+}
+
+func (c *Commando) printHelpContextHints(ctx *cli.Context) {
+	c.printPluginIndexLoadHint(ctx)
+	c.printAiModeHelpHint(ctx)
+}
 
 func getPluginArgsForHelp(productCode string) []string {
 	cmdIndex := -1
@@ -151,9 +179,11 @@ func (c *Commando) printProducts(ctx *cli.Context) {
 		cli.PrintfWithColor(ctx.Stdout(), cli.ColorOff, "\nTo install plugins for uninstalled products, run:\n")
 		cli.PrintfWithColor(ctx.Stdout(), cli.Green, "  aliyun plugin install --names <plugin_name> [--enable-pre]\n")
 	}
+	c.printHelpContextHints(ctx)
 }
 
 func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error {
+	c.printHelpContextHints(ctx)
 	// 1. Check if it's a plugin product
 	var pluginName string
 	var isInstalled bool
@@ -169,6 +199,12 @@ func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error
 			}
 		}
 	}
+	// Locally installed plugin (e.g. plugin install --source) not in remote index
+	if pluginName == "" && c.localManifest != nil {
+		if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
+			pluginName = n
+		}
+	}
 
 	// 2. Check if it's a built-in product
 	product, ok := c.library.GetProduct(productCode)
@@ -181,13 +217,17 @@ func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error
 			if isInstalled {
 				cli.Printf(ctx.Stdout(), "Product '%s' is provided by plugin '%s'\n", productCode, pluginName)
 				c.setLangEnv(ctx)
-				plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), nil)
+				plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), ctx)
 				return nil
 			} else {
 				return fmt.Errorf("'%s' is not a valid product.\nDid you mean to install corresponding product plugin?\n  aliyun plugin install --names %s", productCode, pluginName)
 			}
 		}
-		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: c.pluginIndex.Plugins}
+		var plugList []plugin.PluginInfo
+		if c.pluginIndex != nil {
+			plugList = c.pluginIndex.Plugins
+		}
+		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: plugList}
 	}
 
 	if pluginName != "" {
@@ -265,6 +305,7 @@ func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error
 }
 
 func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName string) error {
+	c.printHelpContextHints(ctx)
 	// 0. Check if it's a plugin product
 	var pluginName string
 	var isInstalled bool
@@ -280,10 +321,16 @@ func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName s
 			}
 		}
 	}
+	if pluginName == "" && c.localManifest != nil {
+		if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
+			pluginName = n
+		}
+	}
 
-	if pluginName != "" {
-		if c.localManifest != nil {
-			localPlugin, isInstalled = c.localManifest.Plugins[pluginName]
+	if pluginName != "" && c.localManifest != nil {
+		if lp, ok := c.localManifest.Plugins[pluginName]; ok {
+			localPlugin = lp
+			isInstalled = true
 		}
 	}
 
@@ -303,7 +350,11 @@ func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName s
 			}
 		}
 		// Not a built-in product and not a plugin product, like fuzzy cmd input
-		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: c.pluginIndex.Plugins}
+		var plugList []plugin.PluginInfo
+		if c.pluginIndex != nil {
+			plugList = c.pluginIndex.Plugins
+		}
+		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: plugList}
 	}
 
 	shouldTryPlugin := false

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -43,8 +43,8 @@ func (c *Commando) printAiModeHelpHint(ctx *cli.Context) {
 		return
 	}
 	msg := i18n.T(
-		"Note: CLI AI mode is enabled in configuration (`aliyun configure ai-mode`); API requests include the AI User-Agent segment.",
-		"提示：已在配置中开启 CLI AI 模式（`aliyun configure ai-mode`），API 请求会带上 AI UA。",
+		"Note: CLI AI mode is enabled in configuration; API requests include the AI User-Agent segment. If you do not want this, run `aliyun configure ai-mode disable`.",
+		"提示：已在配置中开启 CLI AI 模式，API 请求会带上 AI UA。若不需要，请执行 `aliyun configure ai-mode disable` 关闭。",
 	).Text()
 	cli.PrintfWithColor(ctx.Stderr(), cli.Yellow, "%s\n", msg)
 }

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -3,8 +3,10 @@ package openapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -379,4 +381,113 @@ func TestPrintApiUsage_NonBuiltinProduct_PluginInstalled(t *testing.T) {
 
 	output := w.String()
 	assert.Contains(t, output, "Command 'fc deploy' is provided by plugin 'aliyun-cli-fc'")
+}
+
+func setupLocalPluginShellBinary(t *testing.T, pluginName string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("plugin fixture uses a Unix shell shebang")
+	}
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	t.Cleanup(cleanup)
+
+	pluginsDir := filepath.Join(testHome, ".aliyun", "plugins")
+	pluginDir := filepath.Join(pluginsDir, pluginName)
+	assert.NoError(t, os.MkdirAll(pluginDir, 0755))
+
+	binPath := filepath.Join(pluginDir, pluginName)
+	script := "#!/bin/sh\necho HELP_FROM_LOCAL_PLUGIN\nexit 0\n"
+	assert.NoError(t, os.WriteFile(binPath, []byte(script), 0755))
+
+	manifest := plugin.LocalManifest{
+		Plugins: map[string]plugin.LocalPlugin{
+			pluginName: {
+				Name:    pluginName,
+				Version: "1.0.0",
+				Path:    pluginDir,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(filepath.Join(pluginsDir, "manifest.json"), data, 0644))
+}
+
+func TestPrintProductUsage_LocalPluginNotInRemoteIndex(t *testing.T) {
+	setupLocalPluginShellBinary(t, "aliyun-cli-localonly")
+
+	c, w, stderr := newTestCommando()
+	ctx := newTestContext(w, stderr)
+
+	repo, _ := meta.MockLoadRepository([]meta.Product{})
+	c.library.builtinRepo = repo
+	c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{}}
+
+	mgr, err := plugin.NewManager()
+	assert.NoError(t, err)
+	lm, err := mgr.GetLocalManifest()
+	assert.NoError(t, err)
+	c.localManifest = lm
+
+	err = c.printProductUsage(ctx, "localonly")
+	assert.NoError(t, err)
+	out := w.String()
+	assert.Contains(t, out, "Product 'localonly' is provided by plugin 'aliyun-cli-localonly'")
+	assert.Contains(t, out, "HELP_FROM_LOCAL_PLUGIN")
+}
+
+func TestPrintApiUsage_LocalPluginNotInRemoteIndex(t *testing.T) {
+	setupLocalPluginShellBinary(t, "aliyun-cli-localonly2")
+
+	c, w, stderr := newTestCommando()
+	ctx := newTestContext(w, stderr)
+
+	repo, _ := meta.MockLoadRepository([]meta.Product{})
+	c.library.builtinRepo = repo
+	c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{}}
+
+	mgr, err := plugin.NewManager()
+	assert.NoError(t, err)
+	lm, err := mgr.GetLocalManifest()
+	assert.NoError(t, err)
+	c.localManifest = lm
+
+	err = c.printApiUsage(ctx, "localonly2", "SomeApi")
+	assert.NoError(t, err)
+	assert.Contains(t, w.String(), "Command 'localonly2 SomeApi' is provided by plugin 'aliyun-cli-localonly2'")
+}
+
+func TestPrintProducts_PluginIndexLoadHint(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	ctx := newTestContext(stdout, stderr)
+	c.library.builtinRepo = getRepository()
+	c.pluginLoaded = true
+	c.pluginIndexErr = fmt.Errorf("failed to fetch plugin index")
+	c.pluginIndex = nil
+
+	c.printProducts(ctx)
+
+	assert.Contains(t, stderr.String(), "plugin catalog")
+}
+
+func TestPrintHelpContextHints_AiModeConfigEnabled(t *testing.T) {
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	t.Cleanup(cleanup)
+
+	confDir := filepath.Join(testHome, ".aliyun")
+	assert.NoError(t, os.MkdirAll(confDir, 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(confDir, "ai-mode.json"), []byte(`{"enabled":true}`), 0600))
+
+	c, w, stderr := newTestCommando()
+	cmd := &cli.Command{}
+	AddFlags(cmd.Flags())
+	ctx := cli.NewCommandContext(w, stderr)
+	ctx.EnterCommand(cmd)
+
+	c.pluginLoaded = true
+	c.printHelpContextHints(ctx)
+
+	assert.Contains(t, stderr.String(), "configure ai-mode")
 }

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -489,5 +489,7 @@ func TestPrintHelpContextHints_AiModeConfigEnabled(t *testing.T) {
 	c.pluginLoaded = true
 	c.printHelpContextHints(ctx)
 
-	assert.Contains(t, stderr.String(), "configure ai-mode")
+	out := stderr.String()
+	assert.Contains(t, out, "configure ai-mode")
+	assert.Contains(t, out, "disable")
 }

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
 	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/meta"
 )
 
@@ -30,6 +31,50 @@ func newTestCommando() (*Commando, *bytes.Buffer, *bytes.Buffer) {
 
 func newTestContext(w, stderr *bytes.Buffer) *cli.Context {
 	return cli.NewCommandContext(w, stderr)
+}
+
+func TestPrintPluginIndexLoadFailureNote_NoError(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	c, stdout, stderr := newTestCommando()
+	ctx := newTestContext(stdout, stderr)
+
+	c.printPluginIndexLoadFailureNote(ctx)
+
+	assert.Empty(t, stderr.String())
+}
+
+func TestPrintPluginIndexLoadFailureNote_WithError_English(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	prevLang := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(prevLang) })
+	i18n.SetLanguage("en")
+
+	c, stdout, stderr := newTestCommando()
+	ctx := newTestContext(stdout, stderr)
+	c.pluginIndexErr = fmt.Errorf("remote catalog unavailable")
+
+	c.printPluginIndexLoadFailureNote(ctx)
+
+	out := stderr.String()
+	assert.Contains(t, out, "Note: Could not load the remote plugin catalog")
+	assert.Contains(t, out, "remote catalog unavailable")
+}
+
+func TestPrintPluginIndexLoadFailureNote_WithError_Chinese(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	prevLang := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(prevLang) })
+	i18n.SetLanguage("zh")
+
+	c, stdout, stderr := newTestCommando()
+	ctx := newTestContext(stdout, stderr)
+	c.pluginIndexErr = fmt.Errorf("网络错误")
+
+	c.printPluginIndexLoadFailureNote(ctx)
+
+	out := stderr.String()
+	assert.Contains(t, out, "提示：未能加载远程插件目录")
+	assert.Contains(t, out, "网络错误")
 }
 
 func TestPrintProductUsage_BuiltinProduct(t *testing.T) {


### PR DESCRIPTION
**Description**

Add local archive install via `aliyun plugin install --package` (`.zip / .tar.gz / .tgz`), including path handling, manifest/version checks.

Introduce `aliyun plugin show` to display product code, API versions (when declared in the plugin manifest), and inner where relevant.

Support `--source-base` for plugin management.

Improve `--help` message with `ai-mode` and plugin index fetching error.