### PR TITLE
{Core} Fix endpoint shorthand flag `-e` of oss

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -550,11 +550,12 @@ func NewEndpointFlag() *cli.Flag {
 	return &cli.Flag{
 		Category:     "config",
 		Name:         EndpointFlagName,
+		Shorthand:    'e',
 		AssignedMode: cli.AssignedOnce,
 		Persistent:   true,
 		Short: i18n.T(
-			"use `--endpoint <endpoint>` to assign endpoint",
-			"使用 `--endpoint <endpoint>` 来指定接入点地址"),
+			"use `--endpoint`/`-e <endpoint>` to assign endpoint",
+			"使用 `--endpoint`/`-e <endpoint>` 来指定接入点地址"),
 	}
 }
 

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -485,6 +485,7 @@ func TestEndpointTypeFlag(t *testing.T) {
 func TestNewEndpointFlag(t *testing.T) {
 	var a = NewEndpointFlag()
 	assert.Equal(t, EndpointFlagName, a.Name)
+	assert.Equal(t, 'e', a.Shorthand)
 	assert.Equal(t, "config", a.Category)
 	assert.True(t, a.Persistent)
 	assert.Equal(t, cli.AssignedOnce, a.AssignedMode)


### PR DESCRIPTION
**Description**

This PR fixes a regression in `v3.3.5` where `aliyun oss cp … -e <endpoint> …` failed with `unknown flag -e` ([#1302](https://github.com/aliyun/aliyun-cli/issues/1302)). Moving `--endpoint` into `config.NewEndpointFlag()` meant OSS subcommands already had an endpoint flag from `config.AddFlags`, so the OSS bridge no longer added the ossutil-style `-e` shorthand. We restore compatibility by setting Shorthand: `'e'` on `NewEndpointFlag()` and updating the flag help text so `-e` and `--endpoint` behave the same everywhere `config.AddFlags` is used. 

close https://github.com/aliyun/aliyun-cli/issues/1302