### PR TITLE
{Logging} Skip list for self-built-gateway products

### DIFF
--- a/openapi/call_context.go
+++ b/openapi/call_context.go
@@ -28,13 +28,38 @@ const (
 	EnvSourceIP = "ALIBABA_CLOUD_SOURCE_IP"
 	// EnvSecureTransport 调用方是否走安全传输。仅在为非空字符串时注入；值原样透传，由网关自行解析。
 	EnvSecureTransport = "ALIBABA_CLOUD_SECURE_TRANSPORT"
+	// EnvCallContextSkipProducts 自建网关产品扩展跳过列表（逗号分隔，大小写不敏感，附加到默认列表）。
+	EnvCallContextSkipProducts = "ALIBABA_CLOUD_CALL_CONTEXT_SKIP_PRODUCTS"
 
-	headerSourceIP        = "x-acs-source-ip"
-	headerSecureTransport = "x-acs-secure-transport"
-	queryKeySourceIP      = "SourceIp"
+	headerSourceIP          = "x-acs-source-ip"
+	headerSecureTransport   = "x-acs-secure-transport"
+	queryKeySourceIP        = "SourceIp"
 	queryKeySecureTransport = "SecureTransport"
 )
 
+// 已知使用自建网关 / 专属签名规则的产品
+var selfBuiltGatewayProducts = map[string]struct{}{
+	"sls": {},
+	"pds": {},
+}
+
+func shouldSkipCallContext(productCode string) bool {
+	code := strings.ToLower(strings.TrimSpace(productCode))
+	if code == "" {
+		return false
+	}
+	if _, ok := selfBuiltGatewayProducts[code]; ok {
+		return true
+	}
+	if extra := strings.TrimSpace(os.Getenv(EnvCallContextSkipProducts)); extra != "" {
+		for _, p := range strings.Split(extra, ",") {
+			if strings.ToLower(strings.TrimSpace(p)) == code {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 func callContextEnv() (sourceIP string, secureTransport string) {
 	sourceIP = strings.TrimSpace(os.Getenv(EnvSourceIP))
@@ -42,8 +67,8 @@ func callContextEnv() (sourceIP string, secureTransport string) {
 	return
 }
 
-func applyCallContextRPC(queryParams map[string]string) {
-	if queryParams == nil {
+func applyCallContextRPC(productCode string, queryParams map[string]string) {
+	if queryParams == nil || shouldSkipCallContext(productCode) {
 		return
 	}
 	sourceIP, secureTransport := callContextEnv()
@@ -59,8 +84,8 @@ func applyCallContextRPC(queryParams map[string]string) {
 	}
 }
 
-func applyCallContextROA(headers map[string]string) {
-	if headers == nil {
+func applyCallContextROA(productCode string, headers map[string]string) {
+	if headers == nil || shouldSkipCallContext(productCode) {
 		return
 	}
 	sourceIP, secureTransport := callContextEnv()
@@ -76,8 +101,11 @@ func applyCallContextROA(headers map[string]string) {
 	}
 }
 
-func applyCallContextTeaHeaders(headers map[string]*string) {
-	if headers == nil {
+// 用于 darabonba-openapi 风格请求（OpenapiContext / HttpContext）。
+// 该路径下 headers 为 map[string]*string，单独提供一个版本以避免重复装箱逻辑泄露给调用方。
+// 注意：当前主仓走该路径的产品（sls）本身就在跳过列表里。这里做产品判断只是为了让 helper 语义保持一致，便于后续接入新的 darabonba 产品时不踩坑。
+func applyCallContextTeaHeaders(productCode string, headers map[string]*string) {
+	if headers == nil || shouldSkipCallContext(productCode) {
 		return
 	}
 	sourceIP, secureTransport := callContextEnv()

--- a/openapi/call_context_test.go
+++ b/openapi/call_context_test.go
@@ -25,7 +25,7 @@ func TestApplyCallContextRPC(t *testing.T) {
 		t.Setenv(EnvSourceIP, "1.2.3.4")
 		t.Setenv(EnvSecureTransport, "true")
 		q := map[string]string{}
-		applyCallContextRPC(q)
+		applyCallContextRPC("ecs", q)
 		assert.Equal(t, "1.2.3.4", q[queryKeySourceIP])
 		assert.Equal(t, "true", q[queryKeySecureTransport])
 	})
@@ -34,7 +34,7 @@ func TestApplyCallContextRPC(t *testing.T) {
 		t.Setenv(EnvSourceIP, "10.0.0.1")
 		t.Setenv(EnvSecureTransport, "")
 		q := map[string]string{}
-		applyCallContextRPC(q)
+		applyCallContextRPC("ecs", q)
 		assert.Equal(t, "10.0.0.1", q[queryKeySourceIP])
 		_, ok := q[queryKeySecureTransport]
 		assert.False(t, ok)
@@ -44,7 +44,7 @@ func TestApplyCallContextRPC(t *testing.T) {
 		t.Setenv(EnvSourceIP, "")
 		t.Setenv(EnvSecureTransport, "false")
 		q := map[string]string{}
-		applyCallContextRPC(q)
+		applyCallContextRPC("ecs", q)
 		_, ok := q[queryKeySourceIP]
 		assert.False(t, ok)
 		assert.Equal(t, "false", q[queryKeySecureTransport])
@@ -54,7 +54,7 @@ func TestApplyCallContextRPC(t *testing.T) {
 		t.Setenv(EnvSourceIP, "")
 		t.Setenv(EnvSecureTransport, "")
 		q := map[string]string{}
-		applyCallContextRPC(q)
+		applyCallContextRPC("ecs", q)
 		assert.Empty(t, q)
 	})
 
@@ -65,7 +65,7 @@ func TestApplyCallContextRPC(t *testing.T) {
 			queryKeySourceIP:        "user-set",
 			queryKeySecureTransport: "user-set",
 		}
-		applyCallContextRPC(q)
+		applyCallContextRPC("ecs", q)
 		assert.Equal(t, "user-set", q[queryKeySourceIP])
 		assert.Equal(t, "user-set", q[queryKeySecureTransport])
 	})
@@ -73,7 +73,7 @@ func TestApplyCallContextRPC(t *testing.T) {
 	t.Run("nil map no panic", func(t *testing.T) {
 		t.Setenv(EnvSourceIP, "1.2.3.4")
 		assert.NotPanics(t, func() {
-			applyCallContextRPC(nil)
+			applyCallContextRPC("ecs", nil)
 		})
 	})
 
@@ -81,9 +81,34 @@ func TestApplyCallContextRPC(t *testing.T) {
 		t.Setenv(EnvSourceIP, "  1.2.3.4  ")
 		t.Setenv(EnvSecureTransport, "  true  ")
 		q := map[string]string{}
-		applyCallContextRPC(q)
+		applyCallContextRPC("ecs", q)
 		assert.Equal(t, "1.2.3.4", q[queryKeySourceIP])
 		assert.Equal(t, "true", q[queryKeySecureTransport])
+	})
+
+	t.Run("self-built gateway products are skipped", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		for _, code := range []string{"sls", "SLS", "pds", "PDS"} {
+			q := map[string]string{}
+			applyCallContextRPC(code, q)
+			assert.Empty(t, q, "expected %s to be skipped", code)
+		}
+	})
+
+	t.Run("env additive skip list", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		t.Setenv(EnvCallContextSkipProducts, "  Foo , bar ")
+		for _, code := range []string{"foo", "FOO", "Bar"} {
+			q := map[string]string{}
+			applyCallContextRPC(code, q)
+			assert.Empty(t, q, "expected %s to be skipped via env", code)
+		}
+		// Non-listed product still gets injected.
+		q := map[string]string{}
+		applyCallContextRPC("ecs", q)
+		assert.Equal(t, "1.2.3.4", q[queryKeySourceIP])
 	})
 }
 
@@ -92,7 +117,7 @@ func TestApplyCallContextROA(t *testing.T) {
 		t.Setenv(EnvSourceIP, "1.2.3.4")
 		t.Setenv(EnvSecureTransport, "true")
 		h := map[string]string{}
-		applyCallContextROA(h)
+		applyCallContextROA("cs", h)
 		assert.Equal(t, "1.2.3.4", h[headerSourceIP])
 		assert.Equal(t, "true", h[headerSecureTransport])
 	})
@@ -104,7 +129,7 @@ func TestApplyCallContextROA(t *testing.T) {
 			headerSourceIP:        "user-set",
 			headerSecureTransport: "user-set",
 		}
-		applyCallContextROA(h)
+		applyCallContextROA("cs", h)
 		assert.Equal(t, "user-set", h[headerSourceIP])
 		assert.Equal(t, "user-set", h[headerSecureTransport])
 	})
@@ -113,15 +138,25 @@ func TestApplyCallContextROA(t *testing.T) {
 		t.Setenv(EnvSourceIP, "")
 		t.Setenv(EnvSecureTransport, "")
 		h := map[string]string{}
-		applyCallContextROA(h)
+		applyCallContextROA("cs", h)
 		assert.Empty(t, h)
 	})
 
 	t.Run("nil map no panic", func(t *testing.T) {
 		t.Setenv(EnvSourceIP, "1.2.3.4")
 		assert.NotPanics(t, func() {
-			applyCallContextROA(nil)
+			applyCallContextROA("cs", nil)
 		})
+	})
+
+	t.Run("self-built gateway products are skipped", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		for _, code := range []string{"sls", "pds"} {
+			h := map[string]string{}
+			applyCallContextROA(code, h)
+			assert.Empty(t, h, "expected %s to be skipped", code)
+		}
 	})
 }
 
@@ -130,7 +165,7 @@ func TestApplyCallContextTeaHeaders(t *testing.T) {
 		t.Setenv(EnvSourceIP, "1.2.3.4")
 		t.Setenv(EnvSecureTransport, "true")
 		h := map[string]*string{}
-		applyCallContextTeaHeaders(h)
+		applyCallContextTeaHeaders("foo", h)
 		assert.Equal(t, "1.2.3.4", tea.StringValue(h[headerSourceIP]))
 		assert.Equal(t, "true", tea.StringValue(h[headerSecureTransport]))
 	})
@@ -141,7 +176,7 @@ func TestApplyCallContextTeaHeaders(t *testing.T) {
 		h := map[string]*string{
 			headerSourceIP: tea.String("user-set"),
 		}
-		applyCallContextTeaHeaders(h)
+		applyCallContextTeaHeaders("foo", h)
 		assert.Equal(t, "user-set", tea.StringValue(h[headerSourceIP]))
 		assert.Equal(t, "true", tea.StringValue(h[headerSecureTransport]))
 	})
@@ -149,7 +184,35 @@ func TestApplyCallContextTeaHeaders(t *testing.T) {
 	t.Run("nil map no panic", func(t *testing.T) {
 		t.Setenv(EnvSourceIP, "1.2.3.4")
 		assert.NotPanics(t, func() {
-			applyCallContextTeaHeaders(nil)
+			applyCallContextTeaHeaders("foo", nil)
 		})
+	})
+
+	t.Run("sls is skipped", func(t *testing.T) {
+		t.Setenv(EnvSourceIP, "1.2.3.4")
+		t.Setenv(EnvSecureTransport, "true")
+		h := map[string]*string{}
+		applyCallContextTeaHeaders("sls", h)
+		assert.Empty(t, h)
+	})
+}
+
+func TestShouldSkipCallContext(t *testing.T) {
+	t.Run("default skip list", func(t *testing.T) {
+		t.Setenv(EnvCallContextSkipProducts, "")
+		assert.True(t, shouldSkipCallContext("sls"))
+		assert.True(t, shouldSkipCallContext("SLS"))
+		assert.True(t, shouldSkipCallContext("  Pds "))
+		assert.False(t, shouldSkipCallContext("ecs"))
+		assert.False(t, shouldSkipCallContext(""))
+	})
+
+	t.Run("env extends defaults", func(t *testing.T) {
+		t.Setenv(EnvCallContextSkipProducts, "foo,bar, BAZ ")
+		assert.True(t, shouldSkipCallContext("sls"))
+		assert.True(t, shouldSkipCallContext("foo"))
+		assert.True(t, shouldSkipCallContext("BAR"))
+		assert.True(t, shouldSkipCallContext(" baz"))
+		assert.False(t, shouldSkipCallContext("ecs"))
 	})
 }

--- a/openapi/force_rpc.go
+++ b/openapi/force_rpc.go
@@ -56,7 +56,7 @@ func (a *ForceRpcInvoker) Prepare(ctx *cli.Context) (err error) {
 		}
 	}
 
-	applyCallContextRPC(a.request.QueryParams)
+	applyCallContextRPC(a.productCode(), a.request.QueryParams)
 
 	return
 }

--- a/openapi/http_context.go
+++ b/openapi/http_context.go
@@ -183,7 +183,8 @@ func (a *HttpContext) Init(ctx *cli.Context, product *meta.Product) error {
 	}
 	a.profile.InjectBearerTokenHeader(a.openapiRequest.Headers)
 	otel.InjectTeaHeaders(a.openapiRequest.Headers)
-	applyCallContextTeaHeaders(a.openapiRequest.Headers)
+	// 注：sls 等自建网关产品已在 selfBuiltGatewayProducts 中，下面的调用对它会直接跳过。
+	applyCallContextTeaHeaders(product.Code, a.openapiRequest.Headers)
 
 	// a.openapiRequest.Headers["x-acs-region-id"] = tea.String(a.profile.RegionId)
 	return nil

--- a/openapi/invoker.go
+++ b/openapi/invoker.go
@@ -126,6 +126,13 @@ func (a *BasicInvoker) getRequest() *requests.CommonRequest {
 	return a.request
 }
 
+func (a *BasicInvoker) productCode() string {
+	if a.product == nil {
+		return ""
+	}
+	return a.product.Code
+}
+
 func aiModeSuffixForContext(ctx *cli.Context) string {
 	configDir := config.GetConfigDir(ctx)
 	aiCfg, err := aimode.Load(configDir)

--- a/openapi/restful.go
+++ b/openapi/restful.go
@@ -95,7 +95,7 @@ func (a *RestfulInvoker) Prepare(ctx *cli.Context) error {
 		a.request.Scheme = "https"
 	}
 
-	applyCallContextROA(a.request.Headers)
+	applyCallContextROA(a.productCode(), a.request.Headers)
 
 	return nil
 }

--- a/openapi/rpc.go
+++ b/openapi/rpc.go
@@ -88,7 +88,7 @@ func (a *RpcInvoker) Prepare(ctx *cli.Context) error {
 		}
 	}
 
-	applyCallContextRPC(request.QueryParams)
+	applyCallContextRPC(a.productCode(), request.QueryParams)
 
 	err := a.api.CheckRequiredParameters(func(s string) bool {
 		switch s {


### PR DESCRIPTION
**Description**

Some products use proprietary signatures and reject extra params/headers. Injection is now silently skipped for these products to avoid breaking signature verification:
- Built-in default: `sls`, `pds` (case-insensitive)
- Runtime extension: `ALIBABA_CLOUD_CALL_CONTEXT_SKIP_PRODUCTS=foo,bar` (additive to the default; comma-separated; case-insensitive)