### PR TITLE
{Config} Add safety policy env parsing

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -998,7 +998,7 @@ func (c *Commando) handleInstallError(ctx *cli.Context, err error, pluginName st
 
 func (c *Commando) checkSafetyPolicy(ctx *cli.Context, productCode string, apiOrMethod string, path string) error {
 	configDir := config.GetConfigDir(ctx)
-	policy, err := safety.LoadPolicy(configDir)
+	policy, err := safety.LoadEffectivePolicy(configDir)
 	if err != nil {
 		// Failed to load - skip policy check (fail open)
 		return nil

--- a/sysconfig/safety/policy.go
+++ b/sysconfig/safety/policy.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -176,6 +177,110 @@ func LoadPolicy(configDir string) (*Policy, error) {
 	return &p, nil
 }
 
+const EnvSafetyPolicyEnabled = "ALIBABA_CLOUD_SAFETY_POLICY_ENABLED"
+
+// Comma-separated entries, each entry is pattern=action (first '=' separates pattern and action).
+// Example: *:Delete*=deny,ecs:Update*=confirm
+const EnvSafetyPolicyRules = "ALIBABA_CLOUD_SAFETY_POLICY_RULES"
+
+func actionFromEnvToken(s string) (Action, bool) {
+	a := Action(strings.ToLower(strings.TrimSpace(s)))
+	switch a {
+	case ActionAllow, ActionDeny, ActionConfirm, ActionForbid:
+		return a, true
+	default:
+		return "", false
+	}
+}
+
+func parseEnvRulesList(raw string) ([]Rule, bool) {
+	var out []Rule
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		pattern, actionStr, found := strings.Cut(part, "=")
+		if !found {
+			continue
+		}
+		pattern = strings.TrimSpace(pattern)
+		actionStr = strings.TrimSpace(actionStr)
+		if pattern == "" || actionStr == "" {
+			continue
+		}
+		act, ok := actionFromEnvToken(actionStr)
+		if !ok {
+			continue
+		}
+		out = append(out, Rule{Pattern: pattern, Action: act})
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func copyPolicyRules(rules []Rule) []Rule {
+	if len(rules) == 0 {
+		return []Rule{}
+	}
+	return append([]Rule(nil), rules...)
+}
+
+func serializeRulesForEnv(rules []Rule) string {
+	if len(rules) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(rules))
+	for _, r := range rules {
+		pat := strings.TrimSpace(r.Pattern)
+		act := strings.ToLower(strings.TrimSpace(string(r.Action)))
+		if pat == "" || act == "" {
+			continue
+		}
+		parts = append(parts, pat+"="+act)
+	}
+	return strings.Join(parts, ",")
+}
+
+func MergePolicyFromEnv(base *Policy) *Policy {
+	if base == nil {
+		base = DefaultPolicy()
+	}
+
+	enabled := base.Enabled
+	if v, ok := os.LookupEnv(EnvSafetyPolicyEnabled); ok {
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
+			enabled = parsed
+		}
+	}
+
+	var rules []Rule
+	if raw0, ok := os.LookupEnv(EnvSafetyPolicyRules); ok {
+		raw := strings.TrimSpace(raw0)
+		if raw == "" {
+			rules = []Rule{}
+		} else if r, parsed := parseEnvRulesList(raw); parsed {
+			rules = r
+		} else {
+			rules = copyPolicyRules(base.Rules)
+		}
+	} else {
+		rules = copyPolicyRules(base.Rules)
+	}
+
+	return &Policy{Enabled: enabled, Rules: rules}
+}
+
+func LoadEffectivePolicy(configDir string) (*Policy, error) {
+	p, err := LoadPolicy(configDir)
+	if err != nil {
+		return nil, err
+	}
+	return MergePolicyFromEnv(p), nil
+}
+
 const EnvSafetyPolicyFile = "ALIBABA_CLOUD_CLI_SAFETY_POLICY_FILE"
 
 func MergeSafetyPolicyPathIntoEnvs(configDir string, envs map[string]string) {
@@ -187,6 +292,13 @@ func MergeSafetyPolicyPathIntoEnvs(configDir string, envs map[string]string) {
 		p = abs
 	}
 	envs[EnvSafetyPolicyFile] = p
+
+	ef, err := LoadEffectivePolicy(configDir)
+	if err != nil {
+		return
+	}
+	envs[EnvSafetyPolicyEnabled] = strconv.FormatBool(ef.Enabled)
+	envs[EnvSafetyPolicyRules] = serializeRulesForEnv(ef.Rules)
 }
 
 func SavePolicy(configDir string, policy *Policy) error {

--- a/sysconfig/safety/policy_test.go
+++ b/sysconfig/safety/policy_test.go
@@ -15,11 +15,27 @@
 package safety
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+	_ = os.Unsetenv(key)
+}
 
 func TestPolicy_Check_Disabled(t *testing.T) {
 	policy := &Policy{
@@ -136,12 +152,44 @@ func TestMatchPattern(t *testing.T) {
 }
 
 func TestMergeSafetyPolicyPathIntoEnvs(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	unsetEnvForTest(t, EnvSafetyPolicyRules)
 	dir := t.TempDir()
 	m := map[string]string{}
 	MergeSafetyPolicyPathIntoEnvs(dir, m)
 	want, err := filepath.Abs(filepath.Join(dir, SafetyPolicyFileName))
 	assert.NoError(t, err)
 	assert.Equal(t, want, m[EnvSafetyPolicyFile])
+	assert.Equal(t, "false", m[EnvSafetyPolicyEnabled])
+	assert.Equal(t, "", m[EnvSafetyPolicyRules])
+}
+
+func TestMergeSafetyPolicyPathIntoEnvs_EffectiveFromFile(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	unsetEnvForTest(t, EnvSafetyPolicyRules)
+	dir := t.TempDir()
+	require.NoError(t, SavePolicy(dir, &Policy{
+		Enabled: true,
+		Rules:   []Rule{{Pattern: "ecs:Delete*", Action: ActionDeny}},
+	}))
+	m := map[string]string{}
+	MergeSafetyPolicyPathIntoEnvs(dir, m)
+	assert.Equal(t, "true", m[EnvSafetyPolicyEnabled])
+	assert.Equal(t, "ecs:Delete*=deny", m[EnvSafetyPolicyRules])
+}
+
+func TestMergeSafetyPolicyPathIntoEnvs_EffectiveEnvOverridesFile(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyRules)
+	dir := t.TempDir()
+	require.NoError(t, SavePolicy(dir, &Policy{
+		Enabled: false,
+		Rules:   []Rule{{Pattern: "ecs:Delete*", Action: ActionDeny}},
+	}))
+	t.Setenv(EnvSafetyPolicyEnabled, "true")
+	m := map[string]string{}
+	MergeSafetyPolicyPathIntoEnvs(dir, m)
+	assert.Equal(t, "true", m[EnvSafetyPolicyEnabled])
+	assert.Equal(t, "ecs:Delete*=deny", m[EnvSafetyPolicyRules])
 }
 
 func TestMergeSafetyPolicyPathIntoEnvs_nilOrEmpty(t *testing.T) {
@@ -149,4 +197,87 @@ func TestMergeSafetyPolicyPathIntoEnvs_nilOrEmpty(t *testing.T) {
 	m := map[string]string{}
 	MergeSafetyPolicyPathIntoEnvs("/tmp", nil) // no panic
 	assert.Empty(t, m)
+}
+
+func TestMergePolicyFromEnv_NoEnv(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	unsetEnvForTest(t, EnvSafetyPolicyRules)
+
+	base := &Policy{Enabled: true, Rules: []Rule{{Pattern: "ecs:Delete*", Action: ActionDeny}}}
+	got := MergePolicyFromEnv(base)
+	assert.True(t, got.Enabled)
+	require.Len(t, got.Rules, 1)
+	assert.Equal(t, "ecs:Delete*", got.Rules[0].Pattern)
+}
+
+func TestMergePolicyFromEnv_EnabledOverride(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyRules)
+	base := &Policy{Enabled: false, Rules: []Rule{{Pattern: "*:Delete*", Action: ActionDeny}}}
+
+	t.Setenv(EnvSafetyPolicyEnabled, "true")
+	got := MergePolicyFromEnv(base)
+	assert.True(t, got.Enabled)
+	assert.Len(t, got.Rules, 1)
+
+	t.Setenv(EnvSafetyPolicyEnabled, "0")
+	got2 := MergePolicyFromEnv(base)
+	assert.False(t, got2.Enabled)
+}
+
+func TestMergePolicyFromEnv_RulesOverride(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	base := &Policy{Enabled: true, Rules: []Rule{{Pattern: "old:*", Action: ActionDeny}}}
+	t.Setenv(EnvSafetyPolicyRules, "ecs:Update*=confirm")
+	got := MergePolicyFromEnv(base)
+	assert.True(t, got.Enabled)
+	require.Len(t, got.Rules, 1)
+	assert.Equal(t, "ecs:Update*", got.Rules[0].Pattern)
+	assert.Equal(t, ActionConfirm, got.Rules[0].Action)
+}
+
+func TestMergePolicyFromEnv_RulesOverride_MultipleComma(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	base := &Policy{Enabled: true, Rules: []Rule{{Pattern: "old:*", Action: ActionDeny}}}
+	t.Setenv(EnvSafetyPolicyRules, " *:Delete*=deny , ecs:Update* = confirm ")
+	got := MergePolicyFromEnv(base)
+	require.Len(t, got.Rules, 2)
+	assert.Equal(t, "*:Delete*", got.Rules[0].Pattern)
+	assert.Equal(t, ActionDeny, got.Rules[0].Action)
+	assert.Equal(t, "ecs:Update*", got.Rules[1].Pattern)
+	assert.Equal(t, ActionConfirm, got.Rules[1].Action)
+}
+
+func TestMergePolicyFromEnv_RulesEmptyStringClears(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	base := &Policy{Enabled: true, Rules: []Rule{{Pattern: "x", Action: ActionDeny}}}
+	t.Setenv(EnvSafetyPolicyRules, "   ")
+	got := MergePolicyFromEnv(base)
+	assert.Empty(t, got.Rules)
+}
+
+func TestMergePolicyFromEnv_InvalidRulesEnvKeepsFile(t *testing.T) {
+	unsetEnvForTest(t, EnvSafetyPolicyEnabled)
+	base := &Policy{Enabled: true, Rules: []Rule{{Pattern: "keep:me", Action: ActionDeny}}}
+	t.Setenv(EnvSafetyPolicyRules, "not-json,{badaction},noequals")
+	got := MergePolicyFromEnv(base)
+	require.Len(t, got.Rules, 1)
+	assert.Equal(t, "keep:me", got.Rules[0].Pattern)
+}
+
+func TestLoadEffectivePolicy_AppliesEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := GetPolicyFilePath(dir)
+	filePolicy := Policy{Enabled: false, Rules: []Rule{{Pattern: "ecs:Describe*", Action: ActionDeny}}}
+	data, err := json.MarshalIndent(filePolicy, "", "\t")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+
+	t.Setenv(EnvSafetyPolicyEnabled, "true")
+	t.Setenv(EnvSafetyPolicyRules, "ecs:Delete*=deny")
+
+	got, err := LoadEffectivePolicy(dir)
+	require.NoError(t, err)
+	assert.True(t, got.Enabled)
+	require.Len(t, got.Rules, 1)
+	assert.Equal(t, "ecs:Delete*", got.Rules[0].Pattern)
 }


### PR DESCRIPTION
**Description**

Adds `ALIBABA_CLOUD_SAFETY_POLICY_ENABLED` and `ALIBABA_CLOUD_SAFETY_POLICY_RULES` (comma-separated pattern=action) for runtime checks, with env values overriding the policy file when set. 


close https://github.com/aliyun/aliyun-cli/issues/1305