### PR TITLE
{OpenAPI} Add call context logging

### DIFF
--- a/openapi/call_context.go
+++ b/openapi/call_context.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"os"
+	"strings"
+
+	"github.com/alibabacloud-go/tea/tea"
+)
+
+// 调用方上下文相关参数（source-ip / secure-transport）的注入键。
+//   - ROA：通过 header 注入 x-acs-source-ip / x-acs-secure-transport
+//   - RPC：通过 query 注入 SourceIp / SecureTransport
+const (
+	// EnvSourceIP 调用方源 IP。仅在为非空字符串时注入。
+	EnvSourceIP = "ALIBABA_CLOUD_SOURCE_IP"
+	// EnvSecureTransport 调用方是否走安全传输。仅在为非空字符串时注入；值原样透传，由网关自行解析。
+	EnvSecureTransport = "ALIBABA_CLOUD_SECURE_TRANSPORT"
+
+	headerSourceIP        = "x-acs-source-ip"
+	headerSecureTransport = "x-acs-secure-transport"
+	queryKeySourceIP      = "SourceIp"
+	queryKeySecureTransport = "SecureTransport"
+)
+
+
+func callContextEnv() (sourceIP string, secureTransport string) {
+	sourceIP = strings.TrimSpace(os.Getenv(EnvSourceIP))
+	secureTransport = strings.TrimSpace(os.Getenv(EnvSecureTransport))
+	return
+}
+
+func applyCallContextRPC(queryParams map[string]string) {
+	if queryParams == nil {
+		return
+	}
+	sourceIP, secureTransport := callContextEnv()
+	if sourceIP != "" {
+		if _, exists := queryParams[queryKeySourceIP]; !exists {
+			queryParams[queryKeySourceIP] = sourceIP
+		}
+	}
+	if secureTransport != "" {
+		if _, exists := queryParams[queryKeySecureTransport]; !exists {
+			queryParams[queryKeySecureTransport] = secureTransport
+		}
+	}
+}
+
+func applyCallContextROA(headers map[string]string) {
+	if headers == nil {
+		return
+	}
+	sourceIP, secureTransport := callContextEnv()
+	if sourceIP != "" {
+		if _, exists := headers[headerSourceIP]; !exists {
+			headers[headerSourceIP] = sourceIP
+		}
+	}
+	if secureTransport != "" {
+		if _, exists := headers[headerSecureTransport]; !exists {
+			headers[headerSecureTransport] = secureTransport
+		}
+	}
+}
+
+func applyCallContextTeaHeaders(headers map[string]*string) {
+	if headers == nil {
+		return
+	}
+	sourceIP, secureTransport := callContextEnv()
+	if sourceIP != "" {
+		if _, exists := headers[headerSourceIP]; !exists {
+			headers[headerSourceIP] = tea.String(sourceIP)
+		}
+	}
+	if secureTransport != "" {
+		if _, exists := headers[headerSecureTransport]; !exists {
+			headers[headerSecureTransport] = tea.String(secureTransport)
+		}
+	}
+}

--- a/openapi/call_context_test.go
+++ b/openapi/call_context_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"testing"
+
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyCallContextRPC(t *testing.T) {
+	t.Run("both env set", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		q := map[string]string{}
+		applyCallContextRPC(q)
+		assert.Equal(t, "1.2.3.4", q[queryKeySourceIP])
+		assert.Equal(t, "true", q[queryKeySecureTransport])
+	})
+
+	t.Run("only source ip", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "10.0.0.1")
+		t.Setenv(EnvSecureTransport, "")
+		q := map[string]string{}
+		applyCallContextRPC(q)
+		assert.Equal(t, "10.0.0.1", q[queryKeySourceIP])
+		_, ok := q[queryKeySecureTransport]
+		assert.False(t, ok)
+	})
+
+	t.Run("only secure transport", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "")
+		t.Setenv(EnvSecureTransport, "false")
+		q := map[string]string{}
+		applyCallContextRPC(q)
+		_, ok := q[queryKeySourceIP]
+		assert.False(t, ok)
+		assert.Equal(t, "false", q[queryKeySecureTransport])
+	})
+
+	t.Run("none set", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "")
+		t.Setenv(EnvSecureTransport, "")
+		q := map[string]string{}
+		applyCallContextRPC(q)
+		assert.Empty(t, q)
+	})
+
+	t.Run("existing query keys are preserved", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		q := map[string]string{
+			queryKeySourceIP:        "user-set",
+			queryKeySecureTransport: "user-set",
+		}
+		applyCallContextRPC(q)
+		assert.Equal(t, "user-set", q[queryKeySourceIP])
+		assert.Equal(t, "user-set", q[queryKeySecureTransport])
+	})
+
+	t.Run("nil map no panic", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		assert.NotPanics(t, func() {
+			applyCallContextRPC(nil)
+		})
+	})
+
+	t.Run("trim whitespace", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "  1.2.3.4  ")
+		t.Setenv(EnvSecureTransport, "  true  ")
+		q := map[string]string{}
+		applyCallContextRPC(q)
+		assert.Equal(t, "1.2.3.4", q[queryKeySourceIP])
+		assert.Equal(t, "true", q[queryKeySecureTransport])
+	})
+}
+
+func TestApplyCallContextROA(t *testing.T) {
+	t.Run("both env set", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		h := map[string]string{}
+		applyCallContextROA(h)
+		assert.Equal(t, "1.2.3.4", h[headerSourceIP])
+		assert.Equal(t, "true", h[headerSecureTransport])
+	})
+
+	t.Run("existing headers are preserved", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "env-ip")
+		t.Setenv(EnvSecureTransport, "true")
+		h := map[string]string{
+			headerSourceIP:        "user-set",
+			headerSecureTransport: "user-set",
+		}
+		applyCallContextROA(h)
+		assert.Equal(t, "user-set", h[headerSourceIP])
+		assert.Equal(t, "user-set", h[headerSecureTransport])
+	})
+
+	t.Run("none set", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "")
+		t.Setenv(EnvSecureTransport, "")
+		h := map[string]string{}
+		applyCallContextROA(h)
+		assert.Empty(t, h)
+	})
+
+	t.Run("nil map no panic", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		assert.NotPanics(t, func() {
+			applyCallContextROA(nil)
+		})
+	})
+}
+
+func TestApplyCallContextTeaHeaders(t *testing.T) {
+	t.Run("both env set", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		h := map[string]*string{}
+		applyCallContextTeaHeaders(h)
+		assert.Equal(t, "1.2.3.4", tea.StringValue(h[headerSourceIP]))
+		assert.Equal(t, "true", tea.StringValue(h[headerSecureTransport]))
+	})
+
+	t.Run("existing headers preserved", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "env-ip")
+		t.Setenv(EnvSecureTransport, "true")
+		h := map[string]*string{
+			headerSourceIP: tea.String("user-set"),
+		}
+		applyCallContextTeaHeaders(h)
+		assert.Equal(t, "user-set", tea.StringValue(h[headerSourceIP]))
+		assert.Equal(t, "true", tea.StringValue(h[headerSecureTransport]))
+	})
+
+	t.Run("nil map no panic", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		assert.NotPanics(t, func() {
+			applyCallContextTeaHeaders(nil)
+		})
+	})
+}

--- a/openapi/force_rpc.go
+++ b/openapi/force_rpc.go
@@ -56,6 +56,8 @@ func (a *ForceRpcInvoker) Prepare(ctx *cli.Context) (err error) {
 		}
 	}
 
+	applyCallContextRPC(a.request.QueryParams)
+
 	return
 }
 

--- a/openapi/http_context.go
+++ b/openapi/http_context.go
@@ -183,6 +183,7 @@ func (a *HttpContext) Init(ctx *cli.Context, product *meta.Product) error {
 	}
 	a.profile.InjectBearerTokenHeader(a.openapiRequest.Headers)
 	otel.InjectTeaHeaders(a.openapiRequest.Headers)
+	applyCallContextTeaHeaders(a.openapiRequest.Headers)
 
 	// a.openapiRequest.Headers["x-acs-region-id"] = tea.String(a.profile.RegionId)
 	return nil

--- a/openapi/restful.go
+++ b/openapi/restful.go
@@ -95,6 +95,8 @@ func (a *RestfulInvoker) Prepare(ctx *cli.Context) error {
 		a.request.Scheme = "https"
 	}
 
+	applyCallContextROA(a.request.Headers)
+
 	return nil
 }
 

--- a/openapi/rpc.go
+++ b/openapi/rpc.go
@@ -88,6 +88,8 @@ func (a *RpcInvoker) Prepare(ctx *cli.Context) error {
 		}
 	}
 
+	applyCallContextRPC(request.QueryParams)
+
 	err := a.api.CheckRequiredParameters(func(s string) bool {
 		switch s {
 		case "RegionId":


### PR DESCRIPTION
**Description**

Inject caller-context fields (`source-ip` / `secure-transport`) into outgoing API requests, with style-aware routing as following.

Two environment variables drive the injection:
- `ALIBABA_CLOUD_SOURCE_IP`
- `ALIBABA_CLOUD_SECURE_TRANSPORT`

Routing by API style:
- RPC: query params (`SourceIp`, `SecureTransport`)
- ROA: headers(`x-acs-source-ip`, `x-acs-secure-transport`)
