### PR TITLE
{Profile} Add `external-account-type` for user profile

### DIFF
--- a/config/configure_get.go
+++ b/config/configure_get.go
@@ -103,6 +103,8 @@ func doConfigureGet(c *cli.Context, args []string) error {
 			cli.Printf(c.Stdout(), "endpoint-type=%s\n", profile.EndpointType)
 		case EndpointFlagName:
 			cli.Printf(c.Stdout(), "endpoint=%s\n", profile.Endpoint)
+		case ExternalAccountTypeFlagName:
+			cli.Printf(c.Stdout(), "external-account-type=%s\n", profile.ExternalAccountType)
 		}
 	}
 

--- a/config/configure_get_test.go
+++ b/config/configure_get_test.go
@@ -264,3 +264,52 @@ func TestDoConfigureGetEndpoint(t *testing.T) {
 	doConfigureGet(ctx, []string{EndpointFlagName})
 	assert.Equal(t, "endpoint=\n\n", stdout.String())
 }
+
+func TestDoConfigureGetExternalAccountType(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	AddFlags(ctx.Flags())
+	originhook := hookLoadConfigurationWithContext
+	defer func() {
+		hookLoadConfigurationWithContext = originhook
+	}()
+
+	hookLoadConfigurationWithContext = func(fn func(ctx *cli.Context) (*Configuration, error)) func(ctx *cli.Context) (*Configuration, error) {
+		return func(ctx *cli.Context) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{
+						Name:                "default",
+						Mode:                AK,
+						ExternalAccountType: "buc",
+					},
+				},
+			}, nil
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	doConfigureGet(ctx, []string{ExternalAccountTypeFlagName})
+	assert.Equal(t, "external-account-type=buc\n\n", stdout.String())
+
+	hookLoadConfigurationWithContext = func(fn func(ctx *cli.Context) (*Configuration, error)) func(ctx *cli.Context) (*Configuration, error) {
+		return func(ctx *cli.Context) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{
+						Name:                "default",
+						Mode:                AK,
+						ExternalAccountType: "",
+					},
+				},
+			}, nil
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	doConfigureGet(ctx, []string{ExternalAccountTypeFlagName})
+	assert.Equal(t, "external-account-type=\n\n", stdout.String())
+}

--- a/config/configure_set.go
+++ b/config/configure_set.go
@@ -129,6 +129,7 @@ func doConfigureSet(ctx *cli.Context) error {
 	profile.StsRegion = StsRegionFlag(flags).GetStringOrDefault(profile.StsRegion)
 	profile.EndpointType = EndpointTypeFlag(flags).GetStringOrDefault(profile.EndpointType)
 	profile.Endpoint = EndpointFlag(flags).GetStringOrDefault(profile.Endpoint)
+	profile.ExternalAccountType = ExternalAccountTypeFlag(flags).GetStringOrDefault(profile.ExternalAccountType)
 
 	if autoPluginInstallFlag := AutoPluginInstallFlag(flags); autoPluginInstallFlag != nil && autoPluginInstallFlag.IsAssigned() {
 		if val, ok := autoPluginInstallFlag.GetValue(); ok {

--- a/config/configure_set_test.go
+++ b/config/configure_set_test.go
@@ -263,6 +263,49 @@ func TestDoConfigureSetWithMock(t *testing.T) {
 	assert.Empty(t, stdout.String())
 }
 
+func TestDoConfigureSet_ExternalAccountType(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	AddFlags(ctx.Flags())
+
+	originhook := hookLoadOrCreateConfiguration
+	originhookSave := hookSaveConfigurationWithContext
+	defer func() {
+		hookLoadOrCreateConfiguration = originhook
+		hookSaveConfigurationWithContext = originhookSave
+	}()
+
+	var savedProfile Profile
+	hookSaveConfigurationWithContext = func(fn func(ctx *cli.Context, config *Configuration) error) func(ctx *cli.Context, config *Configuration) error {
+		return func(ctx *cli.Context, config *Configuration) error {
+			p, _ := config.GetProfile(config.CurrentProfile)
+			savedProfile = p
+			return nil
+		}
+	}
+
+	hookLoadOrCreateConfiguration = func(fn func(path string) (*Configuration, error)) func(path string) (*Configuration, error) {
+		return func(path string) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{Name: "default", RegionId: "cn-hangzhou", Mode: AK, AccessKeyId: "ak", AccessKeySecret: "sk"},
+				},
+			}, nil
+		}
+	}
+
+	flag := ExternalAccountTypeFlag(ctx.Flags())
+	assert.NotNil(t, flag)
+	flag.SetAssigned(true)
+	flag.SetValue("buc")
+
+	err := doConfigureSet(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "buc", savedProfile.ExternalAccountType)
+}
+
 func TestDoConfigureSet_AutoPluginInstall(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/config/flags.go
+++ b/config/flags.go
@@ -582,7 +582,6 @@ func NewExternalAccountTypeFlag() *cli.Flag {
 		Category:     "config",
 		Name:         ExternalAccountTypeFlagName,
 		AssignedMode: cli.AssignedOnce,
-		Persistent:   true,
 		Short: i18n.T(
 			"use `--external-account-type <type>` to assign external account type",
 			"使用 `--external-account-type <type>` 来指定外部账号类型"),

--- a/config/flags.go
+++ b/config/flags.go
@@ -51,6 +51,7 @@ const (
 	OAuthSiteTypeName                  = "oauth-site-type"
 	EndpointTypeFlagName               = "endpoint-type"
 	EndpointFlagName                   = "endpoint"
+	ExternalAccountTypeFlagName        = "external-account-type"
 	AutoPluginInstallFlagName          = "auto-plugin-install"
 	AutoPluginInstallEnablePreFlagName = "auto-plugin-install-enable-pre"
 )
@@ -87,6 +88,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(NewOAuthSiteTypeFlag())
 	fs.Add(NewEndpointTypeFlag())
 	fs.Add(NewEndpointFlag())
+	fs.Add(NewExternalAccountTypeFlag())
 	fs.Add(NewAutoPluginInstallFlag())
 	fs.Add(NewAutoPluginInstallEnablePreFlag())
 }
@@ -568,6 +570,22 @@ func NewEndpointTypeFlag() *cli.Flag {
 		Short: i18n.T(
 			"use `--endpoint-type` to specify the endpoint type, support vpc or empty (default public)",
 			"使用 `--endpoint-type` 指定 endpoint 类型, 支持 vpc 或空值(默认公网)"),
+	}
+}
+
+func ExternalAccountTypeFlag(fs *cli.FlagSet) *cli.Flag {
+	return fs.Get(ExternalAccountTypeFlagName)
+}
+
+func NewExternalAccountTypeFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "config",
+		Name:         ExternalAccountTypeFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Persistent:   true,
+		Short: i18n.T(
+			"use `--external-account-type <type>` to assign external account type",
+			"使用 `--external-account-type <type>` 来指定外部账号类型"),
 	}
 }
 

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -505,7 +505,7 @@ func TestNewExternalAccountTypeFlag(t *testing.T) {
 	var a = NewExternalAccountTypeFlag()
 	assert.Equal(t, ExternalAccountTypeFlagName, a.Name)
 	assert.Equal(t, "config", a.Category)
-	assert.True(t, a.Persistent)
+	assert.False(t, a.Persistent)
 	assert.Equal(t, cli.AssignedOnce, a.AssignedMode)
 }
 

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -464,6 +464,8 @@ func TestAddFlags(t *testing.T) {
 	assert.NotNil(t, flagSet.Get(EndpointTypeFlagName))
 	// 结果包含EndpointFlagName
 	assert.NotNil(t, flagSet.Get(EndpointFlagName))
+	// 结果包含ExternalAccountTypeFlagName
+	assert.NotNil(t, flagSet.Get(ExternalAccountTypeFlagName))
 }
 
 func TestNewEndpointTypeFlag(t *testing.T) {
@@ -497,4 +499,20 @@ func TestEndpointFlag(t *testing.T) {
 	flag := EndpointFlag(flagSet)
 	assert.NotNil(t, flag)
 	assert.Equal(t, EndpointFlagName, flag.Name)
+}
+
+func TestNewExternalAccountTypeFlag(t *testing.T) {
+	var a = NewExternalAccountTypeFlag()
+	assert.Equal(t, ExternalAccountTypeFlagName, a.Name)
+	assert.Equal(t, "config", a.Category)
+	assert.True(t, a.Persistent)
+	assert.Equal(t, cli.AssignedOnce, a.AssignedMode)
+}
+
+func TestExternalAccountTypeFlag(t *testing.T) {
+	flagSet := cli.NewFlagSet()
+	AddFlags(flagSet)
+	flag := ExternalAccountTypeFlag(flagSet)
+	assert.NotNil(t, flag)
+	assert.Equal(t, ExternalAccountTypeFlagName, flag.Name)
 }

--- a/config/profile.go
+++ b/config/profile.go
@@ -99,6 +99,7 @@ type Profile struct {
 	OAuthSiteType              string           `json:"oauth_site_type,omitempty"` // CN or INTL
 	EndpointType               string           `json:"endpoint_type,omitempty"`   // vpc or empty (default public)
 	Endpoint                   string           `json:"endpoint,omitempty"`
+	ExternalAccountType        string           `json:"external_account_type,omitempty"`
 	AutoPluginInstall          bool             `json:"auto_plugin_install,omitempty"`            // automatically install plugins when not found
 	AutoPluginInstallEnablePre bool             `json:"auto_plugin_install_enable_pre,omitempty"` // install latest version (including pre-release) when true
 	parent                     *Configuration   //`json:"-"`
@@ -231,6 +232,7 @@ func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
 	cp.CloudSSOAccountId = CloudSSOAccountIdFlag(ctx.Flags()).GetStringOrDefault(cp.CloudSSOAccountId)
 	cp.EndpointType = EndpointTypeFlag(ctx.Flags()).GetStringOrDefault(cp.EndpointType)
 	cp.Endpoint = EndpointFlag(ctx.Flags()).GetStringOrDefault(cp.Endpoint)
+	cp.ExternalAccountType = ExternalAccountTypeFlag(ctx.Flags()).GetStringOrDefault(cp.ExternalAccountType)
 
 	if cp.AccessKeyId == "" {
 		cp.AccessKeyId = util.GetFromEnv("ALIBABA_CLOUD_ACCESS_KEY_ID", "ALIBABACLOUD_ACCESS_KEY_ID", "ALICLOUD_ACCESS_KEY_ID", "ACCESS_KEY_ID")
@@ -254,6 +256,10 @@ func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
 
 	if cp.Endpoint == "" {
 		cp.Endpoint = util.GetFromEnv("ALIBABA_CLOUD_ENDPOINT")
+	}
+
+	if cp.ExternalAccountType == "" {
+		cp.ExternalAccountType = util.GetFromEnv("ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE")
 	}
 
 	if cp.CredentialsURI == "" {
@@ -686,6 +692,9 @@ func (cp *Profile) GetRuntimeEnv(ctx *cli.Context) (map[string]string, error) {
 	}
 	if cp.Endpoint != "" {
 		envs["ALIBABA_CLOUD_ENDPOINT"] = cp.Endpoint
+	}
+	if cp.ExternalAccountType != "" {
+		envs["ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE"] = cp.ExternalAccountType
 	}
 	if cp.ReadTimeout > 0 {
 		envs["ALIBABA_CLOUD_READ_TIMEOUT"] = strconv.Itoa(cp.ReadTimeout)

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -291,6 +291,8 @@ func TestOverwriteWithFlags(t *testing.T) {
 	EndpointTypeFlag(ctx.Flags()).SetValue("vpc")
 	EndpointFlag(ctx.Flags()).SetAssigned(true)
 	EndpointFlag(ctx.Flags()).SetValue("custom.endpoint.aliyuncs.com")
+	ExternalAccountTypeFlag(ctx.Flags()).SetAssigned(true)
+	ExternalAccountTypeFlag(ctx.Flags()).SetValue("buc")
 
 	exp := &Profile{
 		Name:                 "default",
@@ -316,6 +318,7 @@ func TestOverwriteWithFlags(t *testing.T) {
 		CloudSSOAccessConfig: "222",
 		EndpointType:         "vpc",
 		Endpoint:             "custom.endpoint.aliyuncs.com",
+		ExternalAccountType:  "buc",
 	}
 
 	actual.OverwriteWithFlags(ctx)
@@ -449,6 +452,7 @@ func resetEnv() {
 	os.Setenv("ALIBABACLOUD_ENDPOINT", "")
 	os.Setenv("ALICLOUD_ENDPOINT", "")
 	os.Setenv("ENDPOINT", "")
+	os.Setenv("ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE", "")
 }
 
 func TestOverwriteWithFlagsWithEndpointTypeEnv(t *testing.T) {
@@ -522,6 +526,27 @@ func TestOverwriteWithFlagsWithEndpointEnv(t *testing.T) {
 	os.Setenv("ALIBABA_CLOUD_ENDPOINT", "endpoint4.aliyuncs.com")
 	actual.OverwriteWithFlags(ctx)
 	exp.Endpoint = "endpoint4.aliyuncs.com"
+	assert.Equal(t, exp, actual)
+
+	resetEnv()
+}
+
+func TestOverwriteWithFlagsWithExternalAccountTypeEnv(t *testing.T) {
+	buf := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(buf, stderr)
+	AddFlags(ctx.Flags())
+
+	resetEnv()
+	actual := newProfile()
+	exp := newProfile()
+	actual.OverwriteWithFlags(ctx)
+	assert.Equal(t, exp, actual)
+
+	actual = newProfile()
+	os.Setenv("ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE", "buc")
+	actual.OverwriteWithFlags(ctx)
+	exp.ExternalAccountType = "buc"
 	assert.Equal(t, exp, actual)
 
 	resetEnv()
@@ -1442,6 +1467,7 @@ func TestGetRuntimeEnv_OptionalFields(t *testing.T) {
 	p.Language = "zh"
 	p.EndpointType = "vpc"
 	p.Endpoint = "custom.endpoint.aliyuncs.com"
+	p.ExternalAccountType = "buc"
 	p.ReadTimeout = 30
 	p.ConnectTimeout = 10
 	p.RetryCount = 3
@@ -1452,6 +1478,7 @@ func TestGetRuntimeEnv_OptionalFields(t *testing.T) {
 	assert.Equal(t, "zh", envs["ALIBABA_CLOUD_LANGUAGE"])
 	assert.Equal(t, "vpc", envs["ALIBABA_CLOUD_ENDPOINT_TYPE"])
 	assert.Equal(t, "custom.endpoint.aliyuncs.com", envs["ALIBABA_CLOUD_ENDPOINT"])
+	assert.Equal(t, "buc", envs["ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE"])
 	assert.Equal(t, "30", envs["ALIBABA_CLOUD_READ_TIMEOUT"])
 	assert.Equal(t, "10", envs["ALIBABA_CLOUD_CONNECT_TIMEOUT"])
 	assert.Equal(t, "3", envs["ALIBABA_CLOUD_RETRY_COUNT"])
@@ -1466,6 +1493,7 @@ func TestGetRuntimeEnv_OptionalFieldsOmitted(t *testing.T) {
 	p.Language = ""
 	p.EndpointType = ""
 	p.Endpoint = ""
+	p.ExternalAccountType = ""
 	p.ReadTimeout = 0
 	p.ConnectTimeout = 0
 	p.RetryCount = 0
@@ -1479,6 +1507,8 @@ func TestGetRuntimeEnv_OptionalFieldsOmitted(t *testing.T) {
 	assert.False(t, hasEndpoint)
 	_, hasEndpointVal := envs["ALIBABA_CLOUD_ENDPOINT"]
 	assert.False(t, hasEndpointVal)
+	_, hasExternalAcct := envs["ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE"]
+	assert.False(t, hasExternalAcct)
 	_, hasReadTimeout := envs["ALIBABA_CLOUD_READ_TIMEOUT"]
 	assert.False(t, hasReadTimeout)
 	_, hasConnTimeout := envs["ALIBABA_CLOUD_CONNECT_TIMEOUT"]


### PR DESCRIPTION
**Description**

New `external_account_type` profile field: `--external-account-type` CLI flag, `configure set/get` support, env fallback `ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE`, and propagation to plugin subprocesses.