### PR TITLE
feat: add codeup-cli subcommand for migrating third-party code repos …

### DIFF
--- a/cliext/codeup/codeup.go
+++ b/cliext/codeup/codeup.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -334,11 +335,29 @@ func (c *Context) ExecuteCodeupCli(args []string) error {
 	cmd.Stdout = c.originCtx.Stdout()
 	cmd.Stderr = c.originCtx.Stderr()
 	cmd.Stdin = os.Stdin
+	cmd.Env = buildSubprocessEnv(os.Environ(), map[string]string{
+		"ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE": "aliyun codeup-cli",
+	})
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to execute %s: %v", c.execFilePath, err)
 	}
 	return nil
+}
+
+func buildSubprocessEnv(base []string, overrides map[string]string) []string {
+	result := make([]string, 0, len(base)+len(overrides))
+	for _, item := range base {
+		key, _, _ := strings.Cut(item, "=")
+		if _, conflict := overrides[key]; conflict {
+			continue
+		}
+		result = append(result, item)
+	}
+	for k, v := range overrides {
+		result = append(result, k+"="+v)
+	}
+	return result
 }
 
 func fileExists(path string) bool {

--- a/cliext/codeup/codeup.go
+++ b/cliext/codeup/codeup.go
@@ -1,0 +1,347 @@
+package codeup
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/openapi"
+)
+
+type Context struct {
+	originCtx          *cli.Context
+	configPath         string
+	execFilePath       string
+	installed          bool
+	osType             string
+	osArch             string
+	osSupport          bool
+	downloadPathSuffix string
+}
+
+var getConfigurePathFunc = func() string {
+	return config.GetConfigPath()
+}
+
+var (
+	downloadAndExtractFunc = DownloadAndExtract
+	execCommandFunc        = exec.Command
+	runtimeGOOSFunc        = func() string { return runtime.GOOS }
+	runtimeGOARCHFunc      = func() string { return runtime.GOARCH }
+)
+
+const (
+	codeupCliBaseUrl   = "https://codeuputil.oss-cn-hangzhou.aliyuncs.com/current/"
+	maxDownloadSize    = 100 * 1024 * 1024 // 100MB
+	maxExtractFileSize = 200 * 1024 * 1024 // 200MB
+)
+
+var httpClient = &http.Client{Timeout: 5 * time.Minute}
+
+var platformArchMap = map[string]string{
+	"darwin-amd64":  "macOS-64",
+	"darwin-arm64":  "macOS-arm64",
+	"linux-386":     "Linux-32",
+	"linux-amd64":   "Linux-64",
+	"linux-arm64":   "Linux-64-arm64",
+	"windows-386":   "Windows-32",
+	"windows-amd64": "Windows-64",
+}
+
+func NewContext(originContext *cli.Context) *Context {
+	return &Context{
+		originCtx: originContext,
+	}
+}
+
+func (c *Context) Run(args []string) error {
+	c.InitBasicInfo()
+	c.CheckOsTypeAndArch()
+	if !c.osSupport {
+		return fmt.Errorf("your os type %s and arch %s is not supported now", c.osType, c.osArch)
+	}
+
+	if !c.installed {
+		err := c.Install()
+		if err != nil {
+			return err
+		}
+	}
+
+	newArgs, err := c.RemoveFlagsForMainCli(args)
+	if err != nil {
+		return err
+	}
+
+	return c.ExecuteCodeupCli(newArgs)
+}
+
+func (c *Context) InitBasicInfo() {
+	c.configPath = getConfigurePathFunc()
+	c.execFilePath = filepath.Join(c.configPath, "codeup-cli")
+	if runtimeGOOSFunc() == "windows" {
+		c.execFilePath += ".exe"
+	}
+	c.installed = fileExists(c.execFilePath)
+}
+
+func (c *Context) CheckOsTypeAndArch() {
+	c.osType = runtimeGOOSFunc()
+	c.osArch = runtimeGOARCHFunc()
+
+	key := c.osType + "-" + c.osArch
+	suffix, ok := platformArchMap[key]
+	if !ok {
+		c.osSupport = false
+		return
+	}
+
+	c.osSupport = true
+	c.downloadPathSuffix = fmt.Sprintf("codeup-cli-%s.zip", suffix)
+}
+
+func (c *Context) Install() error {
+	url := codeupCliBaseUrl + c.downloadPathSuffix
+
+	tmpDir := os.TempDir()
+	tmpFile := filepath.Join(tmpDir, "codeup-cli_download.zip")
+
+	if fileExists(tmpFile) {
+		_ = os.Remove(tmpFile)
+	}
+
+	err := downloadAndExtractFunc(url, tmpFile, c.execFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to download and extract codeup-cli from %s: %v", url, err)
+	}
+	c.installed = true
+	return nil
+}
+
+func DownloadAndExtract(url string, destFile string, exeFilePath string) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for %s: %v", url, err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: status code %d", url, resp.StatusCode)
+	}
+
+	out, err := os.Create(destFile)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %v", destFile, err)
+	}
+
+	written, err := io.Copy(out, io.LimitReader(resp.Body, int64(maxDownloadSize)+1))
+	if err != nil {
+		_ = out.Close()
+		_ = os.Remove(destFile)
+		return fmt.Errorf("failed to write to file %s: %v", destFile, err)
+	}
+	if written > int64(maxDownloadSize) {
+		_ = out.Close()
+		_ = os.Remove(destFile)
+		return fmt.Errorf("download size exceeds limit of %d bytes", maxDownloadSize)
+	}
+	if err = out.Close(); err != nil {
+		_ = os.Remove(destFile)
+		return fmt.Errorf("failed to close file %s: %v", destFile, err)
+	}
+
+	err = extractZip(destFile, exeFilePath)
+	if err != nil {
+		_ = os.Remove(destFile)
+		return err
+	}
+
+	_ = os.Remove(destFile)
+	return nil
+}
+
+func extractZip(zipPath string, exeFilePath string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to open zip %s: %v", zipPath, err)
+	}
+	defer r.Close()
+
+	targetName := "codeup-cli"
+	if runtimeGOOSFunc() == "windows" {
+		targetName = "codeup-cli.exe"
+	}
+
+	for _, file := range r.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		if file.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		baseName := filepath.Base(file.Name)
+		if baseName != targetName {
+			continue
+		}
+
+		if file.UncompressedSize64 > uint64(maxExtractFileSize) {
+			return fmt.Errorf("file size exceeds limit of %d bytes", maxExtractFileSize)
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return fmt.Errorf("failed to open file in zip: %v", err)
+		}
+
+		if fileExists(exeFilePath) {
+			_ = os.Remove(exeFilePath)
+		}
+
+		outFile, err := os.OpenFile(exeFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+		if err != nil {
+			_ = rc.Close()
+			return fmt.Errorf("failed to create file %s: %v", exeFilePath, err)
+		}
+
+		_, err = io.Copy(outFile, io.LimitReader(rc, int64(maxExtractFileSize)+1))
+		_ = rc.Close()
+		if err != nil {
+			_ = outFile.Close()
+			_ = os.Remove(exeFilePath)
+			return fmt.Errorf("failed to extract file: %v", err)
+		}
+		if err = outFile.Close(); err != nil {
+			_ = os.Remove(exeFilePath)
+			return fmt.Errorf("failed to close file %s: %v", exeFilePath, err)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("codeup-cli binary not found in zip archive")
+}
+
+var stripFlags = map[string]bool{
+	"profile":                        true,
+	"mode":                           true,
+	"sts-region":                     true,
+	"ram-role-name":                  true,
+	"ram-role-arn":                   true,
+	"role-session-name":              true,
+	"external-id":                    true,
+	"source-profile":                 true,
+	"private-key":                    true,
+	"key-pair-name":                  true,
+	"expired-seconds":                true,
+	"process-command":                true,
+	"oidc-provider-arn":              true,
+	"oidc-token-file":                true,
+	"cloud-sso-sign-in-url":          true,
+	"cloud-sso-access-config":        true,
+	"cloud-sso-account-id":           true,
+	"oauth-site-type":                true,
+	"external-account-type":          true,
+	"auto-plugin-install":            true,
+	"auto-plugin-install-enable-pre": true,
+	"config-path":                    true,
+	"read-timeout":                   true,
+	"connect-timeout":                true,
+	"retry-count":                    true,
+	"skip-secure-verify":             true,
+	"endpoint-type":                  true,
+	"RegionId":                       true,
+	"secure":                         true,
+	"insecure":                       true,
+	"header":                         true,
+	"pager":                          true,
+	"accept":                         true,
+	"waiter":                         true,
+	"dryrun":                         true,
+	"quiet":                          true,
+	"yes":                            true,
+	"cli-query":                      true,
+	"roa":                            true,
+	"method":                         true,
+	"user-agent":                     true,
+	"cli-ai-mode":                    true,
+	"no-cli-ai-mode":                 true,
+}
+
+func (c *Context) RemoveFlagsForMainCli(args []string) ([]string, error) {
+	allFlags := cli.NewFlagSet()
+	config.AddFlags(allFlags)
+	openapi.AddFlags(allFlags)
+
+	longNeedsValue := make(map[string]bool)
+	shortNeedsValue := make(map[string]bool)
+	for _, f := range allFlags.Flags() {
+		if !stripFlags[f.Name] {
+			continue
+		}
+		needsValue := f.AssignedMode != cli.AssignedNone
+		if f.Name != "" {
+			longNeedsValue["--"+f.Name] = needsValue
+		}
+		for _, alias := range f.Aliases {
+			longNeedsValue["--"+alias] = needsValue
+		}
+		if f.Shorthand != 0 {
+			shortNeedsValue["-"+string(f.Shorthand)] = needsValue
+		}
+	}
+
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		argName := a
+		hasInlineValue := false
+		if prefix, _, ok := cli.SplitStringWithPrefix(a, "=:"); ok {
+			argName = prefix
+			hasInlineValue = true
+		}
+		if needs, ok := longNeedsValue[argName]; ok {
+			if needs && !hasInlineValue && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		if needs, ok := shortNeedsValue[argName]; ok {
+			if needs && !hasInlineValue && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func (c *Context) ExecuteCodeupCli(args []string) error {
+	cmd := execCommandFunc(c.execFilePath, args...)
+	cmd.Stdout = c.originCtx.Stdout()
+	cmd.Stderr = c.originCtx.Stderr()
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute %s: %v", c.execFilePath, err)
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cliext/codeup/codeup_test.go
+++ b/cliext/codeup/codeup_test.go
@@ -1,0 +1,163 @@
+package codeup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckOsTypeAndArch(t *testing.T) {
+	tests := []struct {
+		name       string
+		goos       string
+		goarch     string
+		wantSupp   bool
+		wantSuffix string
+	}{
+		{"darwin-arm64", "darwin", "arm64", true, "codeup-cli-macOS-arm64.zip"},
+		{"darwin-amd64", "darwin", "amd64", true, "codeup-cli-macOS-64.zip"},
+		{"linux-amd64", "linux", "amd64", true, "codeup-cli-Linux-64.zip"},
+		{"linux-arm64", "linux", "arm64", true, "codeup-cli-Linux-64-arm64.zip"},
+		{"linux-386", "linux", "386", true, "codeup-cli-Linux-32.zip"},
+		{"windows-amd64", "windows", "amd64", true, "codeup-cli-Windows-64.zip"},
+		{"windows-386", "windows", "386", true, "codeup-cli-Windows-32.zip"},
+		{"unsupported-os", "freebsd", "amd64", false, ""},
+		{"unsupported-arch", "linux", "mips", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origGOOS := runtimeGOOSFunc
+			origGOARCH := runtimeGOARCHFunc
+			defer func() {
+				runtimeGOOSFunc = origGOOS
+				runtimeGOARCHFunc = origGOARCH
+			}()
+			runtimeGOOSFunc = func() string { return tt.goos }
+			runtimeGOARCHFunc = func() string { return tt.goarch }
+
+			c := &Context{}
+			c.CheckOsTypeAndArch()
+
+			if c.osSupport != tt.wantSupp {
+				t.Errorf("osSupport = %v, want %v", c.osSupport, tt.wantSupp)
+			}
+			if c.downloadPathSuffix != tt.wantSuffix {
+				t.Errorf("downloadPathSuffix = %q, want %q", c.downloadPathSuffix, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestInitBasicInfo(t *testing.T) {
+	tmpDir := t.TempDir()
+	origGetPath := getConfigurePathFunc
+	origGOOS := runtimeGOOSFunc
+	defer func() {
+		getConfigurePathFunc = origGetPath
+		runtimeGOOSFunc = origGOOS
+	}()
+	getConfigurePathFunc = func() string { return tmpDir }
+	runtimeGOOSFunc = func() string { return "linux" }
+
+	c := &Context{}
+	c.InitBasicInfo()
+
+	expectedPath := filepath.Join(tmpDir, "codeup-cli")
+	if c.execFilePath != expectedPath {
+		t.Errorf("execFilePath = %q, want %q", c.execFilePath, expectedPath)
+	}
+	if c.installed {
+		t.Errorf("installed should be false when binary doesn't exist")
+	}
+
+	// create a fake binary
+	_ = os.WriteFile(expectedPath, []byte("fake"), 0755)
+	c.InitBasicInfo()
+	if !c.installed {
+		t.Errorf("installed should be true when binary exists")
+	}
+}
+
+func TestInitBasicInfoWindows(t *testing.T) {
+	tmpDir := t.TempDir()
+	origGetPath := getConfigurePathFunc
+	origGOOS := runtimeGOOSFunc
+	defer func() {
+		getConfigurePathFunc = origGetPath
+		runtimeGOOSFunc = origGOOS
+	}()
+	getConfigurePathFunc = func() string { return tmpDir }
+	runtimeGOOSFunc = func() string { return "windows" }
+
+	c := &Context{}
+	c.InitBasicInfo()
+
+	expectedPath := filepath.Join(tmpDir, "codeup-cli.exe")
+	if c.execFilePath != expectedPath {
+		t.Errorf("execFilePath = %q, want %q", c.execFilePath, expectedPath)
+	}
+}
+
+func TestRemoveFlagsForMainCli(t *testing.T) {
+	c := &Context{}
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			"no flags to strip",
+			[]string{"import", "--run", "true"},
+			[]string{"import", "--run", "true"},
+		},
+		{
+			"strip profile flag",
+			[]string{"import", "--profile", "default", "--run", "true"},
+			[]string{"import", "--run", "true"},
+		},
+		{
+			"strip multiple flags",
+			[]string{"--profile", "test", "status", "--quiet"},
+			[]string{"status"},
+		},
+		{
+			"empty args",
+			[]string{},
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.RemoveFlagsForMainCli(tt.args)
+			if err != nil {
+				t.Fatalf("RemoveFlagsForMainCli error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	existingFile := filepath.Join(tmpDir, "exists")
+	_ = os.WriteFile(existingFile, []byte("data"), 0644)
+
+	if !fileExists(existingFile) {
+		t.Errorf("fileExists should return true for existing file")
+	}
+	if fileExists(filepath.Join(tmpDir, "nonexistent")) {
+		t.Errorf("fileExists should return false for non-existing file")
+	}
+}

--- a/cliext/codeup/codeup_test.go
+++ b/cliext/codeup/codeup_test.go
@@ -148,6 +148,45 @@ func TestRemoveFlagsForMainCli(t *testing.T) {
 	}
 }
 
+func TestBuildSubprocessEnv(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE=stale",
+		"HOME=/home/u",
+	}
+	overrides := map[string]string{
+		"ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE": "aliyun codeup-cli",
+	}
+
+	got := buildSubprocessEnv(base, overrides)
+
+	seenIntegration := 0
+	seenPath := false
+	seenHome := false
+	var integrationValue string
+	for _, item := range got {
+		switch {
+		case item == "PATH=/usr/bin":
+			seenPath = true
+		case item == "HOME=/home/u":
+			seenHome = true
+		case len(item) > len("ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE=") &&
+			item[:len("ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE=")] == "ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE=":
+			seenIntegration++
+			integrationValue = item[len("ALIBABA_CLOUD_CODEUP_INTEGRATION_MODE="):]
+		}
+	}
+	if !seenPath || !seenHome {
+		t.Errorf("expected PATH and HOME to be preserved, got %v", got)
+	}
+	if seenIntegration != 1 {
+		t.Errorf("expected exactly one integration mode entry, got %d", seenIntegration)
+	}
+	if integrationValue != "aliyun codeup-cli" {
+		t.Errorf("integration mode = %q, want %q", integrationValue, "aliyun codeup-cli")
+	}
+}
+
 func TestFileExists(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/cliext/codeup/main.go
+++ b/cliext/codeup/main.go
@@ -1,0 +1,23 @@
+package codeup
+
+import (
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+)
+
+func NewCodeupCliCommand() *cli.Command {
+	return &cli.Command{
+		Name:                   "codeup-cli",
+		Short:                  i18n.T("Migrate third-party code repositories to Alibaba Cloud Codeup", "三方代码平台迁移到阿里云Codeup平台的命令行工具"),
+		Usage:                  "aliyun codeup-cli <command> [args...]",
+		Hidden:                 false,
+		DisablePersistentFlags: true,
+		EnableUnknownFlag:      true,
+		KeepArgs:               true,
+		SkipDefaultHelp:        true,
+		Run: func(ctx *cli.Context, args []string) error {
+			options := NewContext(ctx)
+			return options.Run(args)
+		},
+	}
+}

--- a/cliext/codeup/main_test.go
+++ b/cliext/codeup/main_test.go
@@ -1,0 +1,72 @@
+package codeup
+
+import (
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+)
+
+func TestNewCodeupCliCommand(t *testing.T) {
+	cmd := NewCodeupCliCommand()
+	if cmd == nil {
+		t.Fatalf("NewCodeupCliCommand returned nil")
+	}
+	if cmd.Name != "codeup-cli" {
+		t.Errorf("Name expected 'codeup-cli', got %s", cmd.Name)
+	}
+	if cmd.Short == nil {
+		t.Fatalf("Short i18n text nil")
+	}
+	if en := cmd.Short.Get("en"); en != "Migrate third-party code repositories to Alibaba Cloud Codeup" {
+		t.Errorf("Short en expected 'Migrate third-party code repositories to Alibaba Cloud Codeup', got %s", en)
+	}
+	if zh := cmd.Short.Get("zh"); zh != "三方代码平台迁移到阿里云Codeup平台的命令行工具" {
+		t.Errorf("Short zh expected '三方代码平台迁移到阿里云Codeup平台的命令行工具', got %s", zh)
+	}
+	if cmd.Usage != "aliyun codeup-cli <command> [args...]" {
+		t.Errorf("Usage expected 'aliyun codeup-cli <command> [args...]', got %s", cmd.Usage)
+	}
+	if cmd.Hidden {
+		t.Errorf("Hidden expected false")
+	}
+	if !cmd.DisablePersistentFlags {
+		t.Errorf("DisablePersistentFlags expected true")
+	}
+	if !cmd.EnableUnknownFlag {
+		t.Errorf("EnableUnknownFlag expected true")
+	}
+	if !cmd.KeepArgs {
+		t.Errorf("KeepArgs expected true")
+	}
+	if !cmd.SkipDefaultHelp {
+		t.Errorf("SkipDefaultHelp expected true")
+	}
+	if cmd.Run == nil {
+		t.Errorf("Run function should not be nil")
+	}
+}
+
+func TestNewCodeupCliCommandMetadata(t *testing.T) {
+	cmd := NewCodeupCliCommand()
+	metaMap := map[string]*cli.Metadata{}
+	cmd.GetMetadata(metaMap)
+	m, ok := metaMap[cmd.Name]
+	if !ok {
+		t.Fatalf("metadata for %s not found", cmd.Name)
+	}
+	if m.Name != "codeup-cli" {
+		t.Errorf("metadata name expected codeup-cli, got %s", m.Name)
+	}
+	if m.Usage != cmd.Usage {
+		t.Errorf("metadata usage mismatch")
+	}
+	if m.Hidden != cmd.Hidden {
+		t.Errorf("metadata hidden mismatch")
+	}
+	if se := m.Short["en"]; se != "Migrate third-party code repositories to Alibaba Cloud Codeup" {
+		t.Errorf("metadata short en mismatch: %s", se)
+	}
+	if sz := m.Short["zh"]; sz != "三方代码平台迁移到阿里云Codeup平台的命令行工具" {
+		t.Errorf("metadata short zh mismatch: %s", sz)
+	}
+}

--- a/main/main.go
+++ b/main/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/cliext/acrutil"
 	"github.com/aliyun/aliyun-cli/v3/cliext/appmanagerutil"
 	"github.com/aliyun/aliyun-cli/v3/cliext/cms2"
+	"github.com/aliyun/aliyun-cli/v3/cliext/codeup"
 	"github.com/aliyun/aliyun-cli/v3/cliext/computenestutil"
 	"github.com/aliyun/aliyun-cli/v3/cliext/saectl"
 	"github.com/aliyun/aliyun-cli/v3/config"
@@ -129,6 +130,8 @@ func newRootCommand(profile config.Profile, stdout io.Writer) *cli.Command {
 	rootCmd.AddSubCommand(otsutil.NewOtsutilCommand())
 	// acr command
 	rootCmd.AddSubCommand(acrutil.NewAcrutilCommand())
+	// codeup command
+	rootCmd.AddSubCommand(codeup.NewCodeupCliCommand())
 	// sae command
 	rootCmd.AddSubCommand(saectl.NewSaectlCommand())
 	// appmanager command


### PR DESCRIPTION
## Summary

Add a new top-level subcommand `aliyun codeup-cli` that delegates to the standalone `codeup-cli` binary, used for migrating third-party code repositories (GitHub / GitLab / Gitee, etc.) to Alibaba Cloud Codeup.

The CLI acts as a lightweight wrapper:
1. On first invocation, it auto-detects the current OS / arch, downloads the matching `codeup-cli` archive from `https://codeuputil.oss-cn-hangzhou.aliyuncs.com/current/`, and extracts the binary into the user's aliyun config directory.
2. On subsequent invocations, it simply forwards arguments to the locally cached binary.
3. Before forwarding, it strips out aliyun-cli's own configuration / invocation flags (e.g. `--profile`, `--mode`, `--quiet`, `-p`, `-q`, `-y` …) so they will not leak into the child process.

## Motivation

Codeup migration tooling is maintained as an independent binary. Bundling it directly into aliyun-cli would significantly increase the binary size and tightly couple release cycles. Following the same pattern used by `cms2`, `acrutil`, `saectl`, etc., this PR keeps aliyun-cli slim while still giving users a one-command experience:

```bash
aliyun codeup-cli <command> [args...]