### PR TITLE
feat(appmanager): 通用化 PrepareEnv 凭证透传支持多种认证模式

### DIFF
--- a/cliext/appmanagerutil/appmanager.go
+++ b/cliext/appmanagerutil/appmanager.go
@@ -41,10 +41,10 @@ var getConfigurePathFunc = func() string {
 }
 
 var (
-	execCommandFunc    = exec.Command
-	timeNowFunc        = time.Now
-	runtimeGOOSFunc    = func() string { return runtime.GOOS }
-	runtimeGOARCHFunc  = func() string { return runtime.GOARCH }
+	execCommandFunc   = exec.Command
+	timeNowFunc       = time.Now
+	runtimeGOOSFunc   = func() string { return runtime.GOOS }
+	runtimeGOARCHFunc = func() string { return runtime.GOARCH }
 )
 
 const (
@@ -575,7 +575,6 @@ func (c *Context) downloadWhlFromOSS() (string, error) {
 	return whlPath, nil
 }
 
-
 func (c *Context) RemoveFlagsForMainCli(args []string) ([]string, error) {
 	longNeedsValue := make(map[string]bool)  // key: --name
 	shortNeedsValue := make(map[string]bool) // key: -x
@@ -709,20 +708,29 @@ func (c *Context) PrepareEnv() ([]string, error) {
 		profile.OverwriteWithFlags(c.originCtx)
 	}
 
-	var accessKeyId, accessKeySecret, stsToken string
+	var accessKeyId, accessKeySecret, stsToken, bearerToken, bearerTokenHeaderKey string
 
 	mode := profile.Mode
 	switch mode {
 	case config.AK:
+		// 直接凭证：静态 AK/SK
 		accessKeyId = profile.AccessKeyId
 		accessKeySecret = profile.AccessKeySecret
 	case config.StsToken:
+		// 直接凭证：AK/SK + STS Token
 		accessKeyId = profile.AccessKeyId
 		accessKeySecret = profile.AccessKeySecret
 		stsToken = profile.StsToken
-	case config.RamRoleArn:
-		// RamRoleArn 模式：profile 中的 AK/SK 是静态母凭证，不能直接用于访问 API。
-		// 需要通过 AssumeRole 获取临时 STS 凭证（credentials-go SDK 自动处理）。
+	case config.BearerToken:
+		// Bearer Token 模式：直接注入 bearer token，不走 STS 凭证链
+		bearerToken = profile.BearerTokenValue
+		bearerTokenHeaderKey = profile.BearerTokenHeaderKey
+	default:
+		// 间接凭证模式（RamRoleArn/OAuth/CloudSSO/OIDC/EcsRamRole/
+		// ChainableRamRoleArn/RsaKeyPair/CredentialsURI/External 等）：
+		// 统一通过 GetCredential() 获取最终可用的临时 STS 凭证。
+		// 其中 OAuth/CloudSSO 会自动用 token 换临时 STS 并处理过期刷新，子进程无感；
+		// RamRoleArn 的静态母凭证只用于换取临时 STS，不会泄漏给子进程。
 		cred, err := profile.GetCredential(c.originCtx, nil)
 		if err != nil {
 			return os.Environ(), nil
@@ -740,9 +748,6 @@ func (c *Context) PrepareEnv() ([]string, error) {
 		if model.SecurityToken != nil {
 			stsToken = *model.SecurityToken
 		}
-	default:
-		// 其他认证模式暂不支持自动透传，仅继承父进程环境变量
-		return os.Environ(), nil
 	}
 
 	envs := os.Environ()
@@ -754,6 +759,12 @@ func (c *Context) PrepareEnv() ([]string, error) {
 	}
 	if stsToken != "" {
 		envs = append(envs, "ALIBABA_CLOUD_SECURITY_TOKEN="+stsToken)
+	}
+	if bearerToken != "" {
+		envs = append(envs, "ALIBABA_CLOUD_BEARER_TOKEN="+bearerToken)
+	}
+	if bearerTokenHeaderKey != "" {
+		envs = append(envs, "ALIBABA_CLOUD_BEARER_TOKEN_HEADER_KEY="+bearerTokenHeaderKey)
 	}
 	if profile.RegionId != "" {
 		envs = append(envs, "ALIBABA_CLOUD_REGION_ID="+profile.RegionId)

--- a/cliext/appmanagerutil/appmanager_test.go
+++ b/cliext/appmanagerutil/appmanager_test.go
@@ -526,6 +526,160 @@ func TestPrepareEnv_RamRoleArnNoStaticAKLeak(t *testing.T) {
 	}
 }
 
+func TestPrepareEnv_OAuthModeInjectsTempSTS(t *testing.T) {
+	// OAuth 模式：STS 未过期时，GetCredential 直接复用 profile 中存储的临时 STS，
+	// PrepareEnv 应把这套临时 STS 三元组注入子进程（无需网络请求）。
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
+
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	// OAuth profile，STS 远未过期 → 直接复用存储的临时 STS，不触发网络刷新
+	configJSON := `{"current":"default","profiles":[{"name":"default","mode":"OAuth","oauth_site_type":"CN","oauth_access_token":"tok","access_key_id":"OAUTH_TMP_AK","access_key_secret":"OAUTH_TMP_SK","sts_token":"OAUTH_STS_TOKEN","sts_expiration":9999999999,"region_id":"cn-hangzhou"}]}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv failed: %v", err)
+	}
+
+	var foundAK, foundSK, foundToken bool
+	for _, e := range envs {
+		switch e {
+		case "ALIBABA_CLOUD_ACCESS_KEY_ID=OAUTH_TMP_AK":
+			foundAK = true
+		case "ALIBABA_CLOUD_ACCESS_KEY_SECRET=OAUTH_TMP_SK":
+			foundSK = true
+		case "ALIBABA_CLOUD_SECURITY_TOKEN=OAUTH_STS_TOKEN":
+			foundToken = true
+		}
+	}
+	if !foundAK || !foundSK || !foundToken {
+		t.Errorf("OAuth mode should inject temp STS creds, envs: %v", filterUA(envs))
+	}
+}
+
+func TestPrepareEnv_AKModeInjectsStaticAK(t *testing.T) {
+	// AK 模式：静态 AK/SK 直接注入，且不应出现 STS Token。
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
+
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	configJSON := `{"current":"default","profiles":[{"name":"default","mode":"AK","access_key_id":"AK_ID","access_key_secret":"AK_SECRET","region_id":"cn-hangzhou"}]}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv failed: %v", err)
+	}
+
+	var foundAK, foundSK bool
+	for _, e := range envs {
+		switch e {
+		case "ALIBABA_CLOUD_ACCESS_KEY_ID=AK_ID":
+			foundAK = true
+		case "ALIBABA_CLOUD_ACCESS_KEY_SECRET=AK_SECRET":
+			foundSK = true
+		}
+	}
+	if !foundAK || !foundSK {
+		t.Errorf("AK mode should inject static AK/SK, envs: %v", filterUA(envs))
+	}
+}
+
+func TestPrepareEnv_StsTokenModeInjectsTriple(t *testing.T) {
+	// StsToken 模式：AK/SK + STS Token 三元组直接注入。
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
+
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	configJSON := `{"current":"default","profiles":[{"name":"default","mode":"StsToken","access_key_id":"STS_AK","access_key_secret":"STS_SK","sts_token":"STS_TOKEN","region_id":"cn-hangzhou"}]}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv failed: %v", err)
+	}
+
+	var foundAK, foundSK, foundToken bool
+	for _, e := range envs {
+		switch e {
+		case "ALIBABA_CLOUD_ACCESS_KEY_ID=STS_AK":
+			foundAK = true
+		case "ALIBABA_CLOUD_ACCESS_KEY_SECRET=STS_SK":
+			foundSK = true
+		case "ALIBABA_CLOUD_SECURITY_TOKEN=STS_TOKEN":
+			foundToken = true
+		}
+	}
+	if !foundAK || !foundSK || !foundToken {
+		t.Errorf("StsToken mode should inject AK/SK/STS triple, envs: %v", filterUA(envs))
+	}
+}
+
+func TestPrepareEnv_BearerTokenModeInjectsBearer(t *testing.T) {
+	// BearerToken 模式：注入 bearer token 及 header key，不走 STS 凭证链。
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
+
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	configJSON := `{"current":"default","profiles":[{"name":"default","mode":"BearerToken","bearer_token":"BEARER_VAL","bearer_token_header_key":"x-acs-bearer-token","region_id":"cn-hangzhou"}]}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv failed: %v", err)
+	}
+
+	var foundBearer, foundHeader bool
+	for _, e := range envs {
+		switch e {
+		case "ALIBABA_CLOUD_BEARER_TOKEN=BEARER_VAL":
+			foundBearer = true
+		case "ALIBABA_CLOUD_BEARER_TOKEN_HEADER_KEY=x-acs-bearer-token":
+			foundHeader = true
+		}
+	}
+	if !foundBearer || !foundHeader {
+		t.Errorf("BearerToken mode should inject bearer token + header key, envs: %v", filterUA(envs))
+	}
+}
+
 func filterUA(envs []string) []string {
 	out := make([]string, 0)
 	for _, e := range envs {


### PR DESCRIPTION
- 将 PrepareEnv 改造为按 profile.Mode 分支处理：AK/StsToken 直接注入， BearerToken 注入 bearer token，其余间接模式（OAuth/RamRoleArn/CloudSSO 等） 统一经 GetCredential() 换取临时 STS 注入子进程，避免静态母凭证泄漏
- 新增 AK/StsToken/BearerToken/OAuth/RamRoleArn 各模式的 PrepareEnv 单元测试
- OAuth 透传已端到端验证可用

注：computenest-cli 因上游 Python 包不读 ALIBABA_CLOUD_* 环境变量、 且 token 字段名不匹配，无法通过 env 透传，相关改造已回滚，等待上游修复