### PR TITLE
{Misc} Add `--name` and update version check message for `plugin install` and adjust agent detection

### DIFF
--- a/cli/plugin/command.go
+++ b/cli/plugin/command.go
@@ -262,7 +262,7 @@ func newInstallCommand() *cli.Command {
 	cmd := &cli.Command{
 		Name:  "install",
 		Short: i18n.T("Install a plugin (from remote index or package file/URL)", "安装插件（远程索引或指定包文件/URL）"),
-		Usage: "install [--source-base <url>] --names <plugin_name> [<plugin2> ...] [--version <version>] [--enable-pre] | install --package <path-or-url>",
+		Usage: "install [--source-base <url>] (--name <plugin_name> | --names <plugin1> [<plugin2> ...]) [--version <version>] [--enable-pre] | install --package <path-or-url>",
 		Run: func(ctx *cli.Context, args []string) error {
 			names, pkgRef, version, enablePre, err := parseInstallArgs(ctx)
 			if err != nil {
@@ -278,6 +278,12 @@ func newInstallCommand() *cli.Command {
 		},
 	}
 
+	cmd.Flags().Add(&cli.Flag{
+		Name:         "name",
+		Short:        i18n.T("Plugin name to install (single plugin)", "要安装的单个插件名称"),
+		AssignedMode: cli.AssignedOnce,
+	})
+
 	namesFlag := &cli.Flag{
 		Name:         "names",
 		Short:        i18n.T("Plugin name(s) to install (can specify one or multiple)", "要安装的插件名称（可指定一个或多个）"),
@@ -287,7 +293,7 @@ func newInstallCommand() *cli.Command {
 
 	cmd.Flags().Add(&cli.Flag{
 		Name:         "version",
-		Short:        i18n.T("Specify plugin version when installing from the remote index (--names)", "使用 --names 从远程索引安装时指定插件版本"),
+		Short:        i18n.T("Specify plugin version when installing from the remote index (--name/--names)", "使用 --name/--names 从远程索引安装时指定插件版本"),
 		AssignedMode: cli.AssignedOnce,
 		DefaultValue: "",
 	})
@@ -420,8 +426,23 @@ func newUpdateCommand() *cli.Command {
 }
 
 func parseInstallArgs(ctx *cli.Context) (names []string, pkgRef string, version string, enablePre bool, err error) {
-	if namesFlag := ctx.Flags().Get("names"); namesFlag != nil && namesFlag.IsAssigned() {
-		names = namesFlag.GetValues()
+	nameFlag := ctx.Flags().Get("name")
+	namesFlag := ctx.Flags().Get("names")
+	nameAssigned := nameFlag != nil && nameFlag.IsAssigned()
+	namesAssigned := namesFlag != nil && namesFlag.IsAssigned()
+
+	if nameAssigned && namesAssigned {
+		return nil, "", "", false, fmt.Errorf("--name and --names cannot be used together")
+	}
+
+	if nameAssigned {
+		if v, ok := nameFlag.GetValue(); ok {
+			names = append(names, v)
+		}
+	}
+
+	if namesAssigned {
+		names = append(names, namesFlag.GetValues()...)
 	}
 
 	if f := ctx.Flags().Get("package"); f != nil && f.IsAssigned() {
@@ -444,13 +465,13 @@ func parseInstallArgs(ctx *cli.Context) (names []string, pkgRef string, version 
 func validateInstallArgs(names []string, pkgRef string) ([]string, error) {
 	if strings.TrimSpace(pkgRef) != "" {
 		if len(names) > 0 {
-			return nil, fmt.Errorf("--names cannot be used together with --package")
+			return nil, fmt.Errorf("--name/--names cannot be used together with --package")
 		}
 		return nil, nil
 	}
 
 	if len(names) == 0 {
-		return nil, fmt.Errorf("either --names or --package is required")
+		return nil, fmt.Errorf("either --name/--names or --package is required")
 	}
 
 	validNames := []string{}
@@ -460,7 +481,7 @@ func validateInstallArgs(names []string, pkgRef string) ([]string, error) {
 		}
 	}
 	if len(validNames) == 0 {
-		return nil, fmt.Errorf("--names requires at least one plugin name")
+		return nil, fmt.Errorf("--name/--names requires at least one plugin name")
 	}
 	return validNames, nil
 }

--- a/cli/plugin/command_test.go
+++ b/cli/plugin/command_test.go
@@ -256,6 +256,10 @@ func TestNewInstallCommand(t *testing.T) {
 	assert.NotEmpty(t, cmd.Usage)
 
 	flags := cmd.Flags()
+	nameFlag := flags.Get("name")
+	assert.NotNil(t, nameFlag)
+	assert.False(t, nameFlag.Required)
+
 	namesFlag := flags.Get("names")
 	assert.NotNil(t, namesFlag)
 	assert.False(t, namesFlag.Required)
@@ -311,6 +315,82 @@ func TestNewInstallCommand_Run_WithNamesFlag(t *testing.T) {
 	assert.Contains(t, err.Error(), "nonexistent-plugin-xyz-123 not found")
 }
 
+func TestNewInstallCommand_Run_WithNameFlag(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	nameFlag := ctx.Flags().Get("name")
+	assert.NotNil(t, nameFlag)
+	nameFlag.SetAssigned(true)
+	nameFlag.SetValue("nonexistent-plugin-xyz-456")
+
+	err := cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-plugin-xyz-456 not found")
+}
+
+func TestNewInstallCommand_Run_NameAndNamesConflict(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	nameFlag := ctx.Flags().Get("name")
+	assert.NotNil(t, nameFlag)
+	nameFlag.SetAssigned(true)
+	nameFlag.SetValue("plugin-from-name")
+
+	namesFlag := ctx.Flags().Get("names")
+	assert.NotNil(t, namesFlag)
+	namesFlag.SetAssigned(true)
+	namesFlag.SetValues([]string{"plugin-from-names-1", "plugin-from-names-2"})
+
+	err := cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--name and --names cannot be used together")
+}
+
+func TestNewInstallCommand_Run_NameAndPackageConflict(t *testing.T) {
+	cmd := newInstallCommand()
+
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	nameFlag := ctx.Flags().Get("name")
+	assert.NotNil(t, nameFlag)
+	nameFlag.SetAssigned(true)
+	nameFlag.SetValue("some-plugin")
+
+	pkgFlag := ctx.Flags().Get("package")
+	assert.NotNil(t, pkgFlag)
+	pkgFlag.SetAssigned(true)
+	pkgFlag.SetValue("/tmp/x.zip")
+
+	err := cmd.Run(ctx, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--name/--names cannot be used together with --package")
+}
+
 func TestNewInstallCommand_Run_WithNamesAndVersionFlags(t *testing.T) {
 	cmd := newInstallCommand()
 
@@ -357,7 +437,7 @@ func TestNewInstallCommand_Run_WithVersionFlagOnly(t *testing.T) {
 
 	err := cmd.Run(ctx, []string{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "either --names or --package is required")
+	assert.Contains(t, err.Error(), "either --name/--names or --package is required")
 }
 
 func TestNewInstallCommand_Run_WithNamesAndEnablePreFlags(t *testing.T) {

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -318,6 +318,21 @@ func isDevVersion(version string) bool {
 	return strings.Contains(lowerVersion, "-dev") || strings.Contains(lowerVersion, "dev")
 }
 
+// cliSelfUpgradeMinVersion 是 `aliyun upgrade` 子命令首次可用的 CLI 版本。
+// 低于该版本的 CLI 不存在自升级能力，需要回退到 brew/官方下载页面提示。
+const cliSelfUpgradeMinVersion = "3.3.5"
+
+// 当 currentVersion >= 3.3.5 时优先推荐 `aliyun upgrade` 一键升级，
+// 否则保留原 brew / GitHub Releases 的兜底说明。
+func buildCliUpgradeTip(currentVersion string) string {
+	if !isDevVersion(currentVersion) && compareVersion(currentVersion, cliSelfUpgradeMinVersion) >= 0 {
+		return "Please upgrade the CLI by running: aliyun upgrade\n" +
+			"Or download the latest version from: https://github.com/aliyun/aliyun-cli/releases"
+	}
+	return "Please upgrade the CLI by running: brew upgrade aliyun-cli\n" +
+		"Or download the latest version from: https://github.com/aliyun/aliyun-cli/releases"
+}
+
 // Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if v1 == v2
 func compareVersion(v1, v2 string) int {
 	// Ensure versions have 'v' prefix for semver library
@@ -461,13 +476,12 @@ func (m *Manager) validateVersionAndPlatform(ctx *cli.Context, targetPlugin *Plu
 				verInfo.Metadata.MinCliVersion)
 		} else if compareVersion(currentVersion, verInfo.Metadata.MinCliVersion) < 0 {
 			return nil, fmt.Errorf(
-				"plugin %s version %s requires CLI version %s or higher, but you have %s\n"+
-					"Please upgrade the CLI by running: brew upgrade aliyun-cli\n"+
-					"Or download the latest version from: https://github.com/aliyun/aliyun-cli/releases",
+				"plugin %s version %s requires CLI version %s or higher, but you have %s\n%s",
 				actualPluginName,
 				version,
 				verInfo.Metadata.MinCliVersion,
 				currentVersion,
+				buildCliUpgradeTip(currentVersion),
 			)
 		}
 	}

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -158,7 +158,7 @@ func TestNewInstallCommand_Run_NamesAndSourceConflict(t *testing.T) {
 
 	err := cmd.Run(ctx, []string{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "--names cannot be used together with --package")
+	assert.Contains(t, err.Error(), "--name/--names cannot be used together with --package")
 }
 
 func TestNewInstallCommand_Run_WithPackageFlagSuccess(t *testing.T) {

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -1215,14 +1215,14 @@ func TestValidateVersionAndPlatform_VersionCheck(t *testing.T) {
 		}
 	})
 
-	t.Run("Error - current version lower than required", func(t *testing.T) {
+	t.Run("Error - current version lower than required (legacy CLI suggests brew)", func(t *testing.T) {
 		cli.Version = "3.1.0"
 		targetPlugin := &PluginInfo{
 			Name: "test-plugin",
 			Versions: map[string]VersionInfo{
 				"1.0.0": {
 					Metadata: &VersionMetadata{
-						MinCliVersion: "3.2.0",
+						MinCliVersion: "3.4.0",
 					},
 					Platforms: map[string]PlatformInfo{
 						currentPlatform: {
@@ -1239,9 +1239,41 @@ func TestValidateVersionAndPlatform_VersionCheck(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, platInfo)
 		assert.Contains(t, err.Error(), "requires CLI version")
-		assert.Contains(t, err.Error(), "3.2.0")
+		assert.Contains(t, err.Error(), "3.4.0")
 		assert.Contains(t, err.Error(), "3.1.0")
-		assert.Contains(t, err.Error(), "brew upgrade")
+		assert.Contains(t, err.Error(), "brew upgrade aliyun-cli")
+		assert.NotContains(t, err.Error(), "aliyun upgrade\n")
+		assert.Contains(t, err.Error(), "github.com/aliyun/aliyun-cli/releases")
+	})
+
+	t.Run("Error - current version >= 3.3.5 suggests aliyun upgrade", func(t *testing.T) {
+		cli.Version = "3.3.5"
+		targetPlugin := &PluginInfo{
+			Name: "test-plugin",
+			Versions: map[string]VersionInfo{
+				"1.0.0": {
+					Metadata: &VersionMetadata{
+						MinCliVersion: "3.4.0",
+					},
+					Platforms: map[string]PlatformInfo{
+						currentPlatform: {
+							URL:      "http://example.com/plugin.tar.gz",
+							Checksum: "abc123",
+						},
+					},
+				},
+			},
+		}
+
+		ctx := newTestContext()
+		platInfo, err := mgr.validateVersionAndPlatform(ctx, targetPlugin, "1.0.0", "test-plugin")
+		assert.NotNil(t, err)
+		assert.Nil(t, platInfo)
+		assert.Contains(t, err.Error(), "requires CLI version")
+		assert.Contains(t, err.Error(), "3.4.0")
+		assert.Contains(t, err.Error(), "3.3.5")
+		assert.Contains(t, err.Error(), "aliyun upgrade")
+		assert.NotContains(t, err.Error(), "brew upgrade")
 		assert.Contains(t, err.Error(), "github.com/aliyun/aliyun-cli/releases")
 	})
 

--- a/util/agent.go
+++ b/util/agent.go
@@ -36,14 +36,14 @@ var knownAgentEnv = []struct {
 
 // Agent 标识（小写、固定枚举或 sanitize 后的 AGENT 值）；
 func DetectAgentName() string {
-	if v := strings.TrimSpace(os.Getenv(agentEnvProposal)); v != "" {
-		if s := sanitizeAgentName(v); s != "" {
-			return s
-		}
-	}
 	for _, item := range knownAgentEnv {
 		if os.Getenv(item.env) != "" {
 			return item.name
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv(agentEnvProposal)); v != "" {
+		if s := sanitizeAgentName(v); s != "" {
+			return s
 		}
 	}
 	return ""

--- a/util/agent_test.go
+++ b/util/agent_test.go
@@ -60,10 +60,17 @@ func TestDetectAgentName_EmptyValueIgnored(t *testing.T) {
 	assert.Equal(t, "", DetectAgentName())
 }
 
-func TestDetectAgentName_ProposalAgentEnvWins(t *testing.T) {
+func TestDetectAgentName_SpecificEnvWinsOverProposal(t *testing.T) {
+	snapshotAndUnsetAgentEnvs(t)
+	_ = os.Setenv(agentEnvProposal, "goose")
+	_ = os.Setenv("CURSOR_AGENT", "1")
+	assert.Equal(t, "cursor", DetectAgentName(),
+		"专有变量应优先于 AGENT 提案变量（避免类似 OpenCode 同时设两者时丢失具体名）")
+}
+
+func TestDetectAgentName_ProposalUsedWhenNoSpecific(t *testing.T) {
 	snapshotAndUnsetAgentEnvs(t)
 	_ = os.Setenv(agentEnvProposal, "Goose")
-	_ = os.Setenv("CURSOR_AGENT", "1")
 	assert.Equal(t, "goose", DetectAgentName())
 }
 
@@ -73,12 +80,11 @@ func TestDetectAgentName_ProposalSanitize(t *testing.T) {
 	assert.Equal(t, "my-agent.v1_x", DetectAgentName())
 }
 
-func TestDetectAgentName_ProposalRejectsAllInvalidChars(t *testing.T) {
+func TestDetectAgentName_ProposalAllInvalidCharsReturnsEmpty(t *testing.T) {
 	snapshotAndUnsetAgentEnvs(t)
 	_ = os.Setenv(agentEnvProposal, "$$$ ###")
-	_ = os.Setenv("CURSOR_AGENT", "1")
-	assert.Equal(t, "cursor", DetectAgentName(),
-		"完全无效的 AGENT 值应回退到专有变量")
+	assert.Equal(t, "", DetectAgentName(),
+		"完全无效的 AGENT 值经 sanitize 后为空；无专有变量兜底时返回空")
 }
 
 func TestDetectAgentName_ProposalTruncated(t *testing.T) {


### PR DESCRIPTION
**Description**

Adds a singular `--name <plugin>` flag to align with `uninstall / show / update`. 

When a plugin requires a newer CLI than installed, the error now recommends `aliyun upgrade` for users on CLI ≥ 3.3.5 (where the self-upgrade subcommand is available), and falls back to the existing `brew upgrade aliyun-cli` / GitHub Releases hint for older CLIs.

Detect specific agent envs before the generic `AGENT` env
