### PR TITLE
{Plugin} Allow plugins to opt out of host profile enforcement

### DIFF
--- a/cli/plugin/execution.go
+++ b/cli/plugin/execution.go
@@ -36,6 +36,19 @@ func IsPluginInstalled(command string) (bool, string, error) {
 	return true, pluginName, nil
 }
 
+// Plugins explicitly opt out of host profile enforcement by setting `"profileRequired": false` in their manifest.json. 
+func IsProfileRequiredForCommand(command string) bool {
+	mgr, err := NewManager()
+	if err != nil {
+		return true
+	}
+	_, lp, err := mgr.findLocalPlugin(command)
+	if err != nil || lp == nil {
+		return true
+	}
+	return lp.IsProfileRequired()
+}
+
 // Returns (true, nil) if plugin was found and executed successfully.
 // Returns (true, error) if plugin execution failed.
 // Returns (false, nil) if plugin was not found (not an error).

--- a/cli/plugin/execution_test.go
+++ b/cli/plugin/execution_test.go
@@ -703,3 +703,58 @@ func envSliceToMap(envs []string) map[string]string {
 	}
 	return m
 }
+
+func TestIsProfileRequiredForCommand(t *testing.T) {
+	writeManifest := func(t *testing.T, testHome, body string) {
+		t.Helper()
+		manifestPath := filepath.Join(testHome, ".aliyun", "plugins", "manifest.json")
+		assert.NoError(t, os.MkdirAll(filepath.Dir(manifestPath), 0755))
+		assert.NoError(t, os.WriteFile(manifestPath, []byte(body), 0644))
+	}
+
+	t.Run("plugin not installed defaults to required", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeManifest(t, testHome, `{"plugins":{}}`)
+
+		assert.True(t, IsProfileRequiredForCommand("rdc"))
+	})
+
+	t.Run("manifest entry without profileRequired defaults to required", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeManifest(t, testHome, `{"plugins":{"aliyun-cli-rdc":{"name":"aliyun-cli-rdc","version":"1.0.0","path":"/x","command":"rdc"}}}`)
+
+		assert.True(t, IsProfileRequiredForCommand("rdc"))
+	})
+
+	t.Run("explicit profileRequired=false opts the command out", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeManifest(t, testHome, `{"plugins":{"aliyun-cli-rdc":{"name":"aliyun-cli-rdc","version":"1.0.0","path":"/x","command":"rdc","profileRequired":false}}}`)
+
+		assert.False(t, IsProfileRequiredForCommand("rdc"))
+	})
+
+	t.Run("explicit profileRequired=true keeps strict enforcement", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeManifest(t, testHome, `{"plugins":{"aliyun-cli-rdc":{"name":"aliyun-cli-rdc","version":"1.0.0","path":"/x","command":"rdc","profileRequired":true}}}`)
+
+		assert.True(t, IsProfileRequiredForCommand("rdc"))
+	})
+
+	t.Run("short-name and case-insensitive lookup honors the flag", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+		writeManifest(t, testHome, `{"plugins":{"aliyun-cli-rdc":{"name":"aliyun-cli-rdc","version":"1.0.0","path":"/x","command":"rdc","profileRequired":false}}}`)
+
+		assert.False(t, IsProfileRequiredForCommand("RDC"))
+		assert.False(t, IsProfileRequiredForCommand("aliyun-cli-rdc"))
+	})
+}

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -980,6 +980,7 @@ func (m *Manager) savePluginToManifest(actualPluginName, version, extractDir str
 		Description:      pManifest.Description,
 		CmdNames:         pManifest.CmdNames,
 		Inner:            pManifest.Inner,
+		ProfileRequired:  pManifest.ProfileRequired,
 	}
 
 	return m.saveLocalManifest(localManifest)

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -175,9 +175,18 @@ func (m *Manager) writeCache(cacheFile string, data []byte) {
 	_ = os.WriteFile(cacheFile, data, 0644)
 }
 
+func httpGet(url string, timeout time.Duration) (*http.Response, error) {
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	return client.Do(req)
+}
+
 func (m *Manager) fetchRemote(url string) ([]byte, error) {
-	client := &http.Client{Timeout: fetchTimeout}
-	resp, err := client.Get(url)
+	resp, err := httpGet(url, fetchTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -496,10 +505,7 @@ func (m *Manager) validateVersionAndPlatform(ctx *cli.Context, targetPlugin *Plu
 }
 
 func downloadFile(url, dest string) error {
-	client := &http.Client{
-		Timeout: 300 * time.Second,
-	}
-	resp, err := client.Get(url)
+	resp, err := httpGet(url, pluginArchiveDLTimeout)
 	if err != nil {
 		return err
 	}
@@ -870,8 +876,7 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL string) e
 
 	cli.Printf(ctx.Stdout(), "Downloading plugin package from %s...\n", rawURL)
 
-	client := &http.Client{Timeout: pluginArchiveDLTimeout}
-	resp, err := client.Get(rawURL)
+	resp, err := httpGet(rawURL, pluginArchiveDLTimeout)
 	if err != nil {
 		return fmt.Errorf("download plugin package: %w", err)
 	}

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -1479,6 +1479,45 @@ func TestSavePluginToManifest(t *testing.T) {
 	assert.Equal(t, extractDir, plugin.Path)
 	assert.Equal(t, pManifest.Command, plugin.Command)
 	assert.Equal(t, pManifest.Description, plugin.Description)
+	assert.Nil(t, plugin.ProfileRequired, "absent in manifest should stay nil")
+
+	t.Run("propagates explicit profileRequired=false", func(t *testing.T) {
+		nameOptOut := "test-plugin-opt-out"
+		ff := false
+		pm := &PluginManifest{
+			Name:            nameOptOut,
+			Command:         "opt-out",
+			Description:     "opt-out",
+			ProfileRequired: &ff,
+		}
+		assert.NoError(t, mgr.savePluginToManifest(nameOptOut, version, extractDir, pm))
+		lm, err := mgr.GetLocalManifest()
+		assert.NoError(t, err)
+		got, ok := lm.Plugins[nameOptOut]
+		assert.True(t, ok)
+		assert.NotNil(t, got.ProfileRequired)
+		assert.False(t, *got.ProfileRequired)
+		assert.False(t, got.IsProfileRequired())
+	})
+
+	t.Run("propagates explicit profileRequired=true", func(t *testing.T) {
+		nameStrict := "test-plugin-strict"
+		tt := true
+		pm := &PluginManifest{
+			Name:            nameStrict,
+			Command:         "strict",
+			Description:     "strict",
+			ProfileRequired: &tt,
+		}
+		assert.NoError(t, mgr.savePluginToManifest(nameStrict, version, extractDir, pm))
+		lm, err := mgr.GetLocalManifest()
+		assert.NoError(t, err)
+		got, ok := lm.Plugins[nameStrict]
+		assert.True(t, ok)
+		assert.NotNil(t, got.ProfileRequired)
+		assert.True(t, *got.ProfileRequired)
+		assert.True(t, got.IsProfileRequired())
+	})
 }
 
 func TestManager_downloadAndVerifyPlugin(t *testing.T) {

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -3940,3 +3940,20 @@ func TestManager_FindPluginByCommand(t *testing.T) {
 		assert.Contains(t, err.Error(), "no plugin found for command: fc")
 	})
 }
+
+func TestHttpGet_AcceptEncodingIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "identity", r.Header.Get("Accept-Encoding"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	resp, err := httpGet(server.URL, 5*time.Second)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", string(body))
+}

--- a/cli/plugin/types.go
+++ b/cli/plugin/types.go
@@ -88,6 +88,19 @@ type LocalPlugin struct {
 	ShortDescription string   `json:"shortDescription"`
 	Description      string   `json:"description"`
 	Inner            bool     `json:"inner,omitempty"` // 内置/产品侧插件（manifest.json inner）
+	// ProfileRequired controls whether the host CLI requires a valid configured profile before spawning this plugin. 
+	// Defaults to true (legacy behavior) when unset. 
+	// Set to false for plugins whose APIs may not need a profile (e.g. token-backed gateways, hybrid auth). 
+	// The plugin remains responsible for per-API auth validation. 
+	// Use a pointer so an absent field in legacy manifests is reliably distinguishable from an explicit `false`.
+	ProfileRequired *bool `json:"profileRequired,omitempty"`
+}
+
+func (lp *LocalPlugin) IsProfileRequired() bool {
+	if lp == nil || lp.ProfileRequired == nil {
+		return true
+	}
+	return *lp.ProfileRequired
 }
 
 type PluginAPIVersions struct {
@@ -115,6 +128,7 @@ type PluginManifest struct {
 		Path string `json:"path"` // 二进制文件相对路径
 	} `json:"bin"`
 	CmdNames []string `json:"cmdNames"`
+	ProfileRequired *bool `json:"profileRequired,omitempty"`
 }
 
 // Key: kebab-case command name (e.g., "fc create-alias")

--- a/cli/plugin/types_test.go
+++ b/cli/plugin/types_test.go
@@ -268,3 +268,48 @@ func TestPluginIndex_ParseRealWorld(t *testing.T) {
 		t.Errorf("Version 0.0.9 should have 1 platform, got %d", len(ver009.Platforms))
 	}
 }
+
+func TestLocalPlugin_IsProfileRequired(t *testing.T) {
+	tt := true
+	ff := false
+	tests := []struct {
+		name string
+		lp   *LocalPlugin
+		want bool
+	}{
+		{name: "nil receiver defaults to required", lp: nil, want: true},
+		{name: "absent field defaults to required", lp: &LocalPlugin{Name: "x"}, want: true},
+		{name: "explicit true is required", lp: &LocalPlugin{Name: "x", ProfileRequired: &tt}, want: true},
+		{name: "explicit false opts out", lp: &LocalPlugin{Name: "x", ProfileRequired: &ff}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.lp.IsProfileRequired(); got != tc.want {
+				t.Fatalf("IsProfileRequired() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluginManifest_ProfileRequiredJSONRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want *bool
+	}{
+		{name: "absent", raw: `{"name":"x","version":"1","command":"x","bin":{"path":"x"}}`, want: nil},
+		{name: "explicit_true", raw: `{"name":"x","version":"1","command":"x","bin":{"path":"x"},"profileRequired":true}`, want: func() *bool { b := true; return &b }()},
+		{name: "explicit_false", raw: `{"name":"x","version":"1","command":"x","bin":{"path":"x"},"profileRequired":false}`, want: func() *bool { b := false; return &b }()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m PluginManifest
+			if err := json.Unmarshal([]byte(tc.raw), &m); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(m.ProfileRequired, tc.want) {
+				t.Fatalf("ProfileRequired = %v, want %v", m.ProfileRequired, tc.want)
+			}
+		})
+	}
+}

--- a/config/baseline_env_test.go
+++ b/config/baseline_env_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for BuildBaselineEnv, the minimal env map used when a plugin opts out
+// of host-side profile enforcement (`profileRequired: false` in its manifest)
+// and no usable Profile is available. Kept in its own file so the function's
+// contract — "carry only what the plugin can't get from inherited OS env, and
+// never leak host credentials" — is easy to find and easy to extend.
+package config
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildBaselineEnv(t *testing.T) {
+	// Snapshot and restore envs we touch. We deliberately also clear the
+	// legacy ALIBABACLOUD_/ALICLOUD_ aliases so the "canonical-only" guarantee
+	// can be asserted below without false positives from CI host env.
+	keys := []string{"ALIBABA_CLOUD_REGION_ID", "ALIBABACLOUD_REGION_ID", "ALICLOUD_REGION_ID", "ALIBABA_CLOUD_ENDPOINT", "ALIBABA_CLOUD_LANGUAGE"}
+	saved := make(map[string]string, len(keys))
+	for _, k := range keys {
+		saved[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+	t.Cleanup(func() {
+		for _, k := range keys {
+			if v := saved[k]; v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	})
+
+	newEmptyCtx := func() *cli.Context {
+		ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+		AddFlags(ctx.Flags())
+		return ctx
+	}
+
+	t.Run("baseline always carries CLI version and is region/endpoint-free when nothing is configured", func(t *testing.T) {
+		envs := BuildBaselineEnv(newEmptyCtx())
+		assert.NotEmpty(t, envs["ALIBABA_CLOUD_CLI_VERSION"], "CLI version is the only must-have")
+		_, hasRegion := envs["ALIBABA_CLOUD_REGION_ID"]
+		_, hasEndpoint := envs["ALIBABA_CLOUD_ENDPOINT"]
+		_, hasLang := envs["ALIBABA_CLOUD_LANGUAGE"]
+		assert.False(t, hasRegion)
+		assert.False(t, hasEndpoint)
+		assert.False(t, hasLang)
+	})
+
+	t.Run("flag values populate the env map", func(t *testing.T) {
+		ctx := newEmptyCtx()
+		RegionFlag(ctx.Flags()).SetAssigned(true)
+		RegionFlag(ctx.Flags()).SetValue("cn-hangzhou")
+		EndpointFlag(ctx.Flags()).SetAssigned(true)
+		EndpointFlag(ctx.Flags()).SetValue("https://devops.cn-hangzhou.aliyuncs.com")
+		LanguageFlag(ctx.Flags()).SetAssigned(true)
+		LanguageFlag(ctx.Flags()).SetValue("zh")
+
+		envs := BuildBaselineEnv(ctx)
+		assert.Equal(t, "cn-hangzhou", envs["ALIBABA_CLOUD_REGION_ID"])
+		assert.Equal(t, "https://devops.cn-hangzhou.aliyuncs.com", envs["ALIBABA_CLOUD_ENDPOINT"])
+		assert.Equal(t, "zh", envs["ALIBABA_CLOUD_LANGUAGE"])
+	})
+
+	t.Run("env values are used when no flag is provided", func(t *testing.T) {
+		os.Setenv("ALIBABA_CLOUD_REGION_ID", "cn-shanghai")
+		os.Setenv("ALIBABA_CLOUD_ENDPOINT", "https://devops.cn-shanghai.aliyuncs.com")
+		os.Setenv("ALIBABA_CLOUD_LANGUAGE", "en")
+		t.Cleanup(func() {
+			os.Unsetenv("ALIBABA_CLOUD_REGION_ID")
+			os.Unsetenv("ALIBABA_CLOUD_ENDPOINT")
+			os.Unsetenv("ALIBABA_CLOUD_LANGUAGE")
+		})
+
+		envs := BuildBaselineEnv(newEmptyCtx())
+		assert.Equal(t, "cn-shanghai", envs["ALIBABA_CLOUD_REGION_ID"])
+		assert.Equal(t, "https://devops.cn-shanghai.aliyuncs.com", envs["ALIBABA_CLOUD_ENDPOINT"])
+		assert.Equal(t, "en", envs["ALIBABA_CLOUD_LANGUAGE"])
+	})
+
+	t.Run("flag wins over env", func(t *testing.T) {
+		os.Setenv("ALIBABA_CLOUD_REGION_ID", "cn-shanghai")
+		t.Cleanup(func() { os.Unsetenv("ALIBABA_CLOUD_REGION_ID") })
+
+		ctx := newEmptyCtx()
+		RegionFlag(ctx.Flags()).SetAssigned(true)
+		RegionFlag(ctx.Flags()).SetValue("cn-beijing")
+
+		envs := BuildBaselineEnv(ctx)
+		assert.Equal(t, "cn-beijing", envs["ALIBABA_CLOUD_REGION_ID"])
+	})
+
+	t.Run("legacy region env aliases are intentionally ignored", func(t *testing.T) {
+		// Only the canonical ALIBABA_CLOUD_REGION_ID is honored here; the
+		// historical ALIBABACLOUD_REGION_ID / ALICLOUD_REGION_ID aliases must
+		// not leak into the plugin baseline env. New entry points converge
+		// on one name on purpose; existing call sites that still accept the
+		// aliases stay untouched.
+		os.Setenv("ALIBABACLOUD_REGION_ID", "cn-shanghai")
+		os.Setenv("ALICLOUD_REGION_ID", "cn-beijing")
+		t.Cleanup(func() {
+			os.Unsetenv("ALIBABACLOUD_REGION_ID")
+			os.Unsetenv("ALICLOUD_REGION_ID")
+		})
+
+		envs := BuildBaselineEnv(newEmptyCtx())
+		_, has := envs["ALIBABA_CLOUD_REGION_ID"]
+		assert.False(t, has, "legacy region aliases must not populate baseline env")
+	})
+
+	t.Run("never leaks credentials", func(t *testing.T) {
+		// Even if AK/bearer-token envs are set on the host, BuildBaselineEnv
+		// must not forward them — the plugin must fetch them from its own OS
+		// environment so we do not implicitly authenticate the wrong identity.
+		os.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "ak-from-host")
+		os.Setenv("ALIBABA_CLOUD_BEARER_TOKEN", "leaky-token")
+		t.Cleanup(func() {
+			os.Unsetenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
+			os.Unsetenv("ALIBABA_CLOUD_BEARER_TOKEN")
+		})
+
+		envs := BuildBaselineEnv(newEmptyCtx())
+		_, hasAK := envs["ALIBABA_CLOUD_ACCESS_KEY_ID"]
+		_, hasToken := envs["ALIBABA_CLOUD_BEARER_TOKEN"]
+		assert.False(t, hasAK, "AK must not leak into baseline env")
+		assert.False(t, hasToken, "bearer token must not leak into baseline env")
+	})
+}

--- a/config/profile.go
+++ b/config/profile.go
@@ -784,6 +784,31 @@ func (cp *Profile) GetRuntimeEnv(ctx *cli.Context) (map[string]string, error) {
 	return envs, nil
 }
 
+// Intentionally NOT included (compare with GetRuntimeEnv above):
+//   - access keys, STS tokens, bearer tokens — host-side credentials must never be silently forwarded; the plugin is expected to resolve auth itself (registered CredentialResolver, ALIBABA_CLOUD_BEARER_TOKEN, ...)
+//   - any field that would only exist on a Profile (endpoint type, timeouts, retry count, external account type).
+func BuildBaselineEnv(ctx *cli.Context) map[string]string {
+	envs := map[string]string{
+		"ALIBABA_CLOUD_CLI_VERSION": cli.GetVersion(),
+	}
+	if region, ok := RegionFlag(ctx.Flags()).GetValue(); ok && region != "" {
+		envs["ALIBABA_CLOUD_REGION_ID"] = region
+	} else if v := util.GetFromEnv("ALIBABA_CLOUD_REGION_ID"); v != "" {
+		envs["ALIBABA_CLOUD_REGION_ID"] = v
+	}
+	if endpoint, ok := EndpointFlag(ctx.Flags()).GetValue(); ok && endpoint != "" {
+		envs["ALIBABA_CLOUD_ENDPOINT"] = endpoint
+	} else if v := util.GetFromEnv("ALIBABA_CLOUD_ENDPOINT"); v != "" {
+		envs["ALIBABA_CLOUD_ENDPOINT"] = v
+	}
+	if lang, ok := LanguageFlag(ctx.Flags()).GetValue(); ok && lang != "" {
+		envs["ALIBABA_CLOUD_LANGUAGE"] = lang
+	} else if v := util.GetFromEnv("ALIBABA_CLOUD_LANGUAGE"); v != "" {
+		envs["ALIBABA_CLOUD_LANGUAGE"] = v
+	}
+	return envs
+}
+
 func IsRegion(region string) bool {
 	if match, _ := regexp.MatchString("^[a-zA-Z0-9-]*$", region); !match {
 		return false

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -295,21 +295,35 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			isVersion := (apiOrMethod == "version")
 			if !isHelp && !isVersion && len(pluginArgs) >= 2 {
 				ctx.SetInConfigureMode(DetectInConfigureMode(ctx.Flags()))
-				profile, err := config.LoadProfileWithContext(ctx)
-				if err != nil {
-					return cli.NewErrorWithTip(err, "Configuration failed, use `aliyun configure` to configure it")
-				}
-				c.profile = profile
-				if c.profile.Name == "" {
-					return fmt.Errorf("profile not found, use `aliyun configure` to configure it")
+				// Plugins may opt out of host-side profile enforcement by setting `profileRequired: false` in their manifest.
+				// When opted out, profile resolution is best-effort: we still try to load and forward the profile's env if it works, 
+				// but we never block the plugin on host-side credential failures — the plugin is expected to resolve auth itself.
+				profileRequired := plugin.IsProfileRequiredForCommand(args[0])
+
+				profile, profileErr := config.LoadProfileWithContext(ctx)
+
+				var envs map[string]string
+				if profileErr == nil && profile.Name != "" {
+					c.profile = profile
+					var rtErr error
+					envs, rtErr = c.profile.GetRuntimeEnv(ctx)
+					if rtErr != nil {
+						if profileRequired {
+							return cli.NewErrorWithTip(rtErr,
+								fmt.Sprintf("profile %q: failed to resolve credentials", c.profile.Name))
+						}
+						envs = config.BuildBaselineEnv(ctx)
+					}
+				} else {
+					if profileRequired {
+						if profileErr != nil {
+							return cli.NewErrorWithTip(profileErr, "Configuration failed, use `aliyun configure` to configure it")
+						}
+						return fmt.Errorf("profile not found, use `aliyun configure` to configure it")
+					}
+					envs = config.BuildBaselineEnv(ctx)
 				}
 
-				// 凭证获取失败（OIDC / STS / RamRoleArn 远程换证等）同样 fail-fast
-				envs, err := c.profile.GetRuntimeEnv(ctx)
-				if err != nil {
-					return cli.NewErrorWithTip(err,
-						fmt.Sprintf("profile %q: failed to resolve credentials", c.profile.Name))
-				}
 				configDir := config.GetConfigDir(ctx)
 				forceOn, forceOff := CliAIOverrides(ctx.Flags())
 				aimode.MergeUserAgentIntoPluginEnvs(configDir, envs, forceOn, forceOff)

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -2381,6 +2381,130 @@ func TestMain_PluginExecution_ProfileFailFast(t *testing.T) {
 	})
 }
 
+// TestMain_PluginExecution_LenientProfile mirrors ProfileFailFast but for
+// plugins that opt out via `profileRequired: false`. The contract:
+//   - bad / missing profile must NOT abort the call before the plugin runs;
+//     instead the plugin process is invoked with a baseline env.
+//   - we still surface plugin-level errors (e.g. missing binary), so we
+//     assert the failure point shifted from profile-validation to plugin
+//     execution.
+func TestMain_PluginExecution_LenientProfile(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	bootProfile := config.Profile{
+		Name:     "AkProfile",
+		Language: "en",
+		RegionId: "cn-hangzhou",
+	}
+	command := NewCommando(w, bootProfile)
+
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	command.InitWithCommand(cmd)
+	AddFlags(cmd.Flags())
+	config.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	// Plugin manifest declares profileRequired=false. The bad-oauth profile
+	// would normally fail Profile.Validate; lenient mode must swallow that
+	// and still attempt to spawn the plugin (which then fails with a binary
+	// resolution error because we don't actually drop a real binary).
+	t.Run("invalid profile is bypassed when plugin opts out via profileRequired=false", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+
+		dir := filepath.Join(testHome, ".aliyun")
+		os.MkdirAll(dir, 0755)
+		os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{
+  "current": "AkProfile",
+  "profiles": [
+    {"name":"AkProfile","mode":"AK","access_key_id":"ak","access_key_secret":"sk","region_id":"cn-hangzhou"},
+    {"name":"bad-oauth","mode":"OAuth","region_id":"cn-hangzhou"}
+  ]
+}`), 0644)
+
+		pluginDir := filepath.Join(testHome, ".aliyun", "plugins")
+		pluginPath := filepath.Join(pluginDir, "rdc")
+		os.MkdirAll(pluginPath, 0755)
+		manifestPath := filepath.Join(pluginDir, "manifest.json")
+		manifest := fmt.Sprintf(`{
+  "plugins": {
+    "rdc": {
+      "name": "rdc",
+      "version": "1.0.0",
+      "path": %q,
+      "profileRequired": false
+    }
+  }
+}`, pluginPath)
+		os.WriteFile(manifestPath, []byte(manifest), 0644)
+
+		config.ProfileFlag(ctx.Flags()).SetAssigned(true)
+		config.ProfileFlag(ctx.Flags()).SetValue("bad-oauth")
+		defer func() { config.ProfileFlag(ctx.Flags()).SetAssigned(false) }()
+
+		os.Args = []string{"aliyun", "rdc", "list", "--profile", "bad-oauth"}
+		args := []string{"rdc", "list"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "oauth_site_type",
+			"profileRequired=false 的插件不应被 profile 校验阻塞")
+		assert.Contains(t, err.Error(), "failed to resolve plugin binary",
+			"宽松路径下应继续到 ExecutePlugin，错误来自 binary 解析阶段")
+	})
+
+	// Even when no profile exists at all (no config.json on disk),
+	// profileRequired=false plugins must still execute end-to-end up to the
+	// plugin binary stage.
+	t.Run("missing profile config does not block opted-out plugin", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+
+		// Reset profile flag possibly set by previous subtests.
+		config.ProfileFlag(ctx.Flags()).SetAssigned(false)
+		config.ProfileFlag(ctx.Flags()).SetValue("")
+
+		// Intentionally do NOT write config.json — profile loading will
+		// either return an empty profile or fail; either way, lenient mode
+		// must keep going.
+		pluginDir := filepath.Join(testHome, ".aliyun", "plugins")
+		pluginPath := filepath.Join(pluginDir, "rdc")
+		os.MkdirAll(pluginPath, 0755)
+		manifestPath := filepath.Join(pluginDir, "manifest.json")
+		manifest := fmt.Sprintf(`{
+  "plugins": {
+    "rdc": {
+      "name": "rdc",
+      "version": "1.0.0",
+      "path": %q,
+      "profileRequired": false
+    }
+  }
+}`, pluginPath)
+		os.WriteFile(manifestPath, []byte(manifest), 0644)
+
+		os.Args = []string{"aliyun", "rdc", "list"}
+		args := []string{"rdc", "list"}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "profile not found",
+			"profileRequired=false 不应触发 'profile not found' 报错")
+		assert.NotContains(t, err.Error(), "Configuration failed",
+			"profileRequired=false 不应触发 Configuration failed 报错")
+		assert.Contains(t, err.Error(), "failed to resolve plugin binary",
+			"宽松路径下错误应来自 binary 解析阶段")
+	})
+}
+
 func TestPluginExecutionLogic(t *testing.T) {
 	// Setup test environment
 	stdout := new(bytes.Buffer)


### PR DESCRIPTION
**Description**

Some plugins (e.g. rdc) manage their own credentials and shouldn't require an `aliyun configure` profile. This PR lets a plugin declare `"profileRequired": false` in its manifest to take ownership of auth.