### PR TITLE
{Openapi} Add agent segment to `user-agent`

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/meta"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/safety"
+	"github.com/aliyun/aliyun-cli/v3/util"
 
 	"encoding/json"
 	"fmt"
@@ -301,6 +302,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 					configDir := config.GetConfigDir(ctx)
 					forceOn, forceOff := CliAIOverrides(ctx.Flags())
 					aimode.MergeUserAgentIntoPluginEnvs(configDir, envs, forceOn, forceOff)
+					util.MergeAgentSegmentIntoPluginEnvs(envs)
 					safety.MergeSafetyPolicyPathIntoEnvs(configDir, envs)
 					ctx.SetRuntimeEnvs(envs)
 				}

--- a/openapi/invoker.go
+++ b/openapi/invoker.go
@@ -211,7 +211,7 @@ func (a *BasicInvoker) Init(ctx *cli.Context, product *meta.Product) error {
 	a.client.AppendUserAgent("Aliyun-CLI", cli.GetVersion())
 
 	if name := util.DetectAgentName(); name != "" {
-		a.client.AppendUserAgent("agent", name)
+		a.client.AppendUserAgent("Agent", name)
 	}
 
 	if envUA := util.GetFromEnv("ALIBABA_CLOUD_USER_AGENT"); envUA != "" {

--- a/openapi/invoker.go
+++ b/openapi/invoker.go
@@ -210,6 +210,10 @@ func (a *BasicInvoker) Init(ctx *cli.Context, product *meta.Product) error {
 	}
 	a.client.AppendUserAgent("Aliyun-CLI", cli.GetVersion())
 
+	if name := util.DetectAgentName(); name != "" {
+		a.client.AppendUserAgent("agent", name)
+	}
+
 	if envUA := util.GetFromEnv("ALIBABA_CLOUD_USER_AGENT"); envUA != "" {
 		envUA = util.SanitizeUserAgent(envUA)
 		for _, pair := range parseCustomUserAgentSegments(envUA) {

--- a/util/agent.go
+++ b/util/agent.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+// 设计原则：
+//   - 仅输出严格 sanitize 后的 **固定枚举**，不携带工作区名、路径等可变字段；
+//   - 仅依赖业界已记录在案的 **Agent 自身** 环境变量是否存在；
+
+const (
+	agentEnvProposal = "AGENT"
+
+	agentSegmentPrefix = "agent/"
+
+	maxAgentNameLen = 32
+)
+
+var knownAgentEnv = []struct {
+	env  string
+	name string
+}{
+	{"CURSOR_AGENT", "cursor"},
+	{"CLAUDECODE", "claude-code"},
+	{"CLAUDE_CODE", "claude-code"},
+	{"GEMINI_CLI", "gemini-cli"},
+	{"AUGMENT_AGENT", "augment"},
+	{"OPENCODE", "opencode"},
+	{"OPENCODE_CLIENT", "opencode"},
+	{"CLINE_ACTIVE", "cline"},
+	{"CODEX_SANDBOX", "codex"},
+	{"QODER_AGENT", "qoder"},
+	{"QODER_CLI", "qoder-cli"},
+}
+
+// Agent 标识（小写、固定枚举或 sanitize 后的 AGENT 值）；
+func DetectAgentName() string {
+	if v := strings.TrimSpace(os.Getenv(agentEnvProposal)); v != "" {
+		if s := sanitizeAgentName(v); s != "" {
+			return s
+		}
+	}
+	for _, item := range knownAgentEnv {
+		if os.Getenv(item.env) != "" {
+			return item.name
+		}
+	}
+	return ""
+}
+
+func GetAgentUserAgentSegment() string {
+	name := DetectAgentName()
+	if name == "" {
+		return ""
+	}
+	return agentSegmentPrefix + name
+}
+
+const envCustomUserAgent = "ALIBABA_CLOUD_USER_AGENT"
+
+func MergeAgentSegmentIntoPluginEnvs(envs map[string]string) {
+	if envs == nil {
+		return
+	}
+	seg := GetAgentUserAgentSegment()
+	if seg == "" {
+		return
+	}
+	base := strings.TrimSpace(envs[envCustomUserAgent])
+	if base == "" {
+		base = strings.TrimSpace(os.Getenv(envCustomUserAgent))
+	}
+	if base == "" {
+		envs[envCustomUserAgent] = seg
+		return
+	}
+	envs[envCustomUserAgent] = base + " " + seg
+}
+
+// 仅保留 [a-z0-9._-]，最长 32 字符。
+func sanitizeAgentName(raw string) string {
+	raw = strings.ToLower(raw)
+	if len(raw) > maxAgentNameLen {
+		raw = raw[:maxAgentNameLen]
+	}
+	buf := make([]byte, 0, len(raw))
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
+		case c == '.' || c == '_' || c == '-':
+		default:
+			continue
+		}
+		buf = append(buf, c)
+	}
+	return string(buf)
+}

--- a/util/agent.go
+++ b/util/agent.go
@@ -12,7 +12,7 @@ import (
 const (
 	agentEnvProposal = "AGENT"
 
-	agentSegmentPrefix = "agent/"
+	agentSegmentPrefix = "Agent/"
 
 	maxAgentNameLen = 32
 )

--- a/util/agent_test.go
+++ b/util/agent_test.go
@@ -49,7 +49,7 @@ func TestDetectAgentName_KnownEnvs(t *testing.T) {
 			snapshotAndUnsetAgentEnvs(t)
 			_ = os.Setenv(c.env, "1")
 			assert.Equal(t, c.name, DetectAgentName())
-			assert.Equal(t, "agent/"+c.name, GetAgentUserAgentSegment())
+			assert.Equal(t, "Agent/"+c.name, GetAgentUserAgentSegment())
 		})
 	}
 }
@@ -119,7 +119,7 @@ func TestMergeAgentSegmentIntoPluginEnvs_FreshEnv(t *testing.T) {
 	_ = os.Setenv("CURSOR_AGENT", "1")
 	envs := map[string]string{}
 	MergeAgentSegmentIntoPluginEnvs(envs)
-	assert.Equal(t, "agent/cursor", envs[envCustomUserAgent])
+	assert.Equal(t, "Agent/cursor", envs[envCustomUserAgent])
 }
 
 func TestMergeAgentSegmentIntoPluginEnvs_PreservesParentEnv(t *testing.T) {
@@ -128,8 +128,8 @@ func TestMergeAgentSegmentIntoPluginEnvs_PreservesParentEnv(t *testing.T) {
 	t.Setenv(envCustomUserAgent, "skill/foo")
 	envs := map[string]string{}
 	MergeAgentSegmentIntoPluginEnvs(envs)
-	assert.Equal(t, "skill/foo agent/cursor", envs[envCustomUserAgent],
-		"已 export 的 ALIBABA_CLOUD_USER_AGENT 必须保留并在末尾追加 agent 段")
+	assert.Equal(t, "skill/foo Agent/cursor", envs[envCustomUserAgent],
+		"已 export 的 ALIBABA_CLOUD_USER_AGENT 必须保留并在末尾追加 Agent 段")
 }
 
 func TestMergeAgentSegmentIntoPluginEnvs_RuntimeEnvWinsOverParent(t *testing.T) {
@@ -140,6 +140,6 @@ func TestMergeAgentSegmentIntoPluginEnvs_RuntimeEnvWinsOverParent(t *testing.T) 
 		envCustomUserAgent: "from-runtime",
 	}
 	MergeAgentSegmentIntoPluginEnvs(envs)
-	assert.Equal(t, "from-runtime agent/cursor", envs[envCustomUserAgent],
+	assert.Equal(t, "from-runtime Agent/cursor", envs[envCustomUserAgent],
 		"envs 中已有值时优先使用 envs 中的值")
 }

--- a/util/agent_test.go
+++ b/util/agent_test.go
@@ -1,0 +1,145 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func collectAgentEnvs() []string {
+	envs := make([]string, 0, len(knownAgentEnv)+1)
+	envs = append(envs, agentEnvProposal)
+	for _, item := range knownAgentEnv {
+		envs = append(envs, item.env)
+	}
+	return envs
+}
+
+var allAgentEnvs = collectAgentEnvs()
+
+func snapshotAndUnsetAgentEnvs(t *testing.T) {
+	t.Helper()
+	saved := make(map[string]string, len(allAgentEnvs))
+	for _, k := range allAgentEnvs {
+		if v, ok := os.LookupEnv(k); ok {
+			saved[k] = v
+		}
+		_ = os.Unsetenv(k)
+	}
+	t.Cleanup(func() {
+		for _, k := range allAgentEnvs {
+			_ = os.Unsetenv(k)
+		}
+		for k, v := range saved {
+			_ = os.Setenv(k, v)
+		}
+	})
+}
+
+func TestDetectAgentName_NoEnv(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	assert.Equal(t, "", DetectAgentName())
+	assert.Equal(t, "", GetAgentUserAgentSegment())
+}
+
+func TestDetectAgentName_KnownEnvs(t *testing.T) {
+	for _, c := range knownAgentEnv {
+		t.Run(c.env, func(t *testing.T) {
+			snapshotAndUnsetAgentEnvs(t)
+			_ = os.Setenv(c.env, "1")
+			assert.Equal(t, c.name, DetectAgentName())
+			assert.Equal(t, "agent/"+c.name, GetAgentUserAgentSegment())
+		})
+	}
+}
+
+func TestDetectAgentName_EmptyValueIgnored(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv("CURSOR_AGENT", "")
+	assert.Equal(t, "", DetectAgentName())
+}
+
+func TestDetectAgentName_ProposalAgentEnvWins(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv(agentEnvProposal, "Goose")
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	assert.Equal(t, "goose", DetectAgentName())
+}
+
+func TestDetectAgentName_ProposalSanitize(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv(agentEnvProposal, "  My-Agent.v1_x  ")
+	assert.Equal(t, "my-agent.v1_x", DetectAgentName())
+}
+
+func TestDetectAgentName_ProposalRejectsAllInvalidChars(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv(agentEnvProposal, "$$$ ###")
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	assert.Equal(t, "cursor", DetectAgentName(),
+		"完全无效的 AGENT 值应回退到专有变量")
+}
+
+func TestDetectAgentName_ProposalTruncated(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	long := "abcdefghij1234567890ABCDEFGHIJ-_.zzzzz"
+	_ = os.Setenv(agentEnvProposal, long)
+	got := DetectAgentName()
+	assert.LessOrEqual(t, len(got), maxAgentNameLen)
+}
+
+func TestDetectAgentName_PriorityOrder(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv("CLAUDECODE", "1")
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	assert.Equal(t, "cursor", DetectAgentName(),
+		"CURSOR_AGENT 在表中靠前，应优先返回")
+}
+
+func TestMergeAgentSegmentIntoPluginEnvs_NoAgent(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	envs := map[string]string{}
+	MergeAgentSegmentIntoPluginEnvs(envs)
+	_, ok := envs[envCustomUserAgent]
+	assert.False(t, ok, "未检测到 agent 时不应写入任何 env")
+}
+
+func TestMergeAgentSegmentIntoPluginEnvs_NilMap(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	assert.NotPanics(t, func() {
+		MergeAgentSegmentIntoPluginEnvs(nil)
+	})
+}
+
+func TestMergeAgentSegmentIntoPluginEnvs_FreshEnv(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Unsetenv(envCustomUserAgent)
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	envs := map[string]string{}
+	MergeAgentSegmentIntoPluginEnvs(envs)
+	assert.Equal(t, "agent/cursor", envs[envCustomUserAgent])
+}
+
+func TestMergeAgentSegmentIntoPluginEnvs_PreservesParentEnv(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	t.Setenv(envCustomUserAgent, "skill/foo")
+	envs := map[string]string{}
+	MergeAgentSegmentIntoPluginEnvs(envs)
+	assert.Equal(t, "skill/foo agent/cursor", envs[envCustomUserAgent],
+		"已 export 的 ALIBABA_CLOUD_USER_AGENT 必须保留并在末尾追加 agent 段")
+}
+
+func TestMergeAgentSegmentIntoPluginEnvs_RuntimeEnvWinsOverParent(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	t.Setenv(envCustomUserAgent, "from-parent")
+	envs := map[string]string{
+		envCustomUserAgent: "from-runtime",
+	}
+	MergeAgentSegmentIntoPluginEnvs(envs)
+	assert.Equal(t, "from-runtime agent/cursor", envs[envCustomUserAgent],
+		"envs 中已有值时优先使用 envs 中的值")
+}

--- a/util/util.go
+++ b/util/util.go
@@ -137,6 +137,9 @@ func GetAliyunCliUserAgent() string {
 	if vendorEnv, ok := os.LookupEnv("ALIBABA_CLOUD_VENDOR"); ok {
 		ua += " vendor/" + vendorEnv
 	}
+	if seg := GetAgentUserAgentSegment(); seg != "" {
+		ua += " " + seg
+	}
 	if custom := GetFromEnv("ALIBABA_CLOUD_USER_AGENT"); custom != "" {
 		ua += " " + SanitizeUserAgent(custom)
 	}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -723,7 +723,7 @@ func TestGetAliyunCliUserAgent(t *testing.T) {
 		ua := GetAliyunCliUserAgent()
 
 		assert.Contains(t, ua, "Aliyun-CLI/")
-		assert.Contains(t, ua, "agent/cursor")
+		assert.Contains(t, ua, "Agent/cursor")
 	})
 
 	t.Run("agent segment placed between vendor and custom UA", func(t *testing.T) {
@@ -735,9 +735,9 @@ func TestGetAliyunCliUserAgent(t *testing.T) {
 		ua := GetAliyunCliUserAgent()
 
 		idxVendor := strings.Index(ua, "vendor/")
-		idxAgent := strings.Index(ua, "agent/")
+		idxAgent := strings.Index(ua, "Agent/")
 		idxSkill := strings.Index(ua, "skill/")
 		assert.True(t, idxVendor >= 0 && idxAgent > idxVendor && idxSkill > idxAgent,
-			"顺序应为 vendor/ → agent/ → skill/，实际：%s", ua)
+			"顺序应为 vendor/ → Agent/ → skill/，实际：%s", ua)
 	})
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -610,6 +610,9 @@ func TestGetAliyunCliUserAgent(t *testing.T) {
 		}
 	}()
 
+	// 隔离 Agent 检测相关 env，避免运行环境（如 CURSOR_AGENT=1）影响断言。
+	snapshotAndUnsetAgentEnvs(t)
+
 	t.Run("without vendor environment variable", func(t *testing.T) {
 		os.Unsetenv("ALIBABA_CLOUD_VENDOR")
 		os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
@@ -709,5 +712,32 @@ func TestGetAliyunCliUserAgent(t *testing.T) {
 		ua2 := GetAliyunCliUserAgent()
 
 		assert.Equal(t, ua1, ua2)
+	})
+
+	t.Run("with agent env appends agent segment", func(t *testing.T) {
+		snapshotAndUnsetAgentEnvs(t)
+		os.Unsetenv("ALIBABA_CLOUD_VENDOR")
+		os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
+		os.Setenv("CURSOR_AGENT", "1")
+
+		ua := GetAliyunCliUserAgent()
+
+		assert.Contains(t, ua, "Aliyun-CLI/")
+		assert.Contains(t, ua, "agent/cursor")
+	})
+
+	t.Run("agent segment placed between vendor and custom UA", func(t *testing.T) {
+		snapshotAndUnsetAgentEnvs(t)
+		os.Setenv("ALIBABA_CLOUD_VENDOR", "v1")
+		os.Setenv("ALIBABA_CLOUD_USER_AGENT", "skill/x")
+		os.Setenv("CURSOR_AGENT", "1")
+
+		ua := GetAliyunCliUserAgent()
+
+		idxVendor := strings.Index(ua, "vendor/")
+		idxAgent := strings.Index(ua, "agent/")
+		idxSkill := strings.Index(ua, "skill/")
+		assert.True(t, idxVendor >= 0 && idxAgent > idxVendor && idxSkill > idxAgent,
+			"顺序应为 vendor/ → agent/ → skill/，实际：%s", ua)
 	})
 }


### PR DESCRIPTION
**Description**

Add a fixed `agent/<name>` segment enum to `User-Agent` when the CLI runs inside an AI coding agent.


