### PR TITLE
{Misc} Fix plugin three layer cmd help

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -51,6 +51,11 @@ var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*respons
 	return fn
 }
 
+var (
+	helpDelegateIsInstalled = plugin.IsPluginInstalled
+	helpDelegateExecute     = plugin.ExecutePlugin
+)
+
 func NewCommando(w io.Writer, profile config.Profile) *Commando {
 	r := &Commando{
 		profile: profile,
@@ -987,7 +992,7 @@ func (c *Commando) tryDelegatePluginHelp(ctx *cli.Context, args []string) (bool,
 		return false, nil
 	}
 
-	installed, _, err := plugin.IsPluginInstalled(args[0])
+	installed, _, err := helpDelegateIsInstalled(args[0])
 	if err != nil || !installed {
 		return false, nil
 	}
@@ -995,10 +1000,11 @@ func (c *Commando) tryDelegatePluginHelp(ctx *cli.Context, args []string) (bool,
 	pluginArgs := getPluginArgsForHelp(args[0])
 
 	c.setLangEnv(ctx)
-	ok, perr := plugin.ExecutePlugin(args[0], pluginArgs, ctx)
+	ok, perr := helpDelegateExecute(args[0], pluginArgs, ctx)
 	if !ok {
-		// Manifest said installed but the binary vanished between checks; 
-		// fall through to the original error rather than surface a confusing "plugin not found" at help time.
+		// Manifest said installed but the binary vanished between checks;
+		// fall through to the original error rather than surface a confusing
+		// "plugin not found" at help time.
 		return false, nil
 	}
 	return true, perr

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -51,11 +51,6 @@ var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*respons
 	return fn
 }
 
-var (
-	helpDelegateIsInstalled = plugin.IsPluginInstalled
-	helpDelegateExecute     = plugin.ExecutePlugin
-)
-
 func NewCommando(w io.Writer, profile config.Profile) *Commando {
 	r := &Commando{
 		profile: profile,
@@ -979,35 +974,6 @@ func (c *Commando) help(ctx *cli.Context, args []string) error {
 		}
 		return fmt.Errorf("too many arguments: %d", len(args))
 	}
-}
-
-func (c *Commando) tryDelegatePluginHelp(ctx *cli.Context, args []string) (bool, error) {
-	// Caller invariant: this is only reachable from `len(args) > 2`
-	if len(args) < 2 {
-		return false, nil
-	}
-
-	upper := strings.ToUpper(args[1])
-	if upper == "GET" || upper == "POST" || upper == "PUT" || upper == "DELETE" {
-		return false, nil
-	}
-
-	installed, _, err := helpDelegateIsInstalled(args[0])
-	if err != nil || !installed {
-		return false, nil
-	}
-
-	pluginArgs := getPluginArgsForHelp(args[0])
-
-	c.setLangEnv(ctx)
-	ok, perr := helpDelegateExecute(args[0], pluginArgs, ctx)
-	if !ok {
-		// Manifest said installed but the binary vanished between checks;
-		// fall through to the original error rather than surface a confusing
-		// "plugin not found" at help time.
-		return false, nil
-	}
-	return true, perr
 }
 
 func (c *Commando) complete(ctx *cli.Context, args []string) []string {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -968,8 +968,40 @@ func (c *Commando) help(ctx *cli.Context, args []string) error {
 		cmd.PrintHead(ctx)
 		return c.printApiUsage(ctx, args[0], args[1])
 	} else {
+		// Layer 3: plugin sub-command help (3+ levels deep).
+		if delegated, derr := c.tryDelegatePluginHelp(ctx, args); delegated {
+			return derr
+		}
 		return fmt.Errorf("too many arguments: %d", len(args))
 	}
+}
+
+func (c *Commando) tryDelegatePluginHelp(ctx *cli.Context, args []string) (bool, error) {
+	// Caller invariant: this is only reachable from `len(args) > 2`
+	if len(args) < 2 {
+		return false, nil
+	}
+
+	upper := strings.ToUpper(args[1])
+	if upper == "GET" || upper == "POST" || upper == "PUT" || upper == "DELETE" {
+		return false, nil
+	}
+
+	installed, _, err := plugin.IsPluginInstalled(args[0])
+	if err != nil || !installed {
+		return false, nil
+	}
+
+	pluginArgs := getPluginArgsForHelp(args[0])
+
+	c.setLangEnv(ctx)
+	ok, perr := plugin.ExecutePlugin(args[0], pluginArgs, ctx)
+	if !ok {
+		// Manifest said installed but the binary vanished between checks; 
+		// fall through to the original error rather than surface a confusing "plugin not found" at help time.
+		return false, nil
+	}
+	return true, perr
 }
 
 func (c *Commando) complete(ctx *cli.Context, args []string) []string {

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -406,3 +406,133 @@ func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName s
 
 	return nil
 }
+
+// Test seams for tryDelegatePluginHelp. Production code outside that
+// function should keep calling plugin.IsPluginInstalled /
+// plugin.ExecutePlugin directly — these indirections exist only so the
+// deep-help delegation path (manifest hit → ExecutePlugin success /
+// vanished-binary fallback) is exercisable without spawning real plugin
+// binaries from /Users/.../.aliyun.
+var (
+	helpDelegateIsInstalled = plugin.IsPluginInstalled
+	helpDelegateExecute     = plugin.ExecutePlugin
+)
+
+// tryDelegatePluginHelp is layer-3 of the help hierarchy:
+//
+//	len(args)==1 → printProductUsage      (this file)
+//	len(args)==2 → printApiUsage          (this file)
+//	len(args)>2  → tryDelegatePluginHelp  (this file)
+//
+// It is invoked from commando.go's Commando.help when args run deeper
+// than the OpenAPI product → API hierarchy can model. For example
+// `aliyun hologram config set --help` or `aliyun help hologram dt list`.
+//
+// The cli framework dispatches `--help` directly to cmd.Help, bypassing
+// cmd.Run, so Commando.main's plugin routing never gets a chance to
+// forward these requests. Without this helper, every 3+ level help
+// invocation would just return the legacy `too many arguments: N`,
+// which points at the wrong problem.
+//
+// Returns (true, perr) when the helper produced a final answer (plugin
+// delegated or a tier-1/2/3 diagnostic error was raised). Returns
+// (false, nil) when no tier matched and the caller should fall back to
+// the legacy error. The single early-exit gate is `args[1] ∈ {GET, POST,
+// PUT, DELETE}` — a RESTful OpenAPI invocation shape that must not be
+// misrouted to a plugin (the plugin would not recognise it).
+func (c *Commando) tryDelegatePluginHelp(ctx *cli.Context, args []string) (bool, error) {
+	// Caller invariant: only reachable from `len(args) > 2`.
+	if len(args) < 2 {
+		return false, nil
+	}
+
+	upper := strings.ToUpper(args[1])
+	if upper == "GET" || upper == "POST" || upper == "PUT" || upper == "DELETE" {
+		return false, nil
+	}
+
+	installed, _, err := helpDelegateIsInstalled(args[0])
+	if err != nil {
+		// Treat inspection errors (corrupted manifest etc.) as "not a
+		// plugin". Falling through to the legacy error is always safe
+		// and we don't want to mask the real issue with a confusing
+		// "plugin check failed" stack trace at help time.
+		return false, nil
+	}
+
+	// Tier 0: plugin already installed → forward.
+	if installed {
+		// Reuse getPluginArgsForHelp so we inherit two things a naive
+		// os.Args[i:] slice would miss: case-insensitive plugin-name
+		// matching in os.Args, and auto-appending `--help` for the
+		// `aliyun help <plugin> <sub> ...` entry shape (where no
+		// `--help` flag is present in argv).
+		pluginArgs := getPluginArgsForHelp(args[0])
+
+		c.setLangEnv(ctx)
+		ok, perr := helpDelegateExecute(args[0], pluginArgs, ctx)
+		if !ok {
+			// Manifest said installed but the binary vanished between
+			// checks; fall through to the original error rather than
+			// surface a confusing "plugin not found" at help time.
+			return false, nil
+		}
+		return true, perr
+	}
+
+	// Tier 1: not installed locally, but the remote plugin index knows
+	// args[0] → guide the user to install it. Wording mirrors
+	// printProductUsage's "aliyun plugin install --names <plugin>" so
+	// users see a consistent install command across L1 and L3 help.
+	if c.pluginIndex != nil {
+		for _, pInfo := range c.pluginIndex.Plugins {
+			if strings.EqualFold(pInfo.ProductCode, args[0]) {
+				return true, fmt.Errorf(
+					"'%s' looks like a plugin command but the plugin is not installed.\n"+
+						"Run 'aliyun plugin install --names %s' to install it.",
+					args[0], pInfo.Name,
+				)
+			}
+		}
+	} else if c.pluginIndexErr != nil {
+		// Remote catalog fetch failed (offline / network issue). Surface
+		// it so the user knows install guidance might be missing, then
+		// continue with tier-2 / tier-3 diagnostics below.
+		c.printPluginIndexLoadFailureNote(ctx)
+	}
+
+	// Tier 2: args[0] is a known OpenAPI built-in product → diagnose
+	// args[1] before complaining about arg count. If args[1] isn't a
+	// valid API for this product, report THAT — it's far more
+	// actionable than "too many arguments" (the user usually just
+	// typo'd the API). InvalidUnifiedApiError implements
+	// SuggestibleError so the cli framework prints "Did you mean ..."
+	// automatically.
+	if product, ok := c.library.GetProduct(args[0]); ok {
+		apiValid := false
+		for _, n := range product.ApiNames {
+			if strings.EqualFold(n, args[1]) {
+				apiValid = true
+				break
+			}
+		}
+		if !apiValid {
+			return true, &InvalidUnifiedApiError{Name: args[1], product: &product}
+		}
+		// args[0] is a real product AND args[1] is a real API but
+		// extras remain: this IS a genuine arg-count problem (OpenAPI
+		// API help is two levels max). Fall through to the legacy
+		// error so its pre-existing wording is preserved.
+		return false, nil
+	}
+
+	// Tier 3: args[0] is neither an installed plugin nor a built-in
+	// product. Surface it as an invalid product / plugin name (with
+	// typo suggestions via the error's GetSuggestions) instead of a
+	// misleading "too many arguments" that points at the wrong problem.
+	var plugList []plugin.PluginInfo
+	if c.pluginIndex != nil {
+		plugList = c.pluginIndex.Plugins
+	}
+	return true, &InvalidProductOrPluginError{Code: args[0], library: c.library, plugins: plugList}
+}

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -407,12 +407,6 @@ func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName s
 	return nil
 }
 
-// Test seams for tryDelegatePluginHelp. Production code outside that
-// function should keep calling plugin.IsPluginInstalled /
-// plugin.ExecutePlugin directly — these indirections exist only so the
-// deep-help delegation path (manifest hit → ExecutePlugin success /
-// vanished-binary fallback) is exercisable without spawning real plugin
-// binaries from /Users/.../.aliyun.
 var (
 	helpDelegateIsInstalled = plugin.IsPluginInstalled
 	helpDelegateExecute     = plugin.ExecutePlugin
@@ -423,116 +417,133 @@ var (
 //	len(args)==1 → printProductUsage      (this file)
 //	len(args)==2 → printApiUsage          (this file)
 //	len(args)>2  → tryDelegatePluginHelp  (this file)
+
+// OpenAPI APIs are conventionally PascalCase (DescribeRegions, GetAlias)
+// and RESTful invocations carry an uppercase HTTP method in args[1].
+// A fully-lowercase args[1] is therefore the strongest cheap signal
+// that we're inside a plugin sub-tree (config, dt, list, …).
+// Anything else is treated as legacy-mode and falls through to the historical `too many arguments` error so we don't shadow OpenAPI semantics.
 //
-// It is invoked from commando.go's Commando.help when args run deeper
-// than the OpenAPI product → API hierarchy can model. For example
-// `aliyun hologram config set --help` or `aliyun help hologram dt list`.
+// Decision tree (caller has already ensured len(args) > 2):
 //
-// The cli framework dispatches `--help` directly to cmd.Help, bypassing
-// cmd.Run, so Commando.main's plugin routing never gets a chance to
-// forward these requests. Without this helper, every 3+ level help
-// invocation would just return the legacy `too many arguments: N`,
-// which points at the wrong problem.
+//	Gate-1  args[1] in {GET,POST,PUT,DELETE} → fall through
+//	        (RESTful OpenAPI invocation shape — not a plugin command)
 //
-// Returns (true, perr) when the helper produced a final answer (plugin
-// delegated or a tier-1/2/3 diagnostic error was raised). Returns
-// (false, nil) when no tier matched and the caller should fall back to
-// the legacy error. The single early-exit gate is `args[1] ∈ {GET, POST,
-// PUT, DELETE}` — a RESTful OpenAPI invocation shape that must not be
-// misrouted to a plugin (the plugin would not recognise it).
+//	Gate-2  args[1] contains any uppercase character → fall through
+//	        (PascalCase OpenAPI APIName or other legacy shape)
+//
+//	Step 1  Look up args[0] in the remote plugin catalog
+//	        (case-insensitive) and remember the canonical PluginInfo.
+//
+//	Step 2  Plugin is known to the index. Locally installed?
+//	        YES → forward to plugin --help (let it self-render).
+//	              Binary vanished → reinstall guidance (no fall-through).
+//	        NO  → install guidance (uses canonical Name from index).
+//
+//	Step 3  Index miss but locally installed (dev side-load case)?
+//	        YES → forward to plugin --help anyway.
+//	        NO  → continue.
+//
+//	Step 4  Neither plugin nor product → InvalidProductOrPluginError
+//	        with fuzzy suggestions sourced from the plugin index.
+//
+// Beyond the two gates this function NEVER returns (false, nil):
+// once we've decided the shape IS a plugin command,
+// the legacy "too many arguments" error would actively mislead the user,
+// so every reachable path produces an actionable plugin-flavoured diagnostic.
 func (c *Commando) tryDelegatePluginHelp(ctx *cli.Context, args []string) (bool, error) {
-	// Caller invariant: only reachable from `len(args) > 2`.
+	// Defensive caller-invariant: production callers guarantee len > 2.
 	if len(args) < 2 {
 		return false, nil
 	}
 
+	// Gate-1: RESTful HTTP method in args[1] is the legacy `aliyun <product> <METHOD> <path>` shape.
 	upper := strings.ToUpper(args[1])
 	if upper == "GET" || upper == "POST" || upper == "PUT" || upper == "DELETE" {
 		return false, nil
 	}
 
-	installed, _, err := helpDelegateIsInstalled(args[0])
-	if err != nil {
-		// Treat inspection errors (corrupted manifest etc.) as "not a
-		// plugin". Falling through to the legacy error is always safe
-		// and we don't want to mask the real issue with a confusing
-		// "plugin check failed" stack trace at help time.
+	// Gate-2: any uppercase character in args[1] strongly suggests an OpenAPI APIName (PascalCase by convention).
+	// Treat it as legacy mode so users typing `aliyun ecs DescribeRegions extra` keep
+	// seeing the historical "too many arguments" wording instead of a plugin-flavoured error that would point at the wrong problem.
+	if strings.ToLower(args[1]) != args[1] {
 		return false, nil
 	}
 
-	// Tier 0: plugin already installed → forward.
-	if installed {
-		// Reuse getPluginArgsForHelp so we inherit two things a naive
-		// os.Args[i:] slice would miss: case-insensitive plugin-name
-		// matching in os.Args, and auto-appending `--help` for the
-		// `aliyun help <plugin> <sub> ...` entry shape (where no
-		// `--help` flag is present in argv).
-		pluginArgs := getPluginArgsForHelp(args[0])
+	productCode := args[0]
 
-		c.setLangEnv(ctx)
-		ok, perr := helpDelegateExecute(args[0], pluginArgs, ctx)
-		if !ok {
-			// Manifest said installed but the binary vanished between
-			// checks; fall through to the original error rather than
-			// surface a confusing "plugin not found" at help time.
-			return false, nil
-		}
-		return true, perr
-	}
-
-	// Tier 1: not installed locally, but the remote plugin index knows
-	// args[0] → guide the user to install it. Wording mirrors
-	// printProductUsage's "aliyun plugin install --names <plugin>" so
-	// users see a consistent install command across L1 and L3 help.
+	// Step 1: look up args[0] in the remote plugin catalog. We hold the canonical PluginInfo (Name, ProductCode) so install guidance can
+	// reference the exact `aliyun plugin install --names <name>` form.
+	var indexHit *plugin.PluginInfo
 	if c.pluginIndex != nil {
-		for _, pInfo := range c.pluginIndex.Plugins {
-			if strings.EqualFold(pInfo.ProductCode, args[0]) {
-				return true, fmt.Errorf(
-					"'%s' looks like a plugin command but the plugin is not installed.\n"+
-						"Run 'aliyun plugin install --names %s' to install it.",
-					args[0], pInfo.Name,
-				)
-			}
-		}
-	} else if c.pluginIndexErr != nil {
-		// Remote catalog fetch failed (offline / network issue). Surface
-		// it so the user knows install guidance might be missing, then
-		// continue with tier-2 / tier-3 diagnostics below.
-		c.printPluginIndexLoadFailureNote(ctx)
-	}
-
-	// Tier 2: args[0] is a known OpenAPI built-in product → diagnose
-	// args[1] before complaining about arg count. If args[1] isn't a
-	// valid API for this product, report THAT — it's far more
-	// actionable than "too many arguments" (the user usually just
-	// typo'd the API). InvalidUnifiedApiError implements
-	// SuggestibleError so the cli framework prints "Did you mean ..."
-	// automatically.
-	if product, ok := c.library.GetProduct(args[0]); ok {
-		apiValid := false
-		for _, n := range product.ApiNames {
-			if strings.EqualFold(n, args[1]) {
-				apiValid = true
+		for i := range c.pluginIndex.Plugins {
+			if strings.EqualFold(c.pluginIndex.Plugins[i].ProductCode, productCode) {
+				indexHit = &c.pluginIndex.Plugins[i]
 				break
 			}
 		}
-		if !apiValid {
-			return true, &InvalidUnifiedApiError{Name: args[1], product: &product}
-		}
-		// args[0] is a real product AND args[1] is a real API but
-		// extras remain: this IS a genuine arg-count problem (OpenAPI
-		// API help is two levels max). Fall through to the legacy
-		// error so its pre-existing wording is preserved.
-		return false, nil
+	} else if c.pluginIndexErr != nil {
+		// Remote catalog unavailable (offline / network).
+		// Print the fetch-failure note so the user knows install guidance and fuzzy suggestions may be incomplete, then continue.
+		c.printPluginIndexLoadFailureNote(ctx)
 	}
 
-	// Tier 3: args[0] is neither an installed plugin nor a built-in
-	// product. Surface it as an invalid product / plugin name (with
-	// typo suggestions via the error's GetSuggestions) instead of a
-	// misleading "too many arguments" that points at the wrong problem.
+	userCmd := "aliyun " + strings.Join(args, " ")
+
+	// Step 2: known plugin → branch on local install state.
+	if indexHit != nil {
+		installed, _, ierr := helpDelegateIsInstalled(productCode)
+		if ierr != nil || !installed {
+			// Manifest unreadable is treated as "not installed" — the install guidance is the right next step in either case
+			// (re-running install will repair a corrupted manifest).
+			return true, fmt.Errorf(
+				"'%s' looks like a plugin command but plugin '%s' is not installed.\n"+
+					"Run 'aliyun plugin install --name %s' to install it and try again.",
+				userCmd, productCode, indexHit.Name,
+			)
+		}
+		// Installed → forward to plugin --help.
+		pluginArgs := getPluginArgsForHelp(productCode)
+		c.setLangEnv(ctx)
+		if ok, perr := helpDelegateExecute(productCode, pluginArgs, ctx); ok {
+			return true, perr
+		}
+		// Manifest said installed but the binary vanished between checks.
+		// Don't fall through to the legacy error — surface reinstall guidance so the user gets a one-line fix.
+		return true, fmt.Errorf(
+			"'%s' looks like a plugin command and plugin '%s' is registered as installed but its binary cannot be located.\n"+
+				"Run 'aliyun plugin install --name %s' to reinstall it and try again.",
+			userCmd, productCode, indexHit.Name,
+		)
+	}
+
+	// Step 3: index miss but locally installed (dev side-load case — internal plugins distributed before they hit the public catalog).
+	// Forward anyway so these users still get plugin-rendered help.
+	if installed, _, ierr := helpDelegateIsInstalled(productCode); ierr == nil && installed {
+		pluginArgs := getPluginArgsForHelp(productCode)
+		c.setLangEnv(ctx)
+		if ok, perr := helpDelegateExecute(productCode, pluginArgs, ctx); ok {
+			return true, perr
+		}
+		// Binary vanished and we have no canonical Name to suggest a reinstall command — fall through to step 4 fuzzy diagnostics.
+	}
+
+	// Step 4: completely unknown plugin name — fuzzy-suggest from the
+	// remote index via InvalidProductOrPluginError.GetSuggestions.
+	//
+	// Note: built-in OpenAPI products technically can't reach this
+	// step (Gate-2 filters out PascalCase APINames), but a user who types an all-lowercase product name like `ecs foo bar` lands here as if they'd typo'd a plugin.
+	// The Hint surfaces the product-vs-plugin distinction so OpenAPI users who took the "wrong" path get the right syntax instead of a misleading "'ecs' is not a valid product" with no further context.
+	// The fuzzy suggester is still loaded with plugin names so genuine plugin typos see "Did you mean ..." underneath.
 	var plugList []plugin.PluginInfo
 	if c.pluginIndex != nil {
 		plugList = c.pluginIndex.Plugins
 	}
-	return true, &InvalidProductOrPluginError{Code: args[0], library: c.library, plugins: plugList}
+	return true, &InvalidProductOrPluginError{
+		Code:    productCode,
+		library: c.library,
+		plugins: plugList,
+		Hint: "If you meant an OpenAPI built-in call, the form is " +
+			"'aliyun <product> <APIName>' (API names are PascalCase, e.g. 'DescribeRegions').",
+	}
 }

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -540,7 +540,7 @@ func TestPrintHelpContextHints_AiModeConfigEnabled(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  tryDelegatePluginHelp (commando_help.go) — gating + tier-by-tier coverage
+//  tryDelegatePluginHelp (commando_help.go) — gating + step-by-step coverage
 // ─────────────────────────────────────────────────────────────────────────────
 
 func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
@@ -565,18 +565,50 @@ func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
 	}
 }
 
-// Test_tryDelegatePluginHelp_PluginPath covers every tier reached after the
-// HTTP-method gate passes:
-//
-//	tier-0: plugin installed → ExecutePlugin (success / vanished-binary / exit-error)
-//	tier-1: not installed + remote index match → install guidance
-//	tier-2: not installed + builtin product → InvalidUnifiedApiError or fall-through
-//	tier-3: not installed + neither plugin nor product → InvalidProductOrPluginError
-//
-// `helpDelegateIsInstalled` / `helpDelegateExecute` are package-level test
-// seams declared in commando_help.go next to tryDelegatePluginHelp;
-// production code outside the helper still calls plugin.* directly.
-func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
+// Test_tryDelegatePluginHelp_RefusesUppercaseSubcommand exercises Gate-2:
+// any uppercase character in args[1] flags the input as a legacy-mode
+// (typically PascalCase OpenAPI APIName) shape, so the helper falls
+// through to the historical "too many arguments" wording rather than
+// inventing a plugin-flavoured diagnostic that would point at the
+// wrong problem. Examples drawn from real OpenAPI invocations.
+func Test_tryDelegatePluginHelp_RefusesUppercaseSubcommand(t *testing.T) {
+	c, ctx := newTryDelegateHarness(t)
+	// Even with a fully populated index we must NOT treat these as
+	// plugin commands — the gate is purely syntactic on args[1].
+	c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+		{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+		{Name: "aliyun-cli-ecs", ProductCode: "ecs"}, // hypothetical plugin homonym
+	}}
+	helpDelegateIsInstalled = func(string) (bool, string, error) {
+		t.Fatal("Gate-2 must short-circuit before any I/O")
+		return false, "", nil
+	}
+
+	cases := [][]string{
+		{"ecs", "DescribeRegions", "extra"}, // canonical PascalCase API
+		{"hologram", "DescribeFoo", "bar"},  // PascalCase even on a real plugin name
+		{"vpc", "describeVpcs", "x"},        // camelCase — first letter lower but Vpcs uppercased
+		{"fc-open", "InvokeFunction", "y"},  // hyphenated product + PascalCase API
+		{"hologram", "Config", "set"},       // user accidentally TitleCase'd a plugin sub-command
+	}
+	for _, args := range cases {
+		t.Run(args[0]+"/"+args[1], func(t *testing.T) {
+			delegated, err := c.tryDelegatePluginHelp(ctx, args)
+			assert.False(t, delegated, "uppercase args[1] must fall through (legacy shape)")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// newTryDelegateHarness wires a Commando + Context with the framework
+// state tryDelegatePluginHelp needs (cmd flags + i18n short text), and
+// also stashes/restores the package-level test seams so each subtest
+// can swap helpDelegateIsInstalled / helpDelegateExecute freely. The
+// seam wiring is the whole reason these tests live at help-test scope:
+// production code calls plugin.IsPluginInstalled / plugin.ExecutePlugin
+// directly, which would otherwise need a real plugin binary on disk.
+func newTryDelegateHarness(t *testing.T) (*Commando, *cli.Context) {
+	t.Helper()
 	w := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	ctx := cli.NewCommandContext(w, stderr)
@@ -595,134 +627,29 @@ func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
 		helpDelegateIsInstalled = origIsInstalled
 		helpDelegateExecute = origExecute
 	})
+	return c, ctx
+}
 
-	t.Run("IsInstalled error → fall through", func(t *testing.T) {
-		helpDelegateIsInstalled = func(string) (bool, string, error) {
-			return false, "", fmt.Errorf("manifest corrupted")
-		}
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			t.Fatal("ExecutePlugin must not be called when IsInstalled errors")
-			return false, nil
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.False(t, delegated)
-		assert.NoError(t, err, "inspection errors must never bubble up at help time")
-	})
+// Test_tryDelegatePluginHelp_PluginPath covers every step the helper can
+// take after the gates pass (Gate-1 HTTP method, Gate-2 uppercase in
+// args[1]). Layout mirrors the decision tree in commando_help.go:
+//
+//	Step 2 — index hit + installed:    forward (success / exit-err / vanished)
+//	Step 2 — index hit + not installed: install guidance
+//	Step 2 — index hit + manifest err: treated as not installed → install guidance
+//	Step 2 — index hit case-insensitive
+//	Step 3 — index miss + installed:   forward (dev side-load)
+//	Step 4 — neither plugin nor product: InvalidProductOrPluginError + fuzzy
+//	Step 4 — index fetch failed:       fetch-note + InvalidProductOrPluginError
+//
+// Helpers are toggled per-subtest so each path is exercised in isolation.
+func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
+	t.Run("step-2 index hit + installed → forward succeeds", func(t *testing.T) {
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+		}}
 
-	t.Run("not installed + no remote index → tier-3 InvalidProductOrPluginError", func(t *testing.T) {
-		// pluginIndex stays nil (default), args[0] not a built-in product.
-		// Tier-3 diagnostic kicks in: report it as an unknown product /
-		// plugin rather than falling through to "too many arguments",
-		// which would point at the wrong problem.
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			t.Fatal("ExecutePlugin must not be called when plugin not installed")
-			return false, nil
-		}
-		c.pluginIndex = nil
-		c.pluginIndexErr = nil
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"zzzunknown", "foo", "bar"})
-		assert.True(t, delegated, "tier-3 must short-circuit the legacy 'too many arguments'")
-		var ipErr *InvalidProductOrPluginError
-		assert.ErrorAs(t, err, &ipErr)
-		assert.Equal(t, "zzzunknown", ipErr.Code)
-	})
-
-	t.Run("not installed + remote index has match → tier-1 install guidance", func(t *testing.T) {
-		// User typed `aliyun hologram dt list --help` but hologram plugin
-		// was never installed. The remote catalog knows it → we MUST tell
-		// them how to install instead of dumping "too many arguments: N".
-		// This mirrors printProductUsage's behaviour for `aliyun hologram --help`.
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			t.Fatal("ExecutePlugin must not be called when plugin not installed")
-			return false, nil
-		}
-		c.pluginIndex = &plugin.Index{
-			Plugins: []plugin.PluginInfo{
-				{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
-				{Name: "aliyun-cli-pds", ProductCode: "pds"},
-			},
-		}
-		c.pluginIndexErr = nil
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "dt", "list"})
-		assert.True(t, delegated, "guided error must short-circuit the legacy 'too many arguments'")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "aliyun plugin install --names aliyun-cli-hologram",
-			"the error must point the user at the exact install command")
-		assert.Contains(t, err.Error(), "'hologram'",
-			"the error must name the offending command")
-	})
-
-	t.Run("not installed + remote match is case-insensitive", func(t *testing.T) {
-		// `aliyun help Hologram dt list` — user typed mixed case; the index
-		// stores canonical lowercase. EqualFold must still find a match so
-		// the install guidance is consistent with how printProductUsage matches.
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		c.pluginIndex = &plugin.Index{
-			Plugins: []plugin.PluginInfo{{Name: "aliyun-cli-hologram", ProductCode: "hologram"}},
-		}
-		c.pluginIndexErr = nil
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"Hologram", "dt", "list"})
-		assert.True(t, delegated)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "aliyun-cli-hologram")
-	})
-
-	t.Run("not installed + remote index has no match → tier-3 InvalidProductOrPluginError", func(t *testing.T) {
-		// Remote index loaded successfully but doesn't know args[0], and
-		// args[0] isn't a built-in product either. Tier-3 surfaces it as
-		// an unknown product / plugin (with typo suggestions populated
-		// from the remote index for the SuggestibleError protocol).
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		c.pluginIndex = &plugin.Index{
-			Plugins: []plugin.PluginInfo{
-				{Name: "aliyun-cli-pds", ProductCode: "pds"},
-				{Name: "aliyun-cli-fc", ProductCode: "fc"},
-			},
-		}
-		c.pluginIndexErr = nil
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"zzzunknownproduct", "foo", "bar"})
-		assert.True(t, delegated)
-		var ipErr *InvalidProductOrPluginError
-		assert.ErrorAs(t, err, &ipErr)
-		assert.Equal(t, "zzzunknownproduct", ipErr.Code)
-	})
-
-	t.Run("tier-2: builtin product + unknown API → InvalidUnifiedApiError with suggestions", func(t *testing.T) {
-		// args[0]=ecs is a real OpenAPI built-in product, args[1] is a
-		// typo of a real API. Surface the API-name problem (with typo
-		// suggestions from product.ApiNames) instead of the misleading
-		// "too many arguments", which would imply the wrong fix.
-		c.library.builtinRepo = meta.LoadRepository()
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		c.pluginIndex = nil // bypass tier-1
-		c.pluginIndexErr = nil
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", "DescribeXyzTypo", "extra"})
-		assert.True(t, delegated, "tier-2 must short-circuit so user sees the actionable API error")
-		var apiErr *InvalidUnifiedApiError
-		assert.ErrorAs(t, err, &apiErr)
-		assert.Equal(t, "DescribeXyzTypo", apiErr.Name)
-		assert.Contains(t, apiErr.Error(), "ecs",
-			"error message must reference the product so the user knows where to look")
-	})
-
-	t.Run("tier-2: builtin product + valid API but extra args → fall through to legacy", func(t *testing.T) {
-		// args[0]=ecs + a valid API (DescribeRegions is universally
-		// present) + extra junk. This IS a structural arg-count problem
-		// (API help is two-levels deep), so we deliberately fall back to
-		// the legacy "too many arguments" wording rather than fabricating
-		// a more elaborate error.
-		c.library.builtinRepo = meta.LoadRepository()
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		c.pluginIndex = nil
-		c.pluginIndexErr = nil
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", "DescribeRegions", "extra"})
-		assert.False(t, delegated, "valid product+API must fall through; len>2 here is genuinely structural")
-		assert.NoError(t, err)
-	})
-
-	t.Run("installed + execute succeeds → delegated", func(t *testing.T) {
 		var capturedName string
 		var capturedArgs []string
 		helpDelegateIsInstalled = func(name string) (bool, string, error) {
@@ -733,30 +660,23 @@ func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
 			capturedArgs = args
 			return true, nil
 		}
+
 		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
 		assert.True(t, delegated, "must report delegation so caller skips the legacy error")
 		assert.NoError(t, err)
 		assert.Equal(t, "hologram", capturedName)
-		// getPluginArgsForHelp rebuilds argv from os.Args; the test binary's
-		// argv doesn't contain "hologram", so the helper returns its
-		// no-match fallback `[productCode, "--help"]`. The shape is what
-		// matters: the plugin name leads and --help is present.
+		// getPluginArgsForHelp rebuilds argv from os.Args; the test
+		// binary's argv doesn't contain "hologram", so the helper falls
+		// back to `[productCode, "--help"]`. The shape is what matters:
+		// the plugin name leads and --help is present.
 		assert.Equal(t, []string{"hologram", "--help"}, capturedArgs)
 	})
 
-	t.Run("installed + execute returns ok=false (binary vanished) → fall through", func(t *testing.T) {
-		helpDelegateIsInstalled = func(string) (bool, string, error) {
-			return true, "aliyun-cli-hologram", nil
-		}
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			return false, nil // simulate manifest-says-installed-but-binary-missing
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.False(t, delegated, "ok=false must surface as fall-through, not as delegated")
-		assert.NoError(t, err)
-	})
-
-	t.Run("installed + plugin exits with error → delegated, error propagates", func(t *testing.T) {
+	t.Run("step-2 index hit + installed → plugin exit error propagates verbatim", func(t *testing.T) {
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+		}}
 		pluginErr := fmt.Errorf("plugin exited with status 2")
 		helpDelegateIsInstalled = func(string) (bool, string, error) { return true, "x", nil }
 		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
@@ -765,5 +685,231 @@ func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
 		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
 		assert.True(t, delegated)
 		assert.Equal(t, pluginErr, err, "plugin's exit error must reach the user verbatim")
+	})
+
+	t.Run("step-2 index hit + binary vanished → reinstall guidance (no fall-through)", func(t *testing.T) {
+		// Manifest says installed but ExecutePlugin returns ok=false
+		// (binary missing). New behaviour: surface a one-line reinstall
+		// hint instead of the legacy `too many arguments` fall-through,
+		// which would have left the user stranded.
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+		}}
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return true, "aliyun-cli-hologram", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			return false, nil // simulate manifest-says-installed-but-binary-missing
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.True(t, delegated, "vanished-binary case must produce a final answer, not fall through")
+		assert.Error(t, err)
+		// Hallmark phrases of the new copy — locked in so a future
+		// refactor that drifts the wording trips a test instead of
+		// silently changing user-visible diagnostics.
+		assert.Contains(t, err.Error(), "looks like a plugin command",
+			"reinstall guidance must share the plugin-cmd preamble with install guidance")
+		assert.Contains(t, err.Error(), "registered as installed")
+		assert.Contains(t, err.Error(), "binary cannot be located")
+		assert.Contains(t, err.Error(), "to reinstall it and try again",
+			"the reinstall variant must end with the reinstall-and-retry prompt")
+		assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-hologram",
+			"reinstall hint must reference the canonical plugin name")
+		assert.Contains(t, err.Error(), "'aliyun hologram config set'",
+			"error must echo the user's full logical command, not just the plugin code")
+	})
+
+	t.Run("step-2 index hit + not installed → install guidance", func(t *testing.T) {
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+			{Name: "aliyun-cli-pds", ProductCode: "pds"},
+		}}
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when plugin not installed")
+			return false, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "dt", "list"})
+		assert.True(t, delegated, "guided error must short-circuit the legacy 'too many arguments'")
+		assert.Error(t, err)
+		// Hallmark phrases of the new copy — see the matching block in
+		// the binary-vanished subtest for rationale.
+		assert.Contains(t, err.Error(), "looks like a plugin command",
+			"install guidance must lead with the plugin-cmd preamble")
+		assert.Contains(t, err.Error(), "is not installed",
+			"diagnose the install state explicitly")
+		assert.Contains(t, err.Error(), "to install it and try again",
+			"the install variant must end with the install-and-retry prompt")
+		assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-hologram",
+			"the error must point the user at the exact install command")
+		assert.Contains(t, err.Error(), "plugin 'hologram'",
+			"the error must name the offending plugin")
+		assert.Contains(t, err.Error(), "'aliyun hologram dt list'",
+			"error must echo the user's full logical command for long chains")
+	})
+
+	t.Run("step-2 index hit + manifest unreadable → treated as not installed", func(t *testing.T) {
+		// Corrupted manifest used to silently fall through to the
+		// legacy "too many arguments" — masking both the real bug and
+		// the install guidance. New behaviour: index says it's a known
+		// plugin, so guide the user to (re)install regardless of the
+		// manifest hiccup; reinstall would fix a corrupted manifest too.
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+		}}
+		helpDelegateIsInstalled = func(string) (bool, string, error) {
+			return false, "", fmt.Errorf("manifest corrupted")
+		}
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when manifest unreadable")
+			return false, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.True(t, delegated, "manifest errors must NOT silently fall through any more")
+		assert.Error(t, err)
+		// Manifest-error path must produce the SAME diagnostic as the
+		// genuine "not installed" path — re-running install repairs
+		// both, so users shouldn't have to distinguish them.
+		assert.Contains(t, err.Error(), "is not installed")
+		assert.Contains(t, err.Error(), "to install it and try again")
+		assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-hologram")
+		assert.Contains(t, err.Error(), "'aliyun hologram config set'")
+	})
+
+	t.Run("step-2 index hit case-insensitive → canonical Name in guidance", func(t *testing.T) {
+		// `aliyun help Hologram dt list` — user typed mixed case; the
+		// index stores canonical lowercase. EqualFold must still find
+		// a match so the install guidance uses the canonical Name from
+		// the index (consistent with printProductUsage's matching).
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+		}}
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"Hologram", "dt", "list"})
+		assert.True(t, delegated)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "aliyun-cli-hologram")
+	})
+
+	t.Run("step-3 index miss + installed → forward (dev side-load)", func(t *testing.T) {
+		// Internal plugin distributed before it hits the public
+		// catalog. Index doesn't know it but the binary is on disk.
+		// We must still forward, otherwise these users would get
+		// "'myplugin' is not a valid product" — a regression vs the
+		// old fall-through behaviour.
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			// Plugins exist but none matches args[0]
+			{Name: "aliyun-cli-pds", ProductCode: "pds"},
+		}}
+		var capturedName string
+		var capturedArgs []string
+		helpDelegateIsInstalled = func(name string) (bool, string, error) {
+			return true, "aliyun-cli-" + name, nil
+		}
+		helpDelegateExecute = func(name string, args []string, _ *cli.Context) (bool, error) {
+			capturedName = name
+			capturedArgs = args
+			return true, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"sideloaded", "sub", "cmd"})
+		assert.True(t, delegated, "side-loaded plugins must still get to render their own help")
+		assert.NoError(t, err)
+		assert.Equal(t, "sideloaded", capturedName)
+		assert.Equal(t, []string{"sideloaded", "--help"}, capturedArgs)
+	})
+
+	t.Run("step-4 unknown args[0] + remote index has no match → InvalidProductOrPluginError", func(t *testing.T) {
+		// Remote index loaded successfully but doesn't know args[0]
+		// and the plugin isn't installed locally. Step-4 surfaces it
+		// as an unknown product / plugin (with typo suggestions
+		// populated from the remote index for the SuggestibleError
+		// protocol).
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-pds", ProductCode: "pds"},
+			{Name: "aliyun-cli-fc", ProductCode: "fc"},
+		}}
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"zzzunknownproduct", "foo", "bar"})
+		assert.True(t, delegated)
+		var ipErr *InvalidProductOrPluginError
+		assert.ErrorAs(t, err, &ipErr)
+		assert.Equal(t, "zzzunknownproduct", ipErr.Code)
+		// Hint must surface the OpenAPI legacy form so users who
+		// landed here via mistyped APIName (e.g. `aliyun ecs
+		// describeregions extra`) see the right syntax instead of
+		// just "not a valid product".
+		assert.NotEmpty(t, ipErr.Hint, "step-4 must always set Hint so users understand WHY they landed on the diagnostic")
+		assert.Contains(t, err.Error(), "OpenAPI built-in call",
+			"hint must explain the OpenAPI alternative")
+		assert.Contains(t, err.Error(), "PascalCase",
+			"hint must call out APIName casing convention — that's the typical lesson here")
+		assert.Contains(t, err.Error(), "DescribeRegions",
+			"a concrete PascalCase example anchors the explanation")
+	})
+
+	t.Run("step-4 unknown args[0] + no remote index → InvalidProductOrPluginError", func(t *testing.T) {
+		// pluginIndex stays nil (default), nothing installed. Step-4
+		// still kicks in: never fall through to "too many arguments"
+		// once we've decided the shape is plugin-cmd.
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = nil
+		c.pluginIndexErr = nil
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"zzzunknown", "foo", "bar"})
+		assert.True(t, delegated, "step-4 must short-circuit the legacy 'too many arguments'")
+		var ipErr *InvalidProductOrPluginError
+		assert.ErrorAs(t, err, &ipErr)
+		assert.Equal(t, "zzzunknown", ipErr.Code)
+		// Hint is independent of the remote index — it only depends
+		// on having reached step-4. Lock that in.
+		assert.Contains(t, err.Error(), "OpenAPI built-in call")
+	})
+
+	t.Run("step-4 index fetch failed → fetch-note printed + InvalidProductOrPluginError", func(t *testing.T) {
+		// Offline / catalog-load failure. We still produce a final
+		// answer, plus we surface a fetch-failure note so the user
+		// understands why fuzzy suggestions might be sparse.
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = nil
+		c.pluginIndexErr = fmt.Errorf("network unreachable")
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"unknown", "x", "y"})
+		assert.True(t, delegated)
+		var ipErr *InvalidProductOrPluginError
+		assert.ErrorAs(t, err, &ipErr)
+		assert.Contains(t, err.Error(), "OpenAPI built-in call",
+			"hint must be present even when the remote catalog couldn't load")
+		// printPluginIndexLoadFailureNote writes to ctx.Stderr; assert
+		// the side-effect happened so users actually get the heads-up.
+		stderrBuf := ctx.Stderr().(*bytes.Buffer)
+		assert.NotEmpty(t, stderrBuf.String(),
+			"fetch-failure note must be visible to the user when the index can't be loaded")
+	})
+
+	t.Run("PascalCase args[1] never reaches step-1 (regression guard)", func(t *testing.T) {
+		// Defensive duplicate of Test_tryDelegatePluginHelp_RefusesUppercaseSubcommand,
+		// kept here so anyone reading PluginPath in isolation sees that
+		// `ecs DescribeRegions extra` does NOT reach step-1, even when
+		// the index, library, and local manifest are all populated.
+		// Without this guard a future refactor could regress Gate-2 and
+		// silently misroute legacy OpenAPI shapes into plugin diagnostics.
+		c, ctx := newTryDelegateHarness(t)
+		c.pluginIndex = &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-ecs", ProductCode: "ecs"}, // tempt step-1
+		}}
+		helpDelegateIsInstalled = func(string) (bool, string, error) {
+			t.Fatal("plugin-cmd predicate must reject PascalCase before any I/O")
+			return false, "", nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", "DescribeRegions", "extra"})
+		assert.False(t, delegated, "PascalCase args[1] must fall through; legacy 'too many arguments' is the right error here")
+		assert.NoError(t, err)
 	})
 }

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -538,3 +538,232 @@ func TestPrintHelpContextHints_AiModeConfigEnabled(t *testing.T) {
 	assert.Contains(t, out, "configure ai-mode")
 	assert.Contains(t, out, "disable")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  tryDelegatePluginHelp (commando_help.go) — gating + tier-by-tier coverage
+// ─────────────────────────────────────────────────────────────────────────────
+
+func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
+	c := NewCommando(w, profile)
+
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+		t.Run("HTTP method "+method, func(t *testing.T) {
+			delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", method, "/path"})
+			assert.False(t, delegated, "RESTful shape must not be delegated to plugin")
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// Test_tryDelegatePluginHelp_PluginPath covers every tier reached after the
+// HTTP-method gate passes:
+//
+//	tier-0: plugin installed → ExecutePlugin (success / vanished-binary / exit-error)
+//	tier-1: not installed + remote index match → install guidance
+//	tier-2: not installed + builtin product → InvalidUnifiedApiError or fall-through
+//	tier-3: not installed + neither plugin nor product → InvalidProductOrPluginError
+//
+// `helpDelegateIsInstalled` / `helpDelegateExecute` are package-level test
+// seams declared in commando_help.go next to tryDelegatePluginHelp;
+// production code outside the helper still calls plugin.* directly.
+func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
+	c := NewCommando(w, profile)
+
+	origIsInstalled := helpDelegateIsInstalled
+	origExecute := helpDelegateExecute
+	t.Cleanup(func() {
+		helpDelegateIsInstalled = origIsInstalled
+		helpDelegateExecute = origExecute
+	})
+
+	t.Run("IsInstalled error → fall through", func(t *testing.T) {
+		helpDelegateIsInstalled = func(string) (bool, string, error) {
+			return false, "", fmt.Errorf("manifest corrupted")
+		}
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when IsInstalled errors")
+			return false, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.False(t, delegated)
+		assert.NoError(t, err, "inspection errors must never bubble up at help time")
+	})
+
+	t.Run("not installed + no remote index → tier-3 InvalidProductOrPluginError", func(t *testing.T) {
+		// pluginIndex stays nil (default), args[0] not a built-in product.
+		// Tier-3 diagnostic kicks in: report it as an unknown product /
+		// plugin rather than falling through to "too many arguments",
+		// which would point at the wrong problem.
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when plugin not installed")
+			return false, nil
+		}
+		c.pluginIndex = nil
+		c.pluginIndexErr = nil
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"zzzunknown", "foo", "bar"})
+		assert.True(t, delegated, "tier-3 must short-circuit the legacy 'too many arguments'")
+		var ipErr *InvalidProductOrPluginError
+		assert.ErrorAs(t, err, &ipErr)
+		assert.Equal(t, "zzzunknown", ipErr.Code)
+	})
+
+	t.Run("not installed + remote index has match → tier-1 install guidance", func(t *testing.T) {
+		// User typed `aliyun hologram dt list --help` but hologram plugin
+		// was never installed. The remote catalog knows it → we MUST tell
+		// them how to install instead of dumping "too many arguments: N".
+		// This mirrors printProductUsage's behaviour for `aliyun hologram --help`.
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when plugin not installed")
+			return false, nil
+		}
+		c.pluginIndex = &plugin.Index{
+			Plugins: []plugin.PluginInfo{
+				{Name: "aliyun-cli-hologram", ProductCode: "hologram"},
+				{Name: "aliyun-cli-pds", ProductCode: "pds"},
+			},
+		}
+		c.pluginIndexErr = nil
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "dt", "list"})
+		assert.True(t, delegated, "guided error must short-circuit the legacy 'too many arguments'")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "aliyun plugin install --names aliyun-cli-hologram",
+			"the error must point the user at the exact install command")
+		assert.Contains(t, err.Error(), "'hologram'",
+			"the error must name the offending command")
+	})
+
+	t.Run("not installed + remote match is case-insensitive", func(t *testing.T) {
+		// `aliyun help Hologram dt list` — user typed mixed case; the index
+		// stores canonical lowercase. EqualFold must still find a match so
+		// the install guidance is consistent with how printProductUsage matches.
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		c.pluginIndex = &plugin.Index{
+			Plugins: []plugin.PluginInfo{{Name: "aliyun-cli-hologram", ProductCode: "hologram"}},
+		}
+		c.pluginIndexErr = nil
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"Hologram", "dt", "list"})
+		assert.True(t, delegated)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "aliyun-cli-hologram")
+	})
+
+	t.Run("not installed + remote index has no match → tier-3 InvalidProductOrPluginError", func(t *testing.T) {
+		// Remote index loaded successfully but doesn't know args[0], and
+		// args[0] isn't a built-in product either. Tier-3 surfaces it as
+		// an unknown product / plugin (with typo suggestions populated
+		// from the remote index for the SuggestibleError protocol).
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		c.pluginIndex = &plugin.Index{
+			Plugins: []plugin.PluginInfo{
+				{Name: "aliyun-cli-pds", ProductCode: "pds"},
+				{Name: "aliyun-cli-fc", ProductCode: "fc"},
+			},
+		}
+		c.pluginIndexErr = nil
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"zzzunknownproduct", "foo", "bar"})
+		assert.True(t, delegated)
+		var ipErr *InvalidProductOrPluginError
+		assert.ErrorAs(t, err, &ipErr)
+		assert.Equal(t, "zzzunknownproduct", ipErr.Code)
+	})
+
+	t.Run("tier-2: builtin product + unknown API → InvalidUnifiedApiError with suggestions", func(t *testing.T) {
+		// args[0]=ecs is a real OpenAPI built-in product, args[1] is a
+		// typo of a real API. Surface the API-name problem (with typo
+		// suggestions from product.ApiNames) instead of the misleading
+		// "too many arguments", which would imply the wrong fix.
+		c.library.builtinRepo = meta.LoadRepository()
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		c.pluginIndex = nil // bypass tier-1
+		c.pluginIndexErr = nil
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", "DescribeXyzTypo", "extra"})
+		assert.True(t, delegated, "tier-2 must short-circuit so user sees the actionable API error")
+		var apiErr *InvalidUnifiedApiError
+		assert.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, "DescribeXyzTypo", apiErr.Name)
+		assert.Contains(t, apiErr.Error(), "ecs",
+			"error message must reference the product so the user knows where to look")
+	})
+
+	t.Run("tier-2: builtin product + valid API but extra args → fall through to legacy", func(t *testing.T) {
+		// args[0]=ecs + a valid API (DescribeRegions is universally
+		// present) + extra junk. This IS a structural arg-count problem
+		// (API help is two-levels deep), so we deliberately fall back to
+		// the legacy "too many arguments" wording rather than fabricating
+		// a more elaborate error.
+		c.library.builtinRepo = meta.LoadRepository()
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		c.pluginIndex = nil
+		c.pluginIndexErr = nil
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", "DescribeRegions", "extra"})
+		assert.False(t, delegated, "valid product+API must fall through; len>2 here is genuinely structural")
+		assert.NoError(t, err)
+	})
+
+	t.Run("installed + execute succeeds → delegated", func(t *testing.T) {
+		var capturedName string
+		var capturedArgs []string
+		helpDelegateIsInstalled = func(name string) (bool, string, error) {
+			return true, "aliyun-cli-" + name, nil
+		}
+		helpDelegateExecute = func(name string, args []string, _ *cli.Context) (bool, error) {
+			capturedName = name
+			capturedArgs = args
+			return true, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.True(t, delegated, "must report delegation so caller skips the legacy error")
+		assert.NoError(t, err)
+		assert.Equal(t, "hologram", capturedName)
+		// getPluginArgsForHelp rebuilds argv from os.Args; the test binary's
+		// argv doesn't contain "hologram", so the helper returns its
+		// no-match fallback `[productCode, "--help"]`. The shape is what
+		// matters: the plugin name leads and --help is present.
+		assert.Equal(t, []string{"hologram", "--help"}, capturedArgs)
+	})
+
+	t.Run("installed + execute returns ok=false (binary vanished) → fall through", func(t *testing.T) {
+		helpDelegateIsInstalled = func(string) (bool, string, error) {
+			return true, "aliyun-cli-hologram", nil
+		}
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			return false, nil // simulate manifest-says-installed-but-binary-missing
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.False(t, delegated, "ok=false must surface as fall-through, not as delegated")
+		assert.NoError(t, err)
+	})
+
+	t.Run("installed + plugin exits with error → delegated, error propagates", func(t *testing.T) {
+		pluginErr := fmt.Errorf("plugin exited with status 2")
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return true, "x", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			return true, pluginErr
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.True(t, delegated)
+		assert.Equal(t, pluginErr, err, "plugin's exit error must reach the user verbatim")
+	})
+}

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -501,133 +501,14 @@ func Test_help(t *testing.T) {
 	args = []string{"test", "test0", "test1"}
 	err = command.help(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "too many arguments: 3", err.Error())
-}
-
-// The "plugin not installed → don't delegate, fall through to original
-// error" path is implicitly covered by Test_help's last case
-// (args=["test","test0","test1"] still reports "too many arguments: 3").
-func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
-	w := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	ctx := cli.NewCommandContext(w, stderr)
-	cmd := &cli.Command{}
-	cmd.EnableUnknownFlag = true
-	AddFlags(cmd.Flags())
-	ctx.EnterCommand(cmd)
-	ctx.Command().Short = &i18n.Text{}
-
-	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
-	c := NewCommando(w, profile)
-
-	for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
-		t.Run("HTTP method "+method, func(t *testing.T) {
-			delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", method, "/path"})
-			assert.False(t, delegated, "RESTful shape must not be delegated to plugin")
-			assert.NoError(t, err)
-		})
-	}
-}
-
-// Test_tryDelegatePluginHelp_PluginPath covers the three branches reached
-// after the gating checks pass: (1) plugin manifest lookup returns an error
-// → caller falls through, (2) manifest hit → ExecutePlugin succeeds and the
-// plugin's exit error is returned, (3) manifest said installed but the
-// binary vanished (ExecutePlugin returns ok=false) → caller falls through
-// to the legacy error so the user sees the original "too many arguments"
-// rather than a confusing "plugin not found" at help time.
-//
-// `helpDelegateIsInstalled` / `helpDelegateExecute` are package-level test
-// seams declared in commando.go right next to `hookdo`; production code
-// outside `tryDelegatePluginHelp` still calls plugin.* directly.
-func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
-	w := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	ctx := cli.NewCommandContext(w, stderr)
-	cmd := &cli.Command{}
-	cmd.EnableUnknownFlag = true
-	AddFlags(cmd.Flags())
-	ctx.EnterCommand(cmd)
-	ctx.Command().Short = &i18n.Text{}
-
-	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
-	c := NewCommando(w, profile)
-
-	origIsInstalled := helpDelegateIsInstalled
-	origExecute := helpDelegateExecute
-	t.Cleanup(func() {
-		helpDelegateIsInstalled = origIsInstalled
-		helpDelegateExecute = origExecute
-	})
-
-	t.Run("IsInstalled error → fall through", func(t *testing.T) {
-		helpDelegateIsInstalled = func(string) (bool, string, error) {
-			return false, "", fmt.Errorf("manifest corrupted")
-		}
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			t.Fatal("ExecutePlugin must not be called when IsInstalled errors")
-			return false, nil
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.False(t, delegated)
-		assert.NoError(t, err, "inspection errors must never bubble up at help time")
-	})
-
-	t.Run("not installed → fall through", func(t *testing.T) {
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			t.Fatal("ExecutePlugin must not be called when plugin not installed")
-			return false, nil
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.False(t, delegated)
-		assert.NoError(t, err)
-	})
-
-	t.Run("installed + execute succeeds → delegated", func(t *testing.T) {
-		var capturedName string
-		var capturedArgs []string
-		helpDelegateIsInstalled = func(name string) (bool, string, error) {
-			return true, "aliyun-cli-" + name, nil
-		}
-		helpDelegateExecute = func(name string, args []string, _ *cli.Context) (bool, error) {
-			capturedName = name
-			capturedArgs = args
-			return true, nil
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.True(t, delegated, "must report delegation so caller skips the legacy error")
-		assert.NoError(t, err)
-		assert.Equal(t, "hologram", capturedName)
-		// getPluginArgsForHelp rebuilds argv from os.Args; the test binary's
-		// argv doesn't contain "hologram", so the helper returns its
-		// no-match fallback `[productCode, "--help"]`. The shape is what
-		// matters: the plugin name leads and --help is present.
-		assert.Equal(t, []string{"hologram", "--help"}, capturedArgs)
-	})
-
-	t.Run("installed + execute returns ok=false (binary vanished) → fall through", func(t *testing.T) {
-		helpDelegateIsInstalled = func(string) (bool, string, error) {
-			return true, "aliyun-cli-hologram", nil
-		}
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			return false, nil // simulate manifest-says-installed-but-binary-missing
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.False(t, delegated, "ok=false must surface as fall-through, not as delegated")
-		assert.NoError(t, err)
-	})
-
-	t.Run("installed + plugin exits with error → delegated, error propagates", func(t *testing.T) {
-		pluginErr := fmt.Errorf("plugin exited with status 2")
-		helpDelegateIsInstalled = func(string) (bool, string, error) { return true, "x", nil }
-		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
-			return true, pluginErr
-		}
-		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
-		assert.True(t, delegated)
-		assert.Equal(t, pluginErr, err, "plugin's exit error must reach the user verbatim")
-	})
+	// tryDelegatePluginHelp's tier-3 diagnostic now intercepts this case
+	// (args[0]="test" is neither an installed plugin nor a built-in
+	// product) and surfaces a far more actionable error than the legacy
+	// "too many arguments: 3" — which previously pointed at the wrong
+	// problem (the user's real issue is the unknown product name). See
+	// Test_tryDelegatePluginHelp_* in commando_help_test.go for the full
+	// tier-by-tier coverage.
+	assert.Equal(t, "'test' is not a valid product. See `aliyun help`.", err.Error())
 }
 
 func Test_complete(t *testing.T) {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -504,6 +504,31 @@ func Test_help(t *testing.T) {
 	assert.Equal(t, "too many arguments: 3", err.Error())
 }
 
+// The "plugin not installed → don't delegate, fall through to original
+// error" path is implicitly covered by Test_help's last case
+// (args=["test","test0","test1"] still reports "too many arguments: 3").
+func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
+	c := NewCommando(w, profile)
+
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+		t.Run("HTTP method "+method, func(t *testing.T) {
+			delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", method, "/path"})
+			assert.False(t, delegated, "RESTful shape must not be delegated to plugin")
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func Test_complete(t *testing.T) {
 	w := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -529,6 +529,107 @@ func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
 	}
 }
 
+// Test_tryDelegatePluginHelp_PluginPath covers the three branches reached
+// after the gating checks pass: (1) plugin manifest lookup returns an error
+// → caller falls through, (2) manifest hit → ExecutePlugin succeeds and the
+// plugin's exit error is returned, (3) manifest said installed but the
+// binary vanished (ExecutePlugin returns ok=false) → caller falls through
+// to the legacy error so the user sees the original "too many arguments"
+// rather than a confusing "plugin not found" at help time.
+//
+// `helpDelegateIsInstalled` / `helpDelegateExecute` are package-level test
+// seams declared in commando.go right next to `hookdo`; production code
+// outside `tryDelegatePluginHelp` still calls plugin.* directly.
+func Test_tryDelegatePluginHelp_PluginPath(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
+	c := NewCommando(w, profile)
+
+	origIsInstalled := helpDelegateIsInstalled
+	origExecute := helpDelegateExecute
+	t.Cleanup(func() {
+		helpDelegateIsInstalled = origIsInstalled
+		helpDelegateExecute = origExecute
+	})
+
+	t.Run("IsInstalled error → fall through", func(t *testing.T) {
+		helpDelegateIsInstalled = func(string) (bool, string, error) {
+			return false, "", fmt.Errorf("manifest corrupted")
+		}
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when IsInstalled errors")
+			return false, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.False(t, delegated)
+		assert.NoError(t, err, "inspection errors must never bubble up at help time")
+	})
+
+	t.Run("not installed → fall through", func(t *testing.T) {
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return false, "", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			t.Fatal("ExecutePlugin must not be called when plugin not installed")
+			return false, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.False(t, delegated)
+		assert.NoError(t, err)
+	})
+
+	t.Run("installed + execute succeeds → delegated", func(t *testing.T) {
+		var capturedName string
+		var capturedArgs []string
+		helpDelegateIsInstalled = func(name string) (bool, string, error) {
+			return true, "aliyun-cli-" + name, nil
+		}
+		helpDelegateExecute = func(name string, args []string, _ *cli.Context) (bool, error) {
+			capturedName = name
+			capturedArgs = args
+			return true, nil
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.True(t, delegated, "must report delegation so caller skips the legacy error")
+		assert.NoError(t, err)
+		assert.Equal(t, "hologram", capturedName)
+		// getPluginArgsForHelp rebuilds argv from os.Args; the test binary's
+		// argv doesn't contain "hologram", so the helper returns its
+		// no-match fallback `[productCode, "--help"]`. The shape is what
+		// matters: the plugin name leads and --help is present.
+		assert.Equal(t, []string{"hologram", "--help"}, capturedArgs)
+	})
+
+	t.Run("installed + execute returns ok=false (binary vanished) → fall through", func(t *testing.T) {
+		helpDelegateIsInstalled = func(string) (bool, string, error) {
+			return true, "aliyun-cli-hologram", nil
+		}
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			return false, nil // simulate manifest-says-installed-but-binary-missing
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.False(t, delegated, "ok=false must surface as fall-through, not as delegated")
+		assert.NoError(t, err)
+	})
+
+	t.Run("installed + plugin exits with error → delegated, error propagates", func(t *testing.T) {
+		pluginErr := fmt.Errorf("plugin exited with status 2")
+		helpDelegateIsInstalled = func(string) (bool, string, error) { return true, "x", nil }
+		helpDelegateExecute = func(string, []string, *cli.Context) (bool, error) {
+			return true, pluginErr
+		}
+		delegated, err := c.tryDelegatePluginHelp(ctx, []string{"hologram", "config", "set"})
+		assert.True(t, delegated)
+		assert.Equal(t, pluginErr, err, "plugin's exit error must reach the user verbatim")
+	})
+}
+
 func Test_complete(t *testing.T) {
 	w := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -501,14 +501,13 @@ func Test_help(t *testing.T) {
 	args = []string{"test", "test0", "test1"}
 	err = command.help(ctx, args)
 	assert.NotNil(t, err)
-	// tryDelegatePluginHelp's tier-3 diagnostic now intercepts this case
-	// (args[0]="test" is neither an installed plugin nor a built-in
-	// product) and surfaces a far more actionable error than the legacy
-	// "too many arguments: 3" — which previously pointed at the wrong
-	// problem (the user's real issue is the unknown product name). See
-	// Test_tryDelegatePluginHelp_* in commando_help_test.go for the full
-	// tier-by-tier coverage.
-	assert.Equal(t, "'test' is not a valid product. See `aliyun help`.", err.Error())
+	// tryDelegatePluginHelp now intercepts every 3+ arg shape and produces an actionable diagnostic instead of the legacy "too many arguments: 3"
+	// — which used to imply args[0] was a valid product even when (as here) it wasn't.
+	// For args[0]="test", neither an installed plugin nor a built-in OpenAPI product,
+	// the helper falls all the way through to step-4 (fuzzy suggestion via InvalidProductOrPluginError, plus a Hint explaining the OpenAPI alternative form).
+	assert.Contains(t, err.Error(), "'test' is not a valid product. See `aliyun help`.")
+	assert.Contains(t, err.Error(), "OpenAPI built-in call",
+		"step-4 must surface the OpenAPI alternative as a Hint")
 }
 
 func Test_complete(t *testing.T) {

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -82,13 +82,23 @@ func (e *InvalidParameterError) GetSuggestions() []string {
 }
 
 type InvalidProductOrPluginError struct {
-	Code    string
+	Code string
+	// Hint, when non-empty, is appended to Error() on its own line.
+	// Used by callers that have additional context to share
+	// — for example tryDelegatePluginHelp's step-4 explains why a 3+ arg lowercase shape was treated as a plugin command,
+	// so users who actually meant an OpenAPI built-in call see the right syntax.
+	// Default callers leave it empty; behaviour is unchanged.
+	Hint    string
 	library *Library
 	plugins []plugin.PluginInfo
 }
 
 func (e *InvalidProductOrPluginError) Error() string {
-	return fmt.Sprintf("'%s' is not a valid product. See `aliyun help`.", e.Code)
+	msg := fmt.Sprintf("'%s' is not a valid product. See `aliyun help`.", e.Code)
+	if e.Hint != "" {
+		msg += "\n" + e.Hint
+	}
+	return msg
 }
 
 func (e *InvalidProductOrPluginError) GetSuggestions() []string {

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -108,10 +108,26 @@ func TestInvalidParameterError_GetSuggestions(t *testing.T) {
 }
 
 func TestInvalidProductOrPluginError_Error(t *testing.T) {
-	err := &InvalidProductOrPluginError{
-		Code: "fcc",
-	}
-	assert.Equal(t, "'fcc' is not a valid product. See `aliyun help`.", err.Error())
+	t.Run("default (no hint) keeps legacy single-line wording", func(t *testing.T) {
+		err := &InvalidProductOrPluginError{
+			Code: "fcc",
+		}
+		assert.Equal(t, "'fcc' is not a valid product. See `aliyun help`.", err.Error())
+	})
+
+	t.Run("hint is appended on its own line", func(t *testing.T) {
+		// Hint exists so callers with extra context (e.g. step-4 of tryDelegatePluginHelp) can explain WHY the user landed on this diagnostic without the explanation leaking into other callers.
+		// Default Hint=="" must not change pre-existing output (covered by the subtest above).
+		err := &InvalidProductOrPluginError{
+			Code: "ecs",
+			Hint: "If you meant an OpenAPI built-in call, the form is 'aliyun <product> <APIName>'.",
+		}
+		assert.Equal(t,
+			"'ecs' is not a valid product. See `aliyun help`.\n"+
+				"If you meant an OpenAPI built-in call, the form is 'aliyun <product> <APIName>'.",
+			err.Error(),
+			"hint must follow the legacy line on its own line — single-line legacy users keep their format")
+	})
 }
 
 func TestInvalidProductOrPluginError_GetSuggestions(t *testing.T) {


### PR DESCRIPTION
**Description**

Fix `too many arguments: N` when running help on plugin subcommands 3 or more levels deep, e.g.:
```
aliyun hologram config set --help
aliyun hologram dt list --help
aliyun help hologram config set
```
The cli framework `Commando.help` itself only modelled the OpenAPI product → API hierarchy (max depth 2); anything deeper hit the else branch and returned `too many arguments: N`. Add a third layer to `Commando.help`