### PR TITLE
{config} Fix: Only honor `ALIBABA_CLOUD_ENDPOINT` for profile endpoint env injection

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -253,7 +253,7 @@ func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
 	}
 
 	if cp.Endpoint == "" {
-		cp.Endpoint = util.GetFromEnv("ALIBABA_CLOUD_ENDPOINT", "ALIBABACLOUD_ENDPOINT", "ALICLOUD_ENDPOINT", "ENDPOINT")
+		cp.Endpoint = util.GetFromEnv("ALIBABA_CLOUD_ENDPOINT")
 	}
 
 	if cp.CredentialsURI == "" {

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -499,21 +499,23 @@ func TestOverwriteWithFlagsWithEndpointEnv(t *testing.T) {
 	actual.OverwriteWithFlags(ctx)
 	assert.Equal(t, exp, actual)
 
+	actual = newProfile()
 	os.Setenv("ENDPOINT", "endpoint1.aliyuncs.com")
 	actual.OverwriteWithFlags(ctx)
-	exp.Endpoint = "endpoint1.aliyuncs.com"
+	// endpoint env is intentionally narrowed to ALIBABA_CLOUD_ENDPOINT only
+	exp.Endpoint = ""
 	assert.Equal(t, exp, actual)
 
 	actual = newProfile()
 	os.Setenv("ALICLOUD_ENDPOINT", "endpoint2.aliyuncs.com")
 	actual.OverwriteWithFlags(ctx)
-	exp.Endpoint = "endpoint2.aliyuncs.com"
+	exp.Endpoint = ""
 	assert.Equal(t, exp, actual)
 
 	actual = newProfile()
 	os.Setenv("ALIBABACLOUD_ENDPOINT", "endpoint3.aliyuncs.com")
 	actual.OverwriteWithFlags(ctx)
-	exp.Endpoint = "endpoint3.aliyuncs.com"
+	exp.Endpoint = ""
 	assert.Equal(t, exp, actual)
 
 	actual = newProfile()


### PR DESCRIPTION
**Description**

This change narrows how the CLI populates `Profile.Endpoint` from environment variables to avoid accidental overrides from generic container variables (notably `ENDPOINT`).

Config profile previously accepted multiple endpoint-related environment variable names from this [pr](https://github.com/aliyun/aliyun-cli/pull/1298). In containerized environments, unrelated services might define `ENDPOINT`, which could unintentionally change Alibaba Cloud CLI to use the wrong API endpoint and lead to customer-facing incidents.

**Solution**
Endpoint env sourcing is now restricted to `ALIBABA_CLOUD_ENDPOINT` only.

**Compatibility / migration**

- Breaking change (intentional) for endpoint env only: `ENDPOINT, ALICLOUD_ENDPOINT, and ALIBABACLOUD_ENDPOINT` will no longer populate `Profile.Endpoint`.
- Users relying on those variables should migrate to `ALIBABA_CLOUD_ENDPOINT`.

