### PR TITLE
{Configure} Match policy rules against the command users actually type for ROA

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -321,9 +321,17 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				c.setLangEnv(ctx)
 			}
 
-			// Safety policy check for plugin execution (before spawning plugin process)
+			// Safety policy check for plugin execution (before spawning plugin process).
+			// Plugins can be N-level (e.g. `aliyun fc function create`), so the
+			// command identifier joins every positional segment with ':' to stay
+			// consistent with how `product:command` itself is separated:
+			//   aliyun fc create-function       -> fc:create-function
+			//   aliyun fc function create       -> fc:function:create
+			//   aliyun fc invoke my-fn          -> fc:invoke:my-fn
+			// Users can still match coarsely with wildcards like `fc:function:*` or `fc:function*`.
 			if !isHelp && !isVersion {
-				if err := c.checkSafetyPolicy(ctx, args[0], apiOrMethod, ""); err != nil {
+				cmdName := strings.Join(args[1:], ":")
+				if err := c.checkSafetyPolicy(ctx, args[0], cmdName, ""); err != nil {
 					return err
 				}
 			}
@@ -381,6 +389,11 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				}
 			}
 		}
+		// Safety policy is keyed on what the user actually typed, so a rule like `sls:ListProject` matches `aliyun sls ListProject` 
+		// regardless of how the cli later dispatches it (REST GET /, RPC, etc.).
+		if err := c.checkSafetyPolicy(ctx, product.Code, args[1], ""); err != nil {
+			return err
+		}
 		if product.ApiStyle == "restful" {
 			api, found := meta.HookGetApi(c.library.GetApi)(product.Code, product.Version, args[1])
 			// For restful products, the 2-arg form `aliyun <product> <ApiName>` requires a valid ApiName so we can resolve the underlying Method + PathPattern from metadata.
@@ -416,6 +429,9 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		if find {
 			c.CheckApiParamWithBuildInArgs(ctx, api)
 		}
+		if err := c.checkSafetyPolicy(ctx, product.Code, args[1], args[2]); err != nil {
+			return err
+		}
 		if ShouldUseOpenapi(ctx, &product) {
 			if !find {
 				return cli.NewErrorWithTip(fmt.Errorf("can not find api by path %s", args[2]),
@@ -437,10 +453,6 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api *meta.Api, method string, path string) error {
 	if product == nil {
 		return fmt.Errorf("invalid product, please check product code")
-	}
-
-	if err := c.checkSafetyPolicy(ctx, product.Code, method, path); err != nil {
-		return err
 	}
 
 	apiContext, err := c.createHttpContext(ctx, product, api, method, path)
@@ -488,10 +500,6 @@ func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api
 }
 
 func (c *Commando) processInvoke(ctx *cli.Context, productCode string, apiOrMethod string, path string) error {
-	if err := c.checkSafetyPolicy(ctx, productCode, apiOrMethod, path); err != nil {
-		return err
-	}
-
 	// create specific invoker
 	invoker, err := c.createInvoker(ctx, productCode, apiOrMethod, path)
 	if err != nil {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/config"
 	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/safety"
 )
 
 // setTestHomeDir sets the test home directory for cross-platform testing.
@@ -3163,5 +3164,210 @@ func TestSetLangEnv(t *testing.T) {
 		envs := ctx.GetRuntimeEnvs()
 		assert.Equal(t, "en_US.UTF-8", envs["LANG"])
 		assert.Equal(t, "bar", envs["FOO"], "existing entries must be kept")
+	})
+}
+
+// writeSafetyPolicy writes a safety-policy.json under ~/.aliyun in testHome and
+// makes sure no leftover env override is present, so the policy on disk is the
+// one that actually takes effect during the test.
+func writeSafetyPolicy(t *testing.T, testHome string, rules []safety.Rule) {
+	t.Helper()
+
+	for _, k := range []string{safety.EnvSafetyPolicyEnabled, safety.EnvSafetyPolicyRules} {
+		prev, had := os.LookupEnv(k)
+		os.Unsetenv(k)
+		t.Cleanup(func() {
+			if had {
+				os.Setenv(k, prev)
+			} else {
+				os.Unsetenv(k)
+			}
+		})
+	}
+
+	dir := filepath.Join(testHome, ".aliyun")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := safety.SavePolicy(dir, &safety.Policy{Enabled: true, Rules: rules}); err != nil {
+		t.Fatalf("save safety policy: %v", err)
+	}
+}
+
+// newSafetyCommandoTestCtx builds a ctx + commando wired with the standard
+// flags so command.main can run end-to-end. Mirrors the setup used by other
+// integration tests in this file.
+func newSafetyCommandoTestCtx(t *testing.T) (*cli.Context, *Commando) {
+	t.Helper()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	profile := config.Profile{
+		Language:        "en",
+		Mode:            "AK",
+		AccessKeyId:     "test-ak",
+		AccessKeySecret: "test-sk",
+		RegionId:        "cn-hangzhou",
+	}
+	command := NewCommando(stdout, profile)
+
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	command.InitWithCommand(cmd)
+	AddFlags(cmd.Flags())
+	config.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+	return ctx, command
+}
+
+// TestMain_SafetyPolicyEnforcement guards the three safety-policy call sites
+// in commando.main: the plugin dispatch path, the 2-arg RPC/REST-by-ApiName
+// path and the 3-arg REST-by-method/path path. Each subtest writes a deny
+// rule shaped exactly like what users type and asserts that command.main
+// short-circuits with the canonical "blocked by safety policy" error before
+// any actual API / plugin execution kicks in.
+func TestMain_SafetyPolicyEnforcement(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	t.Run("2-arg RPC: rule on ApiName blocks the call", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeMinimalConfigJSON(t, testHome)
+		writeSafetyPolicy(t, testHome, []safety.Rule{
+			{Pattern: "ecs:DeleteInstance", Action: safety.ActionDeny},
+		})
+
+		ctx, command := newSafetyCommandoTestCtx(t)
+		os.Args = []string{"aliyun", "ecs", "DeleteInstance"}
+		args := []string{"ecs", "DeleteInstance"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blocked by safety policy")
+		assert.Contains(t, err.Error(), "ecs:DeleteInstance",
+			"matched rule pattern should be reported back")
+	})
+
+	t.Run("2-arg ROA invoked by ApiName: rule on ApiName blocks the call", func(t *testing.T) {
+		// Regression for the original bug: `aliyun sls ListProject` is
+		// dispatched as REST GET / under the hood, but a rule keyed on the
+		// ApiName the user actually typed must still match.
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeMinimalConfigJSON(t, testHome)
+		writeSafetyPolicy(t, testHome, []safety.Rule{
+			{Pattern: "sls:ListProject", Action: safety.ActionDeny},
+		})
+
+		ctx, command := newSafetyCommandoTestCtx(t)
+		os.Args = []string{"aliyun", "sls", "ListProject"}
+		args := []string{"sls", "ListProject"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blocked by safety policy")
+		assert.Contains(t, err.Error(), "sls:ListProject")
+	})
+
+	t.Run("3-arg REST: rule on METHOD/path blocks the call", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeMinimalConfigJSON(t, testHome)
+		writeSafetyPolicy(t, testHome, []safety.Rule{
+			{Pattern: "cs:DELETE/*", Action: safety.ActionDeny},
+		})
+
+		ctx, command := newSafetyCommandoTestCtx(t)
+		ForceFlag(ctx.Flags()).SetAssigned(true) // skip metadata lookup for path
+		os.Args = []string{"aliyun", "cs", "DELETE", "/clusters/abc"}
+		args := []string{"cs", "DELETE", "/clusters/abc"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blocked by safety policy")
+		assert.Contains(t, err.Error(), "cs:DELETE/*")
+	})
+
+	t.Run("plugin multi-segment: colon-joined rule blocks the call", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeMinimalConfigJSON(t, testHome)
+		writeSafetyPolicy(t, testHome, []safety.Rule{
+			{Pattern: "fc:function:create", Action: safety.ActionDeny},
+		})
+
+		// Pretend the plugin is installed so commando.main proceeds past the
+		// "is plugin installed?" gate and reaches the safety check.
+		pluginDir := filepath.Join(testHome, ".aliyun", "plugins")
+		pluginPath := filepath.Join(pluginDir, "fc")
+		if err := os.MkdirAll(pluginPath, 0755); err != nil {
+			t.Fatalf("mkdir plugin dir: %v", err)
+		}
+		manifest := fmt.Sprintf(`{
+  "plugins": {
+    "fc": {
+      "name": "fc",
+      "version": "1.0.0",
+      "path": %q
+    }
+  }
+}`, pluginPath)
+		if err := os.WriteFile(filepath.Join(pluginDir, "manifest.json"), []byte(manifest), 0644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		ctx, command := newSafetyCommandoTestCtx(t)
+		os.Args = []string{"aliyun", "fc", "function", "create"}
+		args := []string{"fc", "function", "create"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blocked by safety policy")
+		assert.Contains(t, err.Error(), "fc:function:create")
+	})
+
+	t.Run("plugin single-segment: rule on sub-command blocks the call", func(t *testing.T) {
+		// Single-segment plugins (`aliyun fc create-function`) must keep
+		// matching the historical `product:sub-command` form.
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeMinimalConfigJSON(t, testHome)
+		writeSafetyPolicy(t, testHome, []safety.Rule{
+			{Pattern: "fc:create-function", Action: safety.ActionDeny},
+		})
+
+		pluginDir := filepath.Join(testHome, ".aliyun", "plugins")
+		pluginPath := filepath.Join(pluginDir, "fc")
+		if err := os.MkdirAll(pluginPath, 0755); err != nil {
+			t.Fatalf("mkdir plugin dir: %v", err)
+		}
+		manifest := fmt.Sprintf(`{
+  "plugins": {
+    "fc": {
+      "name": "fc",
+      "version": "1.0.0",
+      "path": %q
+    }
+  }
+}`, pluginPath)
+		if err := os.WriteFile(filepath.Join(pluginDir, "manifest.json"), []byte(manifest), 0644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		ctx, command := newSafetyCommandoTestCtx(t)
+		os.Args = []string{"aliyun", "fc", "create-function"}
+		args := []string{"fc", "create-function"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "blocked by safety policy")
+		assert.Contains(t, err.Error(), "fc:create-function")
 	})
 }

--- a/sysconfig/safety/check.go
+++ b/sysconfig/safety/check.go
@@ -59,7 +59,7 @@ func CheckAndConfirm(ctx *cli.Context, policy *Policy, cmd CommandInfo, skipConf
 		return fmt.Errorf(i18n.T(
 			"operation blocked by safety policy: %s %s (rule: %s)",
 			"操作被安全策略拒绝: %s %s (规则: %s)",
-		).GetMessage(), cmd.Product, cmd.ApiOrMethod, result.Rule.Pattern)
+		).GetMessage(), cmd.Product, displayCommand(cmd), result.Rule.Pattern)
 	case ActionConfirm:
 		if skipConfirm {
 			// --yes or env: treat as already confirmed
@@ -72,12 +72,12 @@ func CheckAndConfirm(ctx *cli.Context, policy *Policy, cmd CommandInfo, skipConf
 					"If you are an agent, ask the user whether this operation is allowed; after they confirm (e.g. reply yes or 确认), re-run the same command with --yes.",
 				"安全策略要求确认以下操作：%s %s\n"+
 					"当前为非交互环境，无法自动确认。若调用方为智能体，请先向用户说明并征得同意；用户同意后（可在对话中回复 yes 或「确认」），再使用 --yes 重新执行同一命令。",
-			).GetMessage(), cmd.Product, cmd.ApiOrMethod)
+			).GetMessage(), cmd.Product, displayCommand(cmd))
 		}
 		prompt := fmt.Sprintf(i18n.T(
 			"Safety policy requires confirmation for: %s %s\nType 'yes' to proceed, anything else to cancel: ",
 			"安全策略要求确认以下操作: %s %s\n输入 'yes' 继续，其他任意输入取消: ",
-		).GetMessage(), cmd.Product, cmd.ApiOrMethod)
+		).GetMessage(), cmd.Product, displayCommand(cmd))
 		if !PromptConfirm(ctx.Stderr(), prompt) {
 			return fmt.Errorf(i18n.T(
 				"operation cancelled by user",
@@ -89,4 +89,11 @@ func CheckAndConfirm(ctx *cli.Context, policy *Policy, cmd CommandInfo, skipConf
 		// No restriction
 	}
 	return nil
+}
+
+func displayCommand(cmd CommandInfo) string {
+	if cmd.Path != "" {
+		return strings.ToUpper(cmd.ApiOrMethod) + " " + cmd.Path
+	}
+	return cmd.ApiOrMethod
 }

--- a/sysconfig/safety/policy.go
+++ b/sysconfig/safety/policy.go
@@ -69,11 +69,22 @@ type CheckResult struct {
 }
 
 type CommandInfo struct {
-	Product string // e.g., "ecs", "cs"
-	// For RPC: ApiName like "DeleteInstance", "UpdateInstance"
-	// For REST: HTTP method like "DELETE", "PUT", "POST"
+	Product string // e.g., "ecs", "cs", "sls"
+	// ApiOrMethod is whatever the user typed as the second positional arg
+	// (and any trailing positionals for plugins). Examples:
+	//   RPC                              -> ApiName            (e.g. "DeleteInstance")
+	//   RESTful invoked by ApiName       -> ApiName            (e.g. "ListProject")
+	//   RESTful invoked by HTTP method   -> METHOD             (e.g. "GET", "DELETE")
+	//   plugin (single segment)          -> sub-command        (e.g. "delete-function")
+	//   plugin (multi segment)           -> "<sub>:<sub>:..."  (e.g. "function:create", "invoke:my-fn")
+	// In other words, safety always sees the command exactly as the user typed it,
+	// with ':' acting as the canonical hierarchy separator (the same one used between
+	// product and the command), so a rule like `sls:ListProject` matches
+	// `aliyun sls ListProject`, `*:DELETE` matches `aliyun cs DELETE /clusters`,
+	// and `fc:function:*` matches `aliyun fc function create ...`.
 	ApiOrMethod string
-	// For REST only: path like "/clusters"
+	// Path is only set for REST style invocations that supply a path
+	// (e.g. `aliyun cs DELETE /clusters` -> Path = "/clusters").
 	Path string
 }
 
@@ -82,9 +93,6 @@ func (p *Policy) Check(cmd CommandInfo) CheckResult {
 		return CheckResult{Action: ActionAllow, Matched: false}
 	}
 
-	// Build command identifier for matching
-	// RPC: product:ApiName (e.g., ecs:DeleteInstance)
-	// REST: product:METHOD or product:METHOD/path (e.g., cs:DELETE, cs:DELETE/clusters)
 	cmdPattern := buildCommandPattern(cmd)
 
 	// Rules are evaluated in order; first match wins
@@ -109,12 +117,19 @@ func (p *Policy) Check(cmd CommandInfo) CheckResult {
 	return CheckResult{Action: ActionAllow, Matched: false}
 }
 
+// buildCommandPattern renders the user-typed command as a single identifier:
+//
+//	product:ApiOrMethod          (two-segment commands: RPC, REST-by-ApiName, plugin)
+//	product:METHOD/path          (three-segment REST commands)
+//
+// Product is always lowercased; 
+// HTTP methods are upper-cased so rules like `*:DELETE` work regardless of how the user typed the verb. 
+// ApiOrMethod preserves the original casing because matching itself is case-insensitive.
 func buildCommandPattern(cmd CommandInfo) string {
 	product := strings.ToLower(cmd.Product)
 	if cmd.Path != "" {
 		return fmt.Sprintf("%s:%s%s", product, strings.ToUpper(cmd.ApiOrMethod), cmd.Path)
 	}
-	// RPC: product:ApiName (preserve case for API names like DeleteInstance)
 	return fmt.Sprintf("%s:%s", product, cmd.ApiOrMethod)
 }
 

--- a/sysconfig/safety/policy_test.go
+++ b/sysconfig/safety/policy_test.go
@@ -129,6 +129,150 @@ func TestPolicy_Check_Plugin(t *testing.T) {
 	assert.Equal(t, ActionDeny, result.Action)
 }
 
+// Multi-segment plugin commands (`aliyun fc function create`) are joined with
+// ':' by the dispatcher so the hierarchy separator stays consistent with the
+// `product:command` convention. Rules can target either the exact path or use
+// wildcards.
+func TestPolicy_Check_MultiSegmentPlugin(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		cmd     CommandInfo
+		match   bool
+	}{
+		{
+			name:    "exact multi-segment match",
+			pattern: "fc:function:create",
+			cmd:     CommandInfo{Product: "fc", ApiOrMethod: "function:create"},
+			match:   true,
+		},
+		{
+			name:    "wildcard on first segment",
+			pattern: "fc:function:*",
+			cmd:     CommandInfo{Product: "fc", ApiOrMethod: "function:delete"},
+			match:   true,
+		},
+		{
+			name:    "wildcard catches trailing positional value",
+			pattern: "fc:invoke:*",
+			cmd:     CommandInfo{Product: "fc", ApiOrMethod: "invoke:my-function"},
+			match:   true,
+		},
+		{
+			name:    "loose star also works",
+			pattern: "fc:function*",
+			cmd:     CommandInfo{Product: "fc", ApiOrMethod: "function:create:my-fn"},
+			match:   true,
+		},
+		{
+			name:    "non-matching pattern stays allowed",
+			pattern: "fc:function:create",
+			cmd:     CommandInfo{Product: "fc", ApiOrMethod: "function:update"},
+			match:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := &Policy{
+				Enabled: true,
+				Rules:   []Rule{{Pattern: tt.pattern, Action: ActionDeny}},
+			}
+			result := policy.Check(tt.cmd)
+			assert.Equal(t, tt.match, result.Matched)
+			if tt.match {
+				assert.Equal(t, ActionDeny, result.Action)
+			}
+		})
+	}
+}
+
+// User configures a rule using the OpenAPI ApiName they actually typed
+// (`aliyun sls ListProject`). Safety must treat the user-typed ApiOrMethod as
+// the canonical command identifier, regardless of how the cli later
+// dispatches it (REST GET / under the hood).
+func TestPolicy_Check_RESTByApiName(t *testing.T) {
+	policy := &Policy{
+		Enabled: true,
+		Rules: []Rule{
+			{Pattern: "sls:ListProject", Action: ActionDeny},
+		},
+	}
+	cmd := CommandInfo{Product: "sls", ApiOrMethod: "ListProject"}
+	result := policy.Check(cmd)
+	assert.True(t, result.Matched)
+	assert.Equal(t, ActionDeny, result.Action)
+	assert.Equal(t, "sls:ListProject", result.Rule.Pattern)
+}
+
+// Three-segment REST commands (`aliyun cs DELETE /clusters`) are matched as
+// product:METHOD/path; the `*:DELETE*` wildcard pattern keeps working.
+func TestPolicy_Check_RESTByMethodPath(t *testing.T) {
+	policy := &Policy{
+		Enabled: true,
+		Rules: []Rule{
+			{Pattern: "cs:DELETE/*", Action: ActionDeny},
+		},
+	}
+	cmd := CommandInfo{Product: "cs", ApiOrMethod: "DELETE", Path: "/clusters/abc"}
+	result := policy.Check(cmd)
+	assert.True(t, result.Matched)
+	assert.Equal(t, ActionDeny, result.Action)
+}
+
+// `*:DELETE*` should match both two-segment REST `aliyun sls DELETE /...` and
+// classic RPC delete-style API names.
+func TestPolicy_Check_DeleteWildcardCoversBothStyles(t *testing.T) {
+	policy := &Policy{
+		Enabled: true,
+		Rules: []Rule{
+			{Pattern: "*:Delete*", Action: ActionDeny},
+		},
+	}
+
+	rest := policy.Check(CommandInfo{Product: "cs", ApiOrMethod: "DELETE", Path: "/clusters"})
+	assert.True(t, rest.Matched)
+	assert.Equal(t, ActionDeny, rest.Action)
+
+	rpc := policy.Check(CommandInfo{Product: "ecs", ApiOrMethod: "DeleteInstance"})
+	assert.True(t, rpc.Matched)
+	assert.Equal(t, ActionDeny, rpc.Action)
+}
+
+func TestBuildCommandPattern(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  CommandInfo
+		want string
+	}{
+		{
+			name: "RPC two-segment",
+			cmd:  CommandInfo{Product: "ECS", ApiOrMethod: "DeleteInstance"},
+			want: "ecs:DeleteInstance",
+		},
+		{
+			name: "REST two-segment by ApiName",
+			cmd:  CommandInfo{Product: "sls", ApiOrMethod: "ListProject"},
+			want: "sls:ListProject",
+		},
+		{
+			name: "REST three-segment by method+path",
+			cmd:  CommandInfo{Product: "cs", ApiOrMethod: "delete", Path: "/clusters"},
+			want: "cs:DELETE/clusters",
+		},
+		{
+			name: "plugin sub-command",
+			cmd:  CommandInfo{Product: "fc", ApiOrMethod: "delete-function"},
+			want: "fc:delete-function",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCommandPattern(tt.cmd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestMatchPattern(t *testing.T) {
 	tests := []struct {
 		pattern string


### PR DESCRIPTION
**Description**

Make the safety policy key on the command **as the user typed it**, so the pattern is always `product:<what the user wrote>`:

| User input | Safety command string |
|---|---|
| `aliyun ecs DeleteInstance` | `ecs:DeleteInstance` |
| `aliyun sls ListProject` | `sls:ListProject` |
| `aliyun cs DELETE /clusters` | `cs:DELETE/clusters` |
| `aliyun fc create-function` | `fc:create-function` |
| `aliyun fc function create` | `fc:function:create` |
| `aliyun fc invoke my-fn` | `fc:invoke:my-fn` |