### PR TITLE
{Misc} Improve CLI help and error guidance for multi-style invocation

### DIFF
--- a/meta/repository.go
+++ b/meta/repository.go
@@ -135,6 +135,27 @@ func (a *Repository) GetApiByPath(productCode string, version string, method str
 	return result, false
 }
 
+func (a *Repository) FindApisByPath(productCode string, version string, path string) []Api {
+	product, ok := a.GetProduct(productCode)
+	if !ok {
+		return nil
+	}
+	var matches []Api
+	for _, apiName := range product.ApiNames {
+		var api Api
+		if err := ReadJsonFrom(strings.ToLower(product.Code)+"/"+apiName+".json", &api); err != nil {
+			continue
+		}
+		pattern := ReplacePathPattern(api.PathPattern)
+		re := regexp.MustCompile("^" + pattern + "$")
+		if re.MatchString(path) {
+			api.Product = &product
+			matches = append(matches, api)
+		}
+	}
+	return matches
+}
+
 //go:embed versions.json
 var versions []byte
 

--- a/openapi/api_help.go
+++ b/openapi/api_help.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-cli/v3/newmeta"
+)
+
+type apiHelpPlan struct {
+	deliverBuiltInApiHelp bool
+	deliverPluginHelp     bool
+	abortErr              error
+}
+
+func getPluginArgsForApiHelp(productCode, apiName string) []string {
+	return ensurePluginHelpArgs(productCode, []string{productCode, apiName})
+}
+
+func (c *Commando) planApiLevelHelp(productCode, apiName string) (apiHelpPlan, meta.Product, meta.Api, string, bool) {
+	pluginName, hasPlugin := c.lookupPluginForProduct(productCode)
+	isInstalled := hasPlugin && c.isPluginInstalledForProduct(productCode)
+
+	product, inLibrary := c.library.GetProduct(productCode)
+	hasBuiltInApis := inLibrary && productHasBuiltinApis(product)
+	plan := apiHelpPlan{}
+
+	if !inLibrary && !hasPlugin {
+		plan.abortErr = &InvalidProductOrPluginError{
+			Code: productCode, library: c.library, plugins: c.pluginIndex.Plugins,
+		}
+		return plan, product, meta.Api{}, pluginName, false
+	}
+	// shouldn't happen
+	// if inLibrary && !hasPlugin {}
+
+	// Product listed in built-in catalog without APIs, or plugin-only product → plugin path.
+	if !hasBuiltInApis && hasPlugin {
+		if !isInstalled {
+			plan.abortErr = fmt.Errorf(
+				"Command help for '%s %s' requires the product plugin '%s'.\n  aliyun plugin install --name %s\n  After installation, run `aliyun %s %s --help` to view command help.",
+				productCode, apiName, pluginName, pluginName, strings.ToLower(productCode), apiName)
+			return plan, product, meta.Api{}, pluginName, false
+		}
+		plan.deliverPluginHelp = true
+		return plan, product, meta.Api{}, pluginName, false
+	}
+
+	api, apiFound := c.library.GetApi(productCode, product.Version, apiName)
+	if apiFound {
+		plan.deliverBuiltInApiHelp = true
+		return plan, product, api, pluginName, hasBuiltInApis
+	}
+
+	localPlugin := c.getInstalledLocalPlugin(productCode)
+	if isInstalled && pluginCmdMatches(apiName, localPlugin) {
+		plan.deliverPluginHelp = true
+		return plan, product, meta.Api{}, pluginName, hasBuiltInApis
+	}
+
+	plan.abortErr = newApiOrCmdNotFoundError(&product, apiName, localPlugin, pluginName)
+	return plan, product, meta.Api{}, pluginName, hasBuiltInApis
+}
+
+func (c *Commando) executePluginApiHelp(ctx *cli.Context, productCode string, pluginArgs []string) (bool, error) {
+	c.setLangEnv(ctx)
+	ok, err := plugin.ExecutePlugin(productCode, pluginArgs, ctx)
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+func (c *Commando) printBuiltInApiUsage(ctx *cli.Context, product meta.Product, api meta.Api, apiName string) error {
+	productName, _ := newmeta.GetProductName(i18n.GetLanguage(), product.Code)
+
+	if product.ApiStyle == "restful" {
+		cli.Printf(ctx.Stdout(), "\nProduct:     %s (%s)\n", product.Code, productName)
+		cli.Printf(ctx.Stdout(), "Method:      %s\n", api.Method)
+		cli.Printf(ctx.Stdout(), "PathPattern: %s\n", api.PathPattern)
+	} else {
+		cli.Printf(ctx.Stdout(), "\nProduct: %s (%s)\n", product.Code, productName)
+	}
+
+	cli.Printf(ctx.Stdout(), "\nParameters:\n")
+
+	w := tabwriter.NewWriter(ctx.Stdout(), 8, 0, 1, ' ', 0)
+	detail, _ := newmeta.GetAPIDetail(i18n.GetLanguage(), product.Code, apiName)
+	printParameters(w, api.Parameters, "", detail)
+	w.Flush()
+
+	return nil
+}
+
+func (c *Commando) renderApiLevelHelp(ctx *cli.Context, productCode, apiName string, pluginArgs []string) error {
+	c.loadPlugins()
+	c.printHelpContextHints(ctx)
+
+	plan, product, api, _, hasBuiltIn := c.planApiLevelHelp(productCode, apiName)
+	if plan.abortErr != nil {
+		return plan.abortErr
+	}
+
+	pluginArgs = ensurePluginHelpArgs(productCode, pluginArgs)
+
+	if plan.deliverPluginHelp {
+		executed, err := c.executePluginApiHelp(ctx, productCode, pluginArgs)
+		if err != nil {
+			if !hasBuiltIn {
+				return nil
+			}
+		} else if executed {
+			return nil
+		} else if !hasBuiltIn {
+			return nil
+		}
+	}
+
+	if plan.deliverBuiltInApiHelp {
+		return c.printBuiltInApiUsage(ctx, product, api, apiName)
+	}
+	return nil
+}

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -59,6 +59,15 @@ func NewCommando(w io.Writer, profile config.Profile) *Commando {
 	return r
 }
 
+func (c *Commando) ensurePluginState() {
+	if c.pluginIndex == nil {
+		c.pluginIndex = &plugin.Index{}
+	}
+	if c.localManifest == nil {
+		c.localManifest = &plugin.LocalManifest{Plugins: make(map[string]plugin.LocalPlugin)}
+	}
+}
+
 func (c *Commando) loadPlugins() {
 	if c.pluginLoaded {
 		return
@@ -67,11 +76,17 @@ func (c *Commando) loadPlugins() {
 	mgr, err := plugin.NewManager()
 	if err != nil {
 		c.pluginIndexErr = err
+		c.ensurePluginState()
 		return
 	}
 	// Remote index may fail offline; local manifest still loads for installed plugins.
-	c.pluginIndex, c.pluginIndexErr = mgr.GetIndex()
-	c.localManifest, _ = mgr.GetLocalManifest()
+	if c.pluginIndex == nil {
+		c.pluginIndex, c.pluginIndexErr = mgr.GetIndex()
+	}
+	if c.localManifest == nil {
+		c.localManifest, _ = mgr.GetLocalManifest()
+	}
+	c.ensurePluginState()
 }
 
 func (c *Commando) printPluginIndexLoadFailureNote(ctx *cli.Context) {
@@ -163,71 +178,11 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		return nil
 	}
 
-	// Check if we should show original product help instead of plugin help, only and need to be applied in product level
-	envShowOriginalHelp := os.Getenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP")
-	showOriginalProductHelp := envShowOriginalHelp == "true" || envShowOriginalHelp == "1"
-
 	// Strategy: Plugin Execution
 	// If the second argument (API name) is all lowercase or version, use plugin.
-	// If only one arg and corresponding plugin is installed, use plugin, unless showOriginalProductHelp is true.
-	// If only one arg and corresponding plugin is not installed, show original product help.
+	// Product-level help (`aliyun <product>` / `--help`) is handled by renderProductLevelHelp.
 
-	// fmt.Println("args", args)
-	// fmt.Println("os.Args", os.Args)
-	if len(args) == 1 && !showOriginalProductHelp {
-		// 单产品输入，无论是否添加--help，都先由安装的插件运行，插件未安装则执行下面的运行逻辑
-		// 使用 ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP 环境变量可以显示原始产品的 help 信息，而不是插件 help
-		// 单产品运行就是--help
-		installed, pluginName, err := plugin.IsPluginInstalled(args[0])
-		if err != nil {
-			return fmt.Errorf("failed to check plugin status: %w", err)
-		}
-		if installed {
-			c.setLangEnv(ctx)
-			if os.Getenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP") == "true" {
-				// Fall through to built-in help
-			} else {
-				// Extract arguments from os.Args to preserve flags for plugin help, like --api-version
-				var pluginArgs []string
-				cmdIndex := -1
-				for i, arg := range os.Args {
-					if arg == args[0] {
-						cmdIndex = i
-						break
-					}
-				}
-				if cmdIndex != -1 && cmdIndex < len(os.Args) {
-					pluginArgs = os.Args[cmdIndex:]
-				} else {
-					pluginArgs = args
-				}
-
-				ok, err := plugin.ExecutePlugin(args[0], pluginArgs, ctx)
-				if err != nil {
-					return err
-				}
-				if ok {
-					cli.PrintfWithColor(ctx.Stdout(), cli.Green, "\nNote: The help information for product '%s' is provided by the installed plugin '%s'.\n", args[0], pluginName)
-					cli.PrintfWithColor(ctx.Stdout(), cli.Green, "To view the legacy built-in help, set ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true\n")
-					return nil
-				}
-			}
-		} else {
-			c.loadPlugins()
-			if c.pluginIndex != nil {
-				for _, pInfo := range c.pluginIndex.Plugins {
-					if strings.EqualFold(pInfo.ProductCode, args[0]) {
-						cli.PrintfWithColor(ctx.Stdout(), cli.Green, "\n[Suggestion] A dedicated product plugin '%s' is available for '%s'.\n", pInfo.Name, args[0])
-						cli.PrintfWithColor(ctx.Stdout(), cli.Green, "Run 'aliyun plugin install --names %s' to install it for enhanced features.\n\n", pInfo.Name)
-						break
-					}
-				}
-			} else if c.pluginIndexErr != nil {
-				c.printPluginIndexLoadFailureNote(ctx)
-			}
-		}
-
-	} else if len(args) > 1 {
+	if len(args) > 1 {
 		apiOrMethod := args[1]
 		// Check if it's all lowercase (plugin format) and not an HTTP method
 		upperMethod := strings.ToUpper(apiOrMethod)
@@ -296,7 +251,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			if !isHelp && !isVersion && len(pluginArgs) >= 2 {
 				ctx.SetInConfigureMode(DetectInConfigureMode(ctx.Flags()))
 				// Plugins may opt out of host-side profile enforcement by setting `profileRequired: false` in their manifest.
-				// When opted out, profile resolution is best-effort: we still try to load and forward the profile's env if it works, 
+				// When opted out, profile resolution is best-effort: we still try to load and forward the profile's env if it works,
 				// but we never block the plugin on host-side credential failures — the plugin is expected to resolve auth itself.
 				profileRequired := plugin.IsProfileRequiredForCommand(args[0])
 
@@ -385,11 +340,11 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 	//   aliyun <productCode> <method> --param1 value1
 	//   aliyun <productCode> GET <path>
 	productName := args[0]
+	// 单产品运行就是 --help（`aliyun <product>` / `aliyun help <product>` / `aliyun <product> --help`）
 	if len(args) == 1 {
-		// aliyun <productCode>
-		// TODO: aliyun pluginName ...
-		return c.library.PrintProductUsage(productName, true)
-	} else if len(args) == 2 {
+		return c.renderProductLevelHelp(ctx, productName, pluginArgsFromOS(productName, args))
+	}
+	if len(args) == 2 {
 		// rpc or restful call
 		// aliyun <productCode> <method> --param1 value1
 		product, _ := c.library.GetProduct(args[0])
@@ -403,7 +358,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				}
 			}
 		}
-		// Safety policy is keyed on what the user actually typed, so a rule like `sls:ListProject` matches `aliyun sls ListProject` 
+		// Safety policy is keyed on what the user actually typed, so a rule like `sls:ListProject` matches `aliyun sls ListProject`
 		// regardless of how the cli later dispatches it (REST GET /, RPC, etc.).
 		if err := c.checkSafetyPolicy(ctx, product.Code, args[1], ""); err != nil {
 			return err
@@ -432,13 +387,15 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 	} else if len(args) == 3 {
 		// restful call
 		// aliyun <productCode> {GET|PUT|POST|DELETE} <path> --
-		product, _ := c.library.GetProduct(productName)
-		api, find := meta.HookGetApiByPath(c.library.GetApiByPath)(product.Code, product.Version, args[1], args[2])
 		force := ForceFlag(ctx.Flags()).IsAssigned()
+		product, productFound := c.library.GetProduct(productName)
+		if !productFound && !force {
+			return cli.NewErrorWithTip(fmt.Errorf("product %s not found", productName),
+				"Please confirm if the product exists")
+		}
+		api, find := meta.HookGetApiByPath(c.library.GetApiByPath)(product.Code, product.Version, args[1], args[2])
 		if !find && !force {
-			// throw error, can not find api by path
-			return cli.NewErrorWithTip(fmt.Errorf("can not find api by path %s", args[2]),
-				"Please confirm if the API path exists")
+			return newInvalidRestfulPathError(c.library, &product, args[1], args[2])
 		}
 		if find {
 			c.CheckApiParamWithBuildInArgs(ctx, api)
@@ -448,8 +405,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		}
 		if ShouldUseOpenapi(ctx, &product) {
 			if !find {
-				return cli.NewErrorWithTip(fmt.Errorf("can not find api by path %s", args[2]),
-					"Please confirm if the API path exists")
+				return newInvalidRestfulPathError(c.library, &product, args[1], args[2])
 			}
 			if args[2] == "/" {
 				return cli.NewErrorWithTip(fmt.Errorf("too broad path: %s for method: %s, please use specific ApiName instead",

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -394,6 +394,18 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			c.loadPlugins()
 			return &InvalidProductOrPluginError{Code: productName, library: c.library, plugins: c.pluginIndex.Plugins}
 		}
+		if product.Code != "" {
+			if version, _ := ctx.Flags().Get("version").GetValue(); version != "" {
+				if style, ok := c.library.GetStyle(productName, version); ok {
+					product.ApiStyle = style
+				}
+			}
+		}
+		upperMethod := strings.ToUpper(args[1])
+		isHttpMethod := upperMethod == "GET" || upperMethod == "POST" || upperMethod == "PUT" || upperMethod == "DELETE"
+		if isHttpMethod && strings.ToLower(product.ApiStyle) == "rpc" && !force {
+			return c.rpcMethodPathError(&product, args[1], args[2])
+		}
 		api, find := meta.HookGetApiByPath(c.library.GetApiByPath)(product.Code, product.Version, args[1], args[2])
 		if !find && !force {
 			return c.restfulPathNotFoundError(&product, args[1], args[2])
@@ -1056,6 +1068,12 @@ func (c *Commando) restfulBroadPathError(product *meta.Product, method, path str
 	c.loadPlugins()
 	pluginName, _ := c.lookupPluginForProduct(product.Code)
 	return newRestfulBroadPathError(product, method, path, api, pluginName, c.getInstalledLocalPlugin(product.Code))
+}
+
+func (c *Commando) rpcMethodPathError(product *meta.Product, method, path string) error {
+	c.loadPlugins()
+	pluginName, _ := c.lookupPluginForProduct(product.Code)
+	return newRpcMethodPathError(product, method, path, pluginName, c.getInstalledLocalPlugin(product.Code))
 }
 
 func (c *Commando) findAndInstallPlugin(ctx *cli.Context, commandName, productCode string) (string, error) {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -409,8 +409,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				return c.restfulPathNotFoundError(&product, args[1], args[2])
 			}
 			if args[2] == "/" {
-				return cli.NewErrorWithTip(fmt.Errorf("too broad path: %s for method: %s, please use specific ApiName instead",
-					args[2], args[1]), "Please confirm the API path")
+				return c.restfulBroadPathError(&product, args[1], args[2], api)
 			}
 			return c.processApiInvoke(ctx, &product, &api, args[1], args[2])
 		}
@@ -1051,6 +1050,12 @@ func (c *Commando) restfulPathNotFoundError(product *meta.Product, method, path 
 	pluginName, _ := c.lookupPluginForProduct(product.Code)
 	matches := c.library.FindApisByPath(product.Code, product.Version, path)
 	return newInvalidRestfulPathError(product, method, path, matches, pluginName, c.getInstalledLocalPlugin(product.Code))
+}
+
+func (c *Commando) restfulBroadPathError(product *meta.Product, method, path string, api meta.Api) error {
+	c.loadPlugins()
+	pluginName, _ := c.lookupPluginForProduct(product.Code)
+	return newRestfulBroadPathError(product, method, path, api, pluginName, c.getInstalledLocalPlugin(product.Code))
 }
 
 func (c *Commando) findAndInstallPlugin(ctx *cli.Context, commandName, productCode string) (string, error) {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -225,20 +225,10 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				}
 				if foundPluginName == "" {
 					c.loadPlugins()
-					if c.pluginIndex != nil {
-						for _, pInfo := range c.pluginIndex.Plugins {
-							if strings.EqualFold(pInfo.ProductCode, args[0]) {
-								return fmt.Errorf("'%s' is not a valid built-in product.\nA plugin '%s' is available which supports this product.\nRun 'aliyun plugin install --names %s' to install it.", args[0], pInfo.Name, pInfo.Name)
-							}
-						}
-					} else if c.pluginIndexErr != nil {
+					if c.pluginIndexErr != nil {
 						c.printPluginIndexLoadFailureNote(ctx)
 					}
-					var plugins []plugin.PluginInfo
-					if c.pluginIndex != nil {
-						plugins = c.pluginIndex.Plugins
-					}
-					return &InvalidProductOrPluginError{Code: args[0], library: c.library, plugins: plugins}
+					return c.apiOrCmdNotFoundForPluginLane(args[0], args[1])
 				}
 				pluginName = foundPluginName
 			}
@@ -320,6 +310,17 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		return c.help(ctx, args)
 	}
 
+	productName := args[0]
+	// 单产品运行就是 --help（`aliyun <product>` / `aliyun help <product>` / `aliyun <product> --help`）
+	// 不强制 profile， 之前legacy 逻辑为profile 必须配置，现在不强制。 legacy 的用户的profile 已经ready，language 可用；plugin 用户language 从参数或profile获取
+	// aliyun <productCode>
+	if len(args) == 1 {
+		if c.profile.Language != "" {
+			i18n.SetLanguage(c.profile.Language)
+		}
+		return c.renderProductLevelHelp(ctx, productName, pluginArgsFromOS(productName, args))
+	}
+
 	// detect if in configure mode
 	ctx.SetInConfigureMode(DetectInConfigureMode(ctx.Flags()))
 
@@ -334,20 +335,18 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		return cli.NewErrorWithTip(err, "Configuration failed, use `aliyun configure` to configure it.")
 	}
 	i18n.SetLanguage(c.profile.Language)
-
 	// process following commands:
-	//   aliyun <productCode>
 	//   aliyun <productCode> <method> --param1 value1
 	//   aliyun <productCode> GET <path>
-	productName := args[0]
-	// 单产品运行就是 --help（`aliyun <product>` / `aliyun help <product>` / `aliyun <product> --help`）
-	if len(args) == 1 {
-		return c.renderProductLevelHelp(ctx, productName, pluginArgsFromOS(productName, args))
-	}
 	if len(args) == 2 {
 		// rpc or restful call
 		// aliyun <productCode> <method> --param1 value1
-		product, _ := c.library.GetProduct(args[0])
+		product, productFound := c.library.GetProduct(args[0])
+		force := ForceFlag(ctx.Flags()).IsAssigned()
+		if !productFound && !force {
+			c.loadPlugins()
+			return &InvalidProductOrPluginError{Code: productName, library: c.library, plugins: c.pluginIndex.Plugins}
+		}
 		if product.Code != "" {
 			if version, _ := ctx.Flags().Get("version").GetValue(); version != "" {
 				if style, ok := c.library.GetStyle(productName, version); ok {
@@ -367,9 +366,8 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			api, found := meta.HookGetApi(c.library.GetApi)(product.Code, product.Version, args[1])
 			// For restful products, the 2-arg form `aliyun <product> <ApiName>` requires a valid ApiName so we can resolve the underlying Method + PathPattern from metadata.
 			// Otherwise we'd fall through with empty Method/PathPattern and surface the confusing "product 'xxx' need restful call" error from checkRestfulMethod.
-			force := ForceFlag(ctx.Flags()).IsAssigned()
 			if !found && !force {
-				return &InvalidApiError{Name: args[1], product: &product}
+				return c.apiOrCmdNotFoundError(productName, args[1])
 			}
 			c.CheckApiParamWithBuildInArgs(ctx, api)
 			ctx.Command().Name = args[1]
@@ -379,7 +377,10 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			return c.processInvoke(ctx, productName, api.Method, api.PathPattern)
 		} else {
 			// RPC need check API parameters too
-			api, _ := c.library.GetApi(product.Code, product.Version, args[1])
+			api, found := c.library.GetApi(product.Code, product.Version, args[1])
+			if !found && !force {
+				return c.apiOrCmdNotFoundError(productName, args[1])
+			}
 			c.CheckApiParamWithBuildInArgs(ctx, api)
 		}
 
@@ -390,8 +391,8 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		force := ForceFlag(ctx.Flags()).IsAssigned()
 		product, productFound := c.library.GetProduct(productName)
 		if !productFound && !force {
-			return cli.NewErrorWithTip(fmt.Errorf("product %s not found", productName),
-				"Please confirm if the product exists")
+			c.loadPlugins()
+			return &InvalidProductOrPluginError{Code: productName, library: c.library, plugins: c.pluginIndex.Plugins}
 		}
 		api, find := meta.HookGetApiByPath(c.library.GetApiByPath)(product.Code, product.Version, args[1], args[2])
 		if !find && !force {
@@ -746,14 +747,6 @@ func (c *Commando) createInvoker(ctx *cli.Context, productCode string, apiOrMeth
 					&api,
 				}, nil
 			}
-			c.loadPlugins()
-			if c.localManifest != nil {
-				pluginName := "aliyun-cli-" + strings.ToLower(product.Code)
-				localPlugin, isInstalled := c.localManifest.Plugins[pluginName]
-				if isInstalled {
-					return nil, &InvalidUnifiedApiError{Name: apiOrMethod, product: &product, lPlugin: localPlugin}
-				}
-			}
 			return nil, &InvalidApiError{apiOrMethod, &product}
 		}
 
@@ -1026,6 +1019,31 @@ func buildCommandName(args []string) string {
 		return args[0]
 	}
 	return strings.Join(args[:2], " ")
+}
+
+// unified api/cmd guidance (builtin ApiNames + installed plugin CmdNames).
+// assume product level has been verified in the caller
+func (c *Commando) apiOrCmdNotFoundError(productCode, apiOrCmd string) error {
+	c.loadPlugins()
+	product, inLibrary := c.library.GetProduct(productCode)
+	if !inLibrary {
+		product = meta.Product{Code: productCode}
+	}
+	pluginName, _ := c.lookupPluginForProduct(productCode)
+	localPlugin := c.getInstalledLocalPlugin(productCode)
+	return newApiOrCmdNotFoundError(&product, apiOrCmd, localPlugin, pluginName)
+}
+
+// used when lowercase args[1] routed to the plugin lane but no plugin could be resolved.
+// Known products get three-way api/cmd guidance instead of a misleading "invalid product" error (e.g. aliyun sts getcalleridentity).
+func (c *Commando) apiOrCmdNotFoundForPluginLane(productCode, apiOrCmd string) error {
+	c.loadPlugins()
+	_, inLibrary := c.library.GetProduct(productCode)
+	_, hasPlugin := c.lookupPluginForProduct(productCode)
+	if !inLibrary && !hasPlugin {
+		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: c.pluginIndex.Plugins}
+	}
+	return c.apiOrCmdNotFoundError(productCode, apiOrCmd)
 }
 
 func (c *Commando) findAndInstallPlugin(ctx *cli.Context, commandName, productCode string) (string, error) {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -396,7 +396,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		}
 		api, find := meta.HookGetApiByPath(c.library.GetApiByPath)(product.Code, product.Version, args[1], args[2])
 		if !find && !force {
-			return newInvalidRestfulPathError(c.library, &product, args[1], args[2])
+			return c.restfulPathNotFoundError(&product, args[1], args[2])
 		}
 		if find {
 			c.CheckApiParamWithBuildInArgs(ctx, api)
@@ -406,7 +406,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		}
 		if ShouldUseOpenapi(ctx, &product) {
 			if !find {
-				return newInvalidRestfulPathError(c.library, &product, args[1], args[2])
+				return c.restfulPathNotFoundError(&product, args[1], args[2])
 			}
 			if args[2] == "/" {
 				return cli.NewErrorWithTip(fmt.Errorf("too broad path: %s for method: %s, please use specific ApiName instead",
@@ -1044,6 +1044,13 @@ func (c *Commando) apiOrCmdNotFoundForPluginLane(productCode, apiOrCmd string) e
 		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: c.pluginIndex.Plugins}
 	}
 	return c.apiOrCmdNotFoundError(productCode, apiOrCmd)
+}
+
+func (c *Commando) restfulPathNotFoundError(product *meta.Product, method, path string) error {
+	c.loadPlugins()
+	pluginName, _ := c.lookupPluginForProduct(product.Code)
+	matches := c.library.FindApisByPath(product.Code, product.Version, path)
+	return newInvalidRestfulPathError(product, method, path, matches, pluginName, c.getInstalledLocalPlugin(product.Code))
 }
 
 func (c *Commando) findAndInstallPlugin(ctx *cli.Context, commandName, productCode string) (string, error) {

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -15,7 +15,6 @@ package openapi
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -55,28 +54,7 @@ func (c *Commando) printHelpContextHints(ctx *cli.Context) {
 }
 
 func getPluginArgsForHelp(productCode string) []string {
-	cmdIndex := -1
-	for i, arg := range os.Args {
-		if strings.EqualFold(arg, productCode) {
-			cmdIndex = i
-			break
-		}
-	}
-	if cmdIndex != -1 && cmdIndex < len(os.Args) {
-		args := os.Args[cmdIndex:]
-		hasHelp := false
-		for _, arg := range args {
-			if arg == "--help" || arg == "-h" {
-				hasHelp = true
-				break
-			}
-		}
-		if !hasHelp {
-			args = append(args, "--help")
-		}
-		return args
-	}
-	return []string{productCode, "--help"}
+	return ensurePluginHelpArgs(productCode, pluginArgsFromOS(productCode, []string{productCode, "--help"}))
 }
 
 func (c *Commando) printProducts(ctx *cli.Context) {
@@ -183,125 +161,7 @@ func (c *Commando) printProducts(ctx *cli.Context) {
 }
 
 func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error {
-	c.printHelpContextHints(ctx)
-	// 1. Check if it's a plugin product
-	var pluginName string
-	var isInstalled bool
-
-	if c.pluginIndex != nil {
-		for _, pInfo := range c.pluginIndex.Plugins {
-			name := pInfo.Name
-			// aliyun-cli-<lower-product>
-			pCode := pInfo.ProductCode
-			if strings.EqualFold(pCode, productCode) {
-				pluginName = name
-				break
-			}
-		}
-	}
-	// Locally installed plugin (e.g. plugin install --package) not in remote index
-	if pluginName == "" && c.localManifest != nil {
-		if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
-			pluginName = n
-		}
-	}
-
-	// 2. Check if it's a built-in product
-	product, ok := c.library.GetProduct(productCode)
-	if !ok {
-		// If not a built-in product, but is a valid plugin product
-		if pluginName != "" {
-			if c.localManifest != nil {
-				_, isInstalled = c.localManifest.Plugins[pluginName]
-			}
-			if isInstalled {
-				cli.Printf(ctx.Stdout(), "Product '%s' is provided by plugin '%s'\n", productCode, pluginName)
-				c.setLangEnv(ctx)
-				plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), ctx)
-				return nil
-			} else {
-				return fmt.Errorf("'%s' is not a valid product.\nDid you mean to install corresponding product plugin?\n  aliyun plugin install --names %s", productCode, pluginName)
-			}
-		}
-		var plugList []plugin.PluginInfo
-		if c.pluginIndex != nil {
-			plugList = c.pluginIndex.Plugins
-		}
-		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: plugList}
-	}
-
-	if pluginName != "" {
-		if c.localManifest != nil {
-			_, isInstalled = c.localManifest.Plugins[pluginName]
-		}
-
-		if isInstalled {
-			// Built-in product AND installed plugin
-			if os.Getenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP") == "true" {
-				// Show built-in help (fall through)
-			} else {
-				cli.Printf(ctx.Stdout(), "Note: The help information for product '%s' is provided by the installed plugin '%s'.\n", productCode, pluginName)
-				cli.Printf(ctx.Stdout(), "To view legacy built-in help, set ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true\n")
-				c.setLangEnv(ctx)
-				plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), ctx)
-				return nil
-			}
-		} else {
-			cli.Printf(ctx.Stdout(), "\n[Suggestion] A dedicated product plugin is available for '%s'.\n", productCode)
-			cli.Printf(ctx.Stdout(), "Run 'aliyun plugin install --names %s' to install it for enhanced features.\n\n", pluginName)
-		}
-	}
-
-	if product.ApiStyle == "rpc" {
-		cli.Printf(ctx.Stdout(), "\nUsage:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ...\n", strings.ToLower(product.Code))
-	} else {
-		cli.Printf(ctx.Stdout(), "\nUsage 1:\n  aliyun %s [GET|PUT|POST|DELETE] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
-		cli.Printf(ctx.Stdout(), "\nUsage 2 (For API with NO PARAMS in PathPattern only.):\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ... --body \"...\"\n", strings.ToLower(product.Code))
-	}
-	productName, _ := newmeta.GetProductName(i18n.GetLanguage(), product.Code)
-	cli.Printf(ctx.Stdout(), "\nProduct: %s (%s)\n", product.Code, productName)
-	cli.Printf(ctx.Stdout(), "Version: %s \n", product.Version)
-
-	if len(product.ApiNames) > 0 {
-		cli.PrintfWithColor(ctx.Stdout(), cli.ColorOff, "\nAvailable Api List: \n")
-	}
-
-	maxNameLen := 0
-
-	for _, apiName := range product.ApiNames {
-		if len(apiName) > maxNameLen {
-			maxNameLen = len(apiName)
-		}
-	}
-
-	for _, apiName := range product.ApiNames {
-		if product.ApiStyle == "restful" {
-			api, _ := c.library.GetApi(product.Code, product.Version, apiName)
-			ptn := fmt.Sprintf("  %%-%ds : %%s %%s\n", maxNameLen+1)
-			cli.PrintfWithColor(ctx.Stdout(), cli.Green, ptn, apiName, api.Method, api.PathPattern)
-		} else {
-			api, _ := newmeta.GetAPI(i18n.GetLanguage(), product.Code, apiName)
-			if api != nil {
-				apiDetail, _ := newmeta.GetAPIDetail(i18n.GetLanguage(), product.Code, apiName)
-				// use new api metadata
-				if api.Deprecated {
-					fmtStr := fmt.Sprintf("  %%-%ds [Deprecated]%%s\n", maxNameLen+1)
-					cli.PrintfWithColor(ctx.Stdout(), cli.Green, fmtStr, apiName, api.Summary)
-				} else if apiDetail.IsAnonymousAPI() {
-					fmtStr := fmt.Sprintf("  %%-%ds [Anonymous]%%s\n", maxNameLen+1)
-					cli.PrintfWithColor(ctx.Stdout(), cli.Green, fmtStr, apiName, api.Summary)
-				} else {
-					fmtStr := fmt.Sprintf("  %%-%ds %%s\n", maxNameLen+1)
-					cli.PrintfWithColor(ctx.Stdout(), cli.Green, fmtStr, apiName, api.Summary)
-				}
-			} else {
-				cli.PrintfWithColor(ctx.Stdout(), cli.Green, "  %s\n", apiName)
-			}
-		}
-	}
-
-	cli.Printf(ctx.Stdout(), "\nRun `aliyun %s <ApiName> --help` to get more information about this API\n", product.GetLowerCode())
-	return nil
+	return c.renderProductLevelHelp(ctx, productCode, getPluginArgsForHelp(productCode))
 }
 
 func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName string) error {
@@ -346,7 +206,7 @@ func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName s
 				plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), ctx)
 				return nil
 			} else {
-				return fmt.Errorf("'%s' is not a valid product.\nDid you mean to install corresponding product plugin?\n  aliyun plugin install --names %s", productCode, pluginName)
+				return fmt.Errorf("'%s' is not a built-in product and requires an external product plugin.\n  aliyun plugin install --names %s", productCode, pluginName)
 			}
 		}
 		// Not a built-in product and not a plugin product, like fuzzy cmd input

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -165,106 +165,7 @@ func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error
 }
 
 func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName string) error {
-	c.printHelpContextHints(ctx)
-	// 0. Check if it's a plugin product
-	var pluginName string
-	var isInstalled bool
-	var localPlugin plugin.LocalPlugin
-
-	if c.pluginIndex != nil {
-		for _, pInfo := range c.pluginIndex.Plugins {
-			name := pInfo.Name
-			pCode := pInfo.ProductCode
-			if strings.EqualFold(pCode, productCode) {
-				pluginName = name
-				break
-			}
-		}
-	}
-	if pluginName == "" && c.localManifest != nil {
-		if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
-			pluginName = n
-		}
-	}
-
-	if pluginName != "" && c.localManifest != nil {
-		if lp, ok := c.localManifest.Plugins[pluginName]; ok {
-			localPlugin = lp
-			isInstalled = true
-		}
-	}
-
-	// 1. Try to get built-in product info
-	product, ok := c.library.builtinRepo.GetProduct(productCode)
-
-	// Case A: Not a built-in product
-	if !ok {
-		if pluginName != "" { // should not happen, might be true in the future when plugin product has more than built-in product
-			if isInstalled {
-				cli.Printf(ctx.Stdout(), "Command '%s %s' is provided by plugin '%s'.\n", productCode, apiName, pluginName)
-				c.setLangEnv(ctx)
-				plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), ctx)
-				return nil
-			} else {
-				return fmt.Errorf("'%s' is not a built-in product and requires an external product plugin.\n  aliyun plugin install --names %s", productCode, pluginName)
-			}
-		}
-		// Not a built-in product and not a plugin product, like fuzzy cmd input
-		var plugList []plugin.PluginInfo
-		if c.pluginIndex != nil {
-			plugList = c.pluginIndex.Plugins
-		}
-		return &InvalidProductOrPluginError{Code: productCode, library: c.library, plugins: plugList}
-	}
-
-	shouldTryPlugin := false
-	if apiName == strings.ToLower(apiName) { // fuzzy cmd input should apply different logic for build-in and plugin product
-		shouldTryPlugin = true
-	}
-
-	// Case B: Built-in product exists
-	api, ok := c.library.builtinRepo.GetApi(productCode, product.Version, apiName)
-	if !ok {
-		// API not found in built-in metadata. api in plugin is different from api from built-in
-		if pluginName != "" {
-			if shouldTryPlugin { // 全小写进入插件执行及智能纠错系统， 未安装则提示安装
-				if isInstalled {
-					c.setLangEnv(ctx)
-					plugin.ExecutePlugin(productCode, getPluginArgsForHelp(productCode), ctx)
-					return nil
-				} else {
-					return fmt.Errorf("'%s' is not a valid built-in command.\nA plugin '%s' is available which might support this command.\nRun 'aliyun plugin install --names %s' to install it.", apiName, pluginName, pluginName)
-				}
-			} else { // 非插件命令形式，如果本地插件安装了，则返回插件帮助; 如果未安装，则打印插件提示信息，并继续原有api纠错系统
-				if isInstalled {
-					return &InvalidUnifiedApiError{Name: apiName, product: &product, lPlugin: localPlugin}
-				} else {
-					cli.Printf(ctx.Stdout(), "\n[Suggestion] A dedicated product plugin is available for '%s'.\n", productCode)
-					cli.Printf(ctx.Stdout(), "Run 'aliyun plugin install --names %s' to install it for enhanced features.\n\n", pluginName)
-				}
-			}
-		}
-		return &InvalidApiError{Name: apiName, product: &product}
-	}
-
-	productName, _ := newmeta.GetProductName(i18n.GetLanguage(), productCode)
-
-	if product.ApiStyle == "restful" {
-		cli.Printf(ctx.Stdout(), "\nProduct:     %s (%s)\n", product.Code, productName)
-		cli.Printf(ctx.Stdout(), "Method:      %s\n", api.Method)
-		cli.Printf(ctx.Stdout(), "PathPattern: %s\n", api.PathPattern)
-	} else {
-		cli.Printf(ctx.Stdout(), "\nProduct: %s (%s)\n", product.Code, productName)
-	}
-
-	cli.Printf(ctx.Stdout(), "\nParameters:\n")
-
-	w := tabwriter.NewWriter(ctx.Stdout(), 8, 0, 1, ' ', 0)
-	detail, _ := newmeta.GetAPIDetail(i18n.GetLanguage(), productCode, apiName)
-	printParameters(w, api.Parameters, "", detail)
-	w.Flush()
-
-	return nil
+	return c.renderApiLevelHelp(ctx, productCode, apiName, getPluginArgsForApiHelp(productCode, apiName))
 }
 
 var (
@@ -274,9 +175,9 @@ var (
 
 // tryDelegatePluginHelp is layer-3 of the help hierarchy:
 //
-//	len(args)==1 → printProductUsage      (this file)
-//	len(args)==2 → printApiUsage          (this file)
-//	len(args)>2  → tryDelegatePluginHelp  (this file)
+//	len(args)==1 → renderProductLevelHelp   (product_help.go)
+//	len(args)==2 → renderApiLevelHelp       (api_help.go)
+//	len(args)>2  → tryDelegatePluginHelp    (this file)
 
 // OpenAPI APIs are conventionally PascalCase (DescribeRegions, GetAlias)
 // and RESTful invocations carry an uppercase HTTP method in args[1].

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -209,8 +209,9 @@ func TestPrintApiUsage_UnknownApi_NoPlugin(t *testing.T) {
 
 	err := c.printApiUsage(ctx, "ecs", "NonExistentApi")
 	assert.Error(t, err)
-	assert.IsType(t, &InvalidApiError{}, err)
+	assert.IsType(t, &InvalidApiOrCmdNotFoundError{}, err)
 	assert.Contains(t, err.Error(), "NonExistentApi")
+	assert.Contains(t, err.Error(), "CamelCase")
 }
 
 func TestPrintApiUsage_UnknownProduct_NoPlugin(t *testing.T) {
@@ -237,11 +238,13 @@ func TestPrintApiUsage_UnknownApi_PluginAvailableNotInstalled_Lowercase(t *testi
 		Plugins: map[string]plugin.LocalPlugin{},
 	}
 
-	// Lowercase API name triggers shouldTryPlugin=true, uninstalled plugin -> install hint
+	// Lowercase unknown API → three-way scan error + install hint in error body (no auto plugin route)
 	err := c.printApiUsage(ctx, "ecs", "describeinstances")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "aliyun-cli-ecs")
-	assert.Contains(t, err.Error(), "aliyun plugin install --names")
+	assert.IsType(t, &InvalidApiOrCmdNotFoundError{}, err)
+	assert.Contains(t, err.Error(), "CamelCase")
+	assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-ecs")
+	assert.Empty(t, stdout.String())
 }
 
 func TestPrintApiUsage_UnknownApi_PluginHint_NonLowercase(t *testing.T) {
@@ -257,14 +260,12 @@ func TestPrintApiUsage_UnknownApi_PluginHint_NonLowercase(t *testing.T) {
 		Plugins: map[string]plugin.LocalPlugin{},
 	}
 
-	// Non-lowercase (e.g. "BadApiName") -> prints suggestion, then returns InvalidApiError
+	// Non-lowercase unknown API → three-way scan; install hint lives in error body when plugin not installed
 	err := c.printApiUsage(ctx, "ecs", "BadApiName")
 	assert.Error(t, err)
-	assert.IsType(t, &InvalidApiError{}, err)
-
-	output := stdout.String()
-	assert.Contains(t, output, "[Suggestion]")
-	assert.Contains(t, output, "aliyun-cli-ecs")
+	assert.IsType(t, &InvalidApiOrCmdNotFoundError{}, err)
+	assert.Contains(t, err.Error(), "aliyun plugin install --name")
+	assert.Empty(t, stdout.String())
 }
 
 func TestPrintApiUsage_NonBuiltinProduct_PluginNotInstalled(t *testing.T) {
@@ -284,7 +285,8 @@ func TestPrintApiUsage_NonBuiltinProduct_PluginNotInstalled(t *testing.T) {
 
 	err := c.printApiUsage(ctx, "fc", "somecmd")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "aliyun plugin install --names aliyun-cli-fc")
+	assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-fc")
+	assert.Contains(t, err.Error(), "aliyun fc somecmd --help")
 }
 
 func TestGetPluginArgsForHelp(t *testing.T) {
@@ -326,6 +328,11 @@ func TestGetPluginArgsForHelp(t *testing.T) {
 		args := getPluginArgsForHelp("ecs")
 		assert.Equal(t, []string{"ecs", "--api-version", "2014-05-26", "--help"}, args)
 	})
+}
+
+func TestGetPluginArgsForApiHelp(t *testing.T) {
+	args := getPluginArgsForApiHelp("fc", "list-functions")
+	assert.Equal(t, []string{"fc", "list-functions", "--help"}, args)
 }
 
 func setupInstalledPlugin(t *testing.T, pluginName string) {
@@ -402,6 +409,31 @@ func TestPrintProductUsage_BuiltinProduct_PluginInstalled(t *testing.T) {
 	assert.Contains(t, output, "ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true")
 }
 
+func TestPrintApiUsage_BuiltinShellProduct_PluginInstalled(t *testing.T) {
+	setupInstalledPlugin(t, "aliyun-cli-cs")
+
+	c, w, stderr := newTestCommando()
+	ctx := newTestContext(w, stderr)
+
+	repo, _ := meta.MockLoadRepository([]meta.Product{
+		{Code: "CS", Version: "2015-12-15", ApiStyle: "restful", ApiNames: []string{}},
+	})
+	c.library.builtinRepo = repo
+	c.pluginIndex = &plugin.Index{
+		Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-cs", ProductCode: "cs"},
+		},
+	}
+	c.localManifest = &plugin.LocalManifest{
+		Plugins: map[string]plugin.LocalPlugin{
+			"aliyun-cli-cs": {Name: "aliyun-cli-cs", Version: "1.0.0"},
+		},
+	}
+
+	err := c.printApiUsage(ctx, "cs", "list-clusters")
+	assert.NoError(t, err)
+}
+
 func TestPrintApiUsage_NonBuiltinProduct_PluginInstalled(t *testing.T) {
 	setupInstalledPlugin(t, "aliyun-cli-fc")
 
@@ -423,9 +455,6 @@ func TestPrintApiUsage_NonBuiltinProduct_PluginInstalled(t *testing.T) {
 
 	err := c.printApiUsage(ctx, "fc", "deploy")
 	assert.NoError(t, err)
-
-	output := w.String()
-	assert.Contains(t, output, "Command 'fc deploy' is provided by plugin 'aliyun-cli-fc'")
 }
 
 func setupLocalPluginShellBinary(t *testing.T, pluginName string) {
@@ -500,7 +529,7 @@ func TestPrintApiUsage_LocalPluginNotInRemoteIndex(t *testing.T) {
 
 	err = c.printApiUsage(ctx, "localonly2", "SomeApi")
 	assert.NoError(t, err)
-	assert.Contains(t, w.String(), "Command 'localonly2 SomeApi' is provided by plugin 'aliyun-cli-localonly2'")
+	assert.Contains(t, w.String(), "HELP_FROM_LOCAL_PLUGIN")
 }
 
 func TestPrintProducts_PluginIndexLoadHint(t *testing.T) {

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -141,7 +141,7 @@ func TestPrintProductUsage_NonBuiltinProduct_PluginNotInstalled(t *testing.T) {
 
 	err := c.printProductUsage(ctx, "fc")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "aliyun plugin install --names aliyun-cli-fc")
+	assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-fc")
 }
 
 func TestPrintProductUsage_NonBuiltinProduct_NoPlugin(t *testing.T) {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -1484,7 +1484,10 @@ func TestMainForSlsProduct(t *testing.T) {
 
 		args := []string{"sls", "Get", "/"}
 		err := command.main(ctx, args)
-		assert.Contains(t, err.Error(), "too broad path: / for method: Get, please use specific ApiName instead")
+		assert.IsType(t, &RestfulBroadPathError{}, err)
+		assert.Contains(t, err.Error(), `path "/" is too broad for METHOD+path invocation with GET`)
+		assert.Contains(t, err.Error(), "Use a specific ApiName or path instead of the root path")
+		assert.Contains(t, err.Error(), "aliyun sls --help")
 	})
 
 	t.Run("SLSProductWithRestCall", func(t *testing.T) {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -2347,6 +2347,71 @@ func TestMain_RestfulCallWithForceAndApiFinding(t *testing.T) {
 	})
 }
 
+func TestMain_RpcProductRejectsMethodPath(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	profile := config.Profile{
+		Language:        "en",
+		Mode:            "AK",
+		AccessKeyId:     "test-access-key-id",
+		AccessKeySecret: "test-access-key-secret",
+		RegionId:        "cn-hangzhou",
+	}
+	command := NewCommando(stdout, profile)
+
+	cmd := &cli.Command{}
+	AddFlags(cmd.Flags())
+	cmd.EnableUnknownFlag = true
+	command.InitWithCommand(cmd)
+
+	ecsProduct := meta.Product{
+		Code:     "ecs",
+		Version:  "2014-05-26",
+		ApiStyle: "rpc",
+		ApiNames: []string{"DescribeInstances"},
+	}
+	mockRepo, _ := meta.MockLoadRepository([]meta.Product{ecsProduct})
+	command.library = &Library{builtinRepo: mockRepo}
+
+	originalIgnoreProfile := os.Getenv("ALIBABA_CLOUD_IGNORE_PROFILE")
+	os.Setenv("ALIBABA_CLOUD_IGNORE_PROFILE", "TRUE")
+	defer func() {
+		if originalIgnoreProfile == "" {
+			os.Unsetenv("ALIBABA_CLOUD_IGNORE_PROFILE")
+		} else {
+			os.Setenv("ALIBABA_CLOUD_IGNORE_PROFILE", originalIgnoreProfile)
+		}
+	}()
+
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+	regionflag := config.NewRegionFlag()
+	regionflag.SetAssigned(true)
+	regionflag.SetValue("cn-hangzhou")
+	ctx.Flags().Add(regionflag)
+	accessKeyIDFlag := config.NewAccessKeyIdFlag()
+	accessKeyIDFlag.SetAssigned(true)
+	accessKeyIDFlag.SetValue("test-access-key-id")
+	ctx.Flags().Add(accessKeyIDFlag)
+	accessKeySecretFlag := config.NewAccessKeySecretFlag()
+	accessKeySecretFlag.SetAssigned(true)
+	accessKeySecretFlag.SetValue("test-access-key-secret")
+	ctx.Flags().Add(accessKeySecretFlag)
+
+	err := command.main(ctx, []string{"ecs", "GET", "/instances"})
+	assert.Error(t, err)
+	assert.IsType(t, &RpcMethodPathError{}, err)
+	assert.Contains(t, err.Error(), "RPC product")
+	assert.Contains(t, err.Error(), "does not accept METHOD + path")
+	assert.NotContains(t, err.Error(), "can not find api by path")
+
+	ForceFlag(ctx.Flags()).SetAssigned(true)
+	err = command.main(ctx, []string{"ecs", "GET", "/instances"})
+	assert.Error(t, err)
+	_, isRpcMethodPathErr := err.(*RpcMethodPathError)
+	assert.False(t, isRpcMethodPathErr)
+}
+
 func TestMain_PluginExecution_KebabCase(t *testing.T) {
 	w := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -110,7 +110,7 @@ func Test_main(t *testing.T) {
 	profileflag.SetAssigned(false)
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid command or product. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
 
 	ctx.Flags().Get("force").SetAssigned(true)
 	ctx.Flags().Get("version").SetAssigned(true)
@@ -134,12 +134,12 @@ func Test_main(t *testing.T) {
 	args = []string{"aos", "test2"}
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'aos' is not a valid product. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'aos' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
 
 	args = []string{"test", "test2", "test1"}
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid product. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
 
 	args = []string{"test", "Test2", "test1", "test3"}
 	err = command.main(ctx, args)
@@ -491,12 +491,12 @@ func Test_help(t *testing.T) {
 	args = []string{"test"}
 	err = command.help(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid product. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
 
 	args = []string{"test", "test0"}
 	err = command.help(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid product. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
 
 	args = []string{"test", "test0", "test1"}
 	err = command.help(ctx, args)
@@ -505,7 +505,7 @@ func Test_help(t *testing.T) {
 	// — which used to imply args[0] was a valid product even when (as here) it wasn't.
 	// For args[0]="test", neither an installed plugin nor a built-in OpenAPI product,
 	// the helper falls all the way through to step-4 (fuzzy suggestion via InvalidProductOrPluginError, plus a Hint explaining the OpenAPI alternative form).
-	assert.Contains(t, err.Error(), "'test' is not a valid product. See `aliyun help`.")
+	assert.Contains(t, err.Error(), "'test' is not a valid built-in product or external product plugin. See `aliyun help`.")
 	assert.Contains(t, err.Error(), "OpenAPI built-in call",
 		"step-4 must surface the OpenAPI alternative as a Hint")
 }
@@ -2389,7 +2389,7 @@ func TestMain_PluginExecution_KebabCase(t *testing.T) {
 
 		err := command.main(ctx, args)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "'qqq' is not a valid product")
+		assert.Contains(t, err.Error(), "'qqq' is not a valid built-in product or external product plugin")
 	})
 
 	t.Run("Kebab-case API name with multiple arguments extracts all args", func(t *testing.T) {
@@ -2407,7 +2407,7 @@ func TestMain_PluginExecution_KebabCase(t *testing.T) {
 
 		err := command.main(ctx, args)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "'qqq' is not a valid product")
+		assert.Contains(t, err.Error(), "'qqq' is not a valid built-in product or external product plugin")
 	})
 
 	t.Run("Non-kebab-case API name does not trigger plugin", func(t *testing.T) {
@@ -2838,7 +2838,6 @@ exit 0
 		if runtime.GOOS == "windows" {
 			t.Skip("shell script test skipped on Windows")
 		}
-		// Set environment variable
 		originalEnv := os.Getenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP")
 		os.Setenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP", "true")
 		defer func() {
@@ -2849,22 +2848,21 @@ exit 0
 			}
 		}()
 
-		// Create a plugin that exists
+		// Built-in ecs + installed ecs plugin: showOriginal must render legacy built-in help, not plugin.
 		testPluginManifest := `{
 			"plugins": {
-				"envtest": {
-					"name": "envtest",
+				"aliyun-cli-ecs": {
+					"name": "aliyun-cli-ecs",
 					"version": "1.0.0",
-					"path": "` + filepath.Join(pluginDir, "envtest") + `",
-					"command": "envtest"
+					"path": "` + filepath.Join(pluginDir, "aliyun-cli-ecs") + `",
+					"command": "ecs"
 				}
 			}
 		}`
 		err := os.WriteFile(manifestPath, []byte(testPluginManifest), 0644)
 		assert.NoError(t, err)
 
-		// Create the plugin binary so it could be executed
-		pluginPath := filepath.Join(pluginDir, "envtest", "envtest")
+		pluginPath := filepath.Join(pluginDir, "aliyun-cli-ecs", "aliyun-cli-ecs")
 		err = os.MkdirAll(filepath.Dir(pluginPath), 0755)
 		assert.NoError(t, err)
 
@@ -2875,19 +2873,19 @@ exit 0
 		err = os.WriteFile(pluginPath, []byte(mockPluginScript), 0755)
 		assert.NoError(t, err)
 
-		// Test with single argument (product-level help scenario)
-		os.Args = []string{"aliyun", "envtest"}
-		args := []string{"envtest"}
+		command.pluginLoaded = false
+		command.localManifest = nil
+		command.pluginIndex = nil
+
+		os.Args = []string{"aliyun", "ecs"}
+		args := []string{"ecs"}
 
 		stdout.Reset()
 		err = command.main(ctx, args)
 
-		// With ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true and single arg,
-		// plugin execution is skipped
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "not a valid command or product")
+		assert.NoError(t, err)
+		assert.Contains(t, stdout.String(), "Available Api List")
 		assert.NotContains(t, stdout.String(), "Plugin should not execute")
-
 	})
 
 	t.Run("Kebab-case command triggers plugin execution", func(t *testing.T) {
@@ -2986,6 +2984,12 @@ func TestSingleProductPluginExecution(t *testing.T) {
 	err := os.MkdirAll(pluginDir, 0755)
 	assert.NoError(t, err)
 
+	resetPluginCache := func() {
+		command.pluginLoaded = false
+		command.localManifest = nil
+		command.pluginIndex = nil
+	}
+
 	t.Run("Single arg - plugin installed and executes successfully", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("shell script test skipped on Windows")
@@ -3015,6 +3019,7 @@ exit 0
 		err = os.WriteFile(pluginPath, []byte(mockPluginScript), 0755)
 		assert.NoError(t, err)
 
+		resetPluginCache()
 		os.Args = []string{"aliyun", "singletest"}
 		args := []string{"singletest"}
 
@@ -3044,15 +3049,14 @@ exit 0
 		err = os.MkdirAll(filepath.Join(pluginDir, "missingbin"), 0755)
 		assert.NoError(t, err)
 
+		resetPluginCache()
 		os.Args = []string{"aliyun", "missingbin"}
 		args := []string{"missingbin"}
 
 		stdout.Reset()
 		err = command.main(ctx, args)
 
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "plugin")
-		assert.Contains(t, err.Error(), "not found")
+		assert.NoError(t, err)
 	})
 
 	t.Run("Single arg - plugin not installed", func(t *testing.T) {
@@ -3063,6 +3067,7 @@ exit 0
 		err := os.WriteFile(manifestPath, []byte(testPluginManifest), 0644)
 		assert.NoError(t, err)
 
+		resetPluginCache()
 		os.Args = []string{"aliyun", "notinstalled"}
 		args := []string{"notinstalled"}
 
@@ -3074,12 +3079,11 @@ exit 0
 		assert.NotContains(t, err.Error(), "plugin notinstalled not found")
 	})
 
-	t.Run("Single arg - IsPluginInstalled returns error", func(t *testing.T) {
-		// err != nil from IsPluginInstalled
-
-		// Write invalid JSON to manifest
+	t.Run("Single arg - corrupt local manifest", func(t *testing.T) {
 		err := os.WriteFile(manifestPath, []byte(`{invalid json`), 0644)
 		assert.NoError(t, err)
+
+		resetPluginCache()
 
 		os.Args = []string{"aliyun", "testprod"}
 		args := []string{"testprod"}
@@ -3087,14 +3091,13 @@ exit 0
 		stdout.Reset()
 		err = command.main(ctx, args)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to check plugin status")
+		assert.Contains(t, err.Error(), "not a valid built-in product or external product plugin")
 	})
 
 	t.Run("Single arg - with ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("shell script test skipped on Windows")
 		}
-		// Test that environment variable skips the entire plugin check block
 		originalEnv := os.Getenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP")
 		os.Setenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP", "true")
 		defer func() {
@@ -3107,18 +3110,18 @@ exit 0
 
 		testPluginManifest := `{
 			"plugins": {
-				"envskip": {
-					"name": "envskip",
+				"aliyun-cli-ecs": {
+					"name": "aliyun-cli-ecs",
 					"version": "1.0.0",
-					"path": "` + filepath.Join(pluginDir, "envskip") + `",
-					"command": "envskip"
+					"path": "` + filepath.Join(pluginDir, "aliyun-cli-ecs") + `",
+					"command": "ecs"
 				}
 			}
 		}`
 		err := os.WriteFile(manifestPath, []byte(testPluginManifest), 0644)
 		assert.NoError(t, err)
 
-		pluginPath := filepath.Join(pluginDir, "envskip", "envskip")
+		pluginPath := filepath.Join(pluginDir, "aliyun-cli-ecs", "aliyun-cli-ecs")
 		err = os.MkdirAll(filepath.Dir(pluginPath), 0755)
 		assert.NoError(t, err)
 
@@ -3129,18 +3132,17 @@ exit 0
 		err = os.WriteFile(pluginPath, []byte(mockPluginScript), 0755)
 		assert.NoError(t, err)
 
-		os.Args = []string{"aliyun", "envskip"}
-		args := []string{"envskip"}
+		resetPluginCache()
+
+		os.Args = []string{"aliyun", "ecs"}
+		args := []string{"ecs"}
 
 		stdout.Reset()
 		err = command.main(ctx, args)
 
-		// With ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true, the entire if block is skipped
-		// Plugin should NOT be executed
+		assert.NoError(t, err)
+		assert.Contains(t, stdout.String(), "Available Api List")
 		assert.NotContains(t, stdout.String(), "Should not execute")
-
-		// Should try to process as normal product command
-		assert.Error(t, err)
 	})
 }
 

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -2337,13 +2337,10 @@ func TestMain_RestfulCallWithForceAndApiFinding(t *testing.T) {
 		args := []string{"sls", "GET", "/nonexistent"}
 		err := command.main(ctx, args)
 		assert.Error(t, err)
+		assert.IsType(t, &InvalidRestfulPathError{}, err)
 		assert.Contains(t, err.Error(), "can not find api by path")
 		assert.Contains(t, err.Error(), "/nonexistent")
-		if errorWithTip, ok := err.(cli.ErrorWithTip); ok {
-			assert.Contains(t, errorWithTip.GetTip("en"), "Please confirm if the API path exists")
-		} else {
-			t.Fatalf("Expected ErrorWithTip, got %T", err)
-		}
+		assert.Contains(t, err.Error(), "ApiName form")
 	})
 }
 

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -82,7 +82,7 @@ func Test_main(t *testing.T) {
 	err := command.main(ctx, nil)
 	assert.Nil(t, err)
 
-	args := []string{"test"}
+	args := []string{"ecs", "DescribeRegions"}
 	profileflag := config.NewProfileFlag()
 	configpathflag := config.NewConfigurePathFlag()
 	profileflag.SetAssigned(true)
@@ -1486,8 +1486,8 @@ func TestMainForSlsProduct(t *testing.T) {
 		err := command.main(ctx, args)
 		assert.IsType(t, &RestfulBroadPathError{}, err)
 		assert.Contains(t, err.Error(), `path "/" is too broad for METHOD+path invocation with GET`)
-		assert.Contains(t, err.Error(), "Use a specific ApiName or path instead of the root path")
-		assert.Contains(t, err.Error(), "aliyun sls --help")
+		assert.Contains(t, err.Error(), `Use a specific ApiName instead of the root path "/"`)
+		assert.Contains(t, err.Error(), "Use `aliyun sls --help` to confirm the correct ApiName for this product.")
 	})
 
 	t.Run("SLSProductWithRestCall", func(t *testing.T) {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -110,7 +110,7 @@ func Test_main(t *testing.T) {
 	profileflag.SetAssigned(false)
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun --help`.", err.Error())
 
 	ctx.Flags().Get("force").SetAssigned(true)
 	ctx.Flags().Get("version").SetAssigned(true)
@@ -134,12 +134,12 @@ func Test_main(t *testing.T) {
 	args = []string{"aos", "test2"}
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'aos' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'aos' is not a valid built-in product or external product plugin. See `aliyun --help`.", err.Error())
 
 	args = []string{"test", "test2", "test1"}
 	err = command.main(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun --help`.", err.Error())
 
 	args = []string{"test", "Test2", "test1", "test3"}
 	err = command.main(ctx, args)
@@ -491,12 +491,12 @@ func Test_help(t *testing.T) {
 	args = []string{"test"}
 	err = command.help(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun --help`.", err.Error())
 
 	args = []string{"test", "test0"}
 	err = command.help(ctx, args)
 	assert.NotNil(t, err)
-	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
+	assert.Equal(t, "'test' is not a valid built-in product or external product plugin. See `aliyun --help`.", err.Error())
 
 	args = []string{"test", "test0", "test1"}
 	err = command.help(ctx, args)
@@ -505,7 +505,7 @@ func Test_help(t *testing.T) {
 	// — which used to imply args[0] was a valid product even when (as here) it wasn't.
 	// For args[0]="test", neither an installed plugin nor a built-in OpenAPI product,
 	// the helper falls all the way through to step-4 (fuzzy suggestion via InvalidProductOrPluginError, plus a Hint explaining the OpenAPI alternative form).
-	assert.Contains(t, err.Error(), "'test' is not a valid built-in product or external product plugin. See `aliyun help`.")
+	assert.Contains(t, err.Error(), "'test' is not a valid built-in product or external product plugin. See `aliyun --help`.")
 	assert.Contains(t, err.Error(), "OpenAPI built-in call",
 		"step-4 must surface the OpenAPI alternative as a Hint")
 }
@@ -1626,7 +1626,7 @@ func TestMainForNonSlsProductApi(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-// Regression test: for a restful product, when the user provides an API name that does not exist in metadata (e.g. `aliyun apig GetPlugin`), the error should be `InvalidApiError` with suggestions,
+// Regression test: for a restful product, when the user provides an API name that does not exist in metadata (e.g. `aliyun apig GetPlugin`), the error should be unified api/cmd guidance,
 // NOT the confusing `product 'xxx' need restful call` produced by checkRestfulMethod.
 func TestMainRestfulProductWithInvalidApiName(t *testing.T) {
 	stdout := new(bytes.Buffer)
@@ -1684,11 +1684,11 @@ func TestMainRestfulProductWithInvalidApiName(t *testing.T) {
 	args := []string{"apig", "GetPlugin"}
 	err := command.main(ctx, args)
 	assert.NotNil(t, err)
-	// Must be InvalidApiError, not the generic "need restful call" message.
-	invalidApiErr, ok := err.(*InvalidApiError)
-	assert.True(t, ok, "expected *InvalidApiError, got %T: %v", err, err)
+	invalidApiErr, ok := err.(*InvalidApiOrCmdNotFoundError)
+	assert.True(t, ok, "expected *InvalidApiOrCmdNotFoundError, got %T: %v", err, err)
 	assert.Equal(t, "GetPlugin", invalidApiErr.Name)
-	assert.Contains(t, err.Error(), "'GetPlugin' is not a valid api")
+	assert.Contains(t, err.Error(), "api/command")
+	assert.Contains(t, err.Error(), "CamelCase")
 	assert.NotContains(t, err.Error(), "need restful call")
 }
 
@@ -2448,6 +2448,36 @@ func TestMain_PluginExecution_KebabCase(t *testing.T) {
 		}
 	})
 
+	t.Run("Builtin product lowercase cmd uses three-way scan", func(t *testing.T) {
+		testHome := t.TempDir()
+		cleanup := setTestHomeDir(t, testHome)
+		defer cleanup()
+
+		writeMinimalConfigJSON(t, testHome)
+		manifestPath := filepath.Join(testHome, ".aliyun", "plugins", "manifest.json")
+		os.MkdirAll(filepath.Dir(manifestPath), 0755)
+		os.WriteFile(manifestPath, []byte(`{"plugins":{}}`), 0644)
+
+		os.Args = []string{"aliyun", "sts", "getcalleridentity"}
+		args := []string{"sts", "getcalleridentity"}
+
+		oldInteractive := isInteractiveInput
+		isInteractiveInput = func() bool { return false }
+		defer func() { isInteractiveInput = oldInteractive }()
+
+		_, ok := command.library.GetProduct("sts")
+		if !ok {
+			t.Skip("sts not in builtin repository")
+		}
+
+		err := command.main(ctx, args)
+		assert.Error(t, err)
+		assert.IsType(t, &InvalidApiOrCmdNotFoundError{}, err)
+		assert.Contains(t, err.Error(), "getcalleridentity")
+		assert.Contains(t, err.Error(), "CamelCase")
+		assert.NotContains(t, err.Error(), "not a valid built-in product")
+	})
+
 	t.Run("Kebab-case with command not in os.Args", func(t *testing.T) {
 		testHome := t.TempDir()
 		cleanup := setTestHomeDir(t, testHome)
@@ -2468,7 +2498,9 @@ func TestMain_PluginExecution_KebabCase(t *testing.T) {
 
 		err := command.main(ctx, args)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "'fc' is not a valid built-in product")
+		assert.IsType(t, &InvalidApiOrCmdNotFoundError{}, err)
+		assert.Contains(t, err.Error(), "describe-regions")
+		assert.NotContains(t, err.Error(), "not a valid built-in product")
 	})
 }
 

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -94,7 +94,7 @@ type InvalidProductOrPluginError struct {
 }
 
 func (e *InvalidProductOrPluginError) Error() string {
-	msg := fmt.Sprintf("'%s' is not a valid built-in product or external product plugin. See `aliyun help`.", e.Code)
+	msg := fmt.Sprintf("'%s' is not a valid built-in product or external product plugin. See `aliyun --help`.", e.Code)
 	if e.Hint != "" {
 		msg += "\n" + e.Hint
 	}
@@ -134,6 +134,117 @@ func (e *InvalidUnifiedApiError) GetSuggestions() []string {
 	}
 	results := removeDuplicates(sr.GetResults())
 	return results
+}
+
+const apiNamingRulesHintKebabSuffix = "plugin command of external product plugins"
+
+func apiNamingRulesHint(pluginInstalled bool, pluginName string) string {
+	kebabLine := apiNamingRulesHintKebabSuffix
+	if !pluginInstalled && pluginName != "" {
+		kebabLine = fmt.Sprintf("%s (run aliyun plugin install --name %s first)", apiNamingRulesHintKebabSuffix, pluginName)
+	}
+	return fmt.Sprintf(`Naming rules in Aliyun CLI:
+  · CamelCase     → OpenAPI API name of built-in products
+  · kebab-case    → %s
+  · METHOD + path → REST shortcut for built-in restful products`, kebabLine)
+}
+
+// GetSuggestions scans built-in ApiNames and installed plugin CmdNames (three-way scan subset).
+type InvalidApiOrCmdNotFoundError struct {
+	Name         string
+	product      *meta.Product
+	pluginName   string
+	localPlugin  *plugin.LocalPlugin
+	builtinNames map[string]struct{}
+	pluginCmds   map[string]struct{}
+}
+
+func newApiOrCmdNotFoundError(
+	product *meta.Product,
+	name string,
+	localPlugin *plugin.LocalPlugin,
+	pluginName string,
+) *InvalidApiOrCmdNotFoundError {
+	e := &InvalidApiOrCmdNotFoundError{
+		Name:         name,
+		product:      product,
+		pluginName:   pluginName,
+		localPlugin:  localPlugin,
+		builtinNames: make(map[string]struct{}),
+		pluginCmds:   make(map[string]struct{}),
+	}
+	for _, apiName := range product.ApiNames {
+		e.builtinNames[apiName] = struct{}{}
+	}
+	if localPlugin != nil {
+		for _, cmd := range localPlugin.CmdNames {
+			e.pluginCmds[cmd] = struct{}{}
+		}
+	}
+	return e
+}
+
+func (e *InvalidApiOrCmdNotFoundError) Error() string {
+	msg := fmt.Sprintf("'%s' is not a valid api/command for product '%s'.",
+		e.Name, e.product.GetLowerCode())
+	pluginInstalled := e.localPlugin != nil
+	msg += "\n\n" + apiNamingRulesHint(pluginInstalled, e.pluginName)
+	if !pluginInstalled && e.pluginName != "" {
+		msg += fmt.Sprintf(
+			"\n\nExternal product plugins must be installed before kebab-case commands work:\n"+
+				"  aliyun plugin install --name %s\n",
+			e.pluginName)
+	}
+	msg += fmt.Sprintf("\nTo see parameters of a plugin command:\n  aliyun %s <kebab-cmd> --help",
+		e.product.GetLowerCode())
+	return msg
+}
+
+func (e *InvalidApiOrCmdNotFoundError) GetSuggestions() []string {
+	sr := cli.NewSuggester(e.Name, 2)
+	lowerProduct := e.product.GetLowerCode()
+
+	for apiName := range e.builtinNames {
+		sr.UnifyApply(apiName)
+	}
+	for cmd := range e.pluginCmds {
+		sr.UnifyApply(cmd)
+	}
+
+	seen := make(map[string]struct{})
+	suggestions := make([]string, 0)
+	for _, candidate := range sr.GetResults() {
+		if _, ok := e.builtinNames[candidate]; ok {
+			line := fmt.Sprintf("aliyun %s %s  [built-in OpenAPI]", lowerProduct, candidate)
+			if _, dup := seen[line]; dup {
+				continue
+			}
+			seen[line] = struct{}{}
+			suggestions = append(suggestions, line)
+			continue
+		}
+		if _, ok := e.pluginCmds[candidate]; ok {
+			line := fmt.Sprintf("aliyun %s %s  [plugin]", lowerProduct, candidate)
+			if _, dup := seen[line]; dup {
+				continue
+			}
+			seen[line] = struct{}{}
+			suggestions = append(suggestions, line)
+		}
+	}
+	return suggestions
+}
+
+func pluginCmdMatches(apiName string, lp *plugin.LocalPlugin) bool {
+	if lp == nil {
+		return false
+	}
+	for _, cmd := range lp.CmdNames {
+		if cmd == apiName {
+			return true
+		}
+	}
+	return false
 }
 
 // InvalidRestfulPathError is returned when aliyun <product> <METHOD> <path> cannot be resolved.

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -247,38 +247,96 @@ func pluginCmdMatches(apiName string, lp *plugin.LocalPlugin) bool {
 	return false
 }
 
+func pluginCmdsMatchingApiName(apiName string, lp *plugin.LocalPlugin) []string {
+	if lp == nil {
+		return nil
+	}
+	sr := cli.NewSuggester(apiName, 2)
+	for _, cmd := range lp.CmdNames {
+		sr.UnifyApply(cmd)
+	}
+	return sr.GetResults()
+}
+
 // InvalidRestfulPathError is returned when aliyun <product> <METHOD> <path> cannot be resolved.
 // If the path exists for other HTTP methods, GetSuggestions lists them.
 type InvalidRestfulPathError struct {
-	Method  string
-	Path    string
-	Product *meta.Product
-	matches []meta.Api
+	Method      string
+	Path        string
+	Product     *meta.Product
+	matches     []meta.Api
+	pathMissing bool
+	pluginName  string
+	localPlugin *plugin.LocalPlugin
 }
 
-func newInvalidRestfulPathError(library *Library, product *meta.Product, method, path string) error {
-	matches := library.FindApisByPath(product.Code, product.Version, path)
-	if len(matches) == 0 {
-		return cli.NewErrorWithTip(fmt.Errorf("can not find api by path %s", path),
-			"Please confirm if the API path exists")
-	}
+func newInvalidRestfulPathError(
+	product *meta.Product,
+	method, path string,
+	matches []meta.Api,
+	pluginName string,
+	localPlugin *plugin.LocalPlugin,
+) *InvalidRestfulPathError {
 	return &InvalidRestfulPathError{
-		Method:  method,
-		Path:    path,
-		Product: product,
-		matches: matches,
+		Method:      method,
+		Path:        path,
+		Product:     product,
+		matches:     matches,
+		pathMissing: len(matches) == 0,
+		pluginName:  pluginName,
+		localPlugin: localPlugin,
 	}
+}
+
+func restfulInvokeHint(productCode string, pluginInstalled bool, pluginName string) string {
+	lowerProduct := strings.ToLower(productCode)
+	msg := fmt.Sprintf(`
+
+Invocation options for restful product '%s':
+  · ApiName form  : aliyun %s <ApiName> --parameter1 value1 ...
+  · METHOD + path : aliyun %s [GET|PUT|POST|DELETE] <path> ...
+  · kebab-case    : aliyun %s <kebab-cmd> --parameter1 value1 ... from external product plugins`, lowerProduct, lowerProduct, lowerProduct, lowerProduct)
+	if !pluginInstalled && pluginName != "" {
+		msg += fmt.Sprintf(" (run aliyun plugin install --name %s first)", pluginName)
+	}
+	return msg
 }
 
 func (e *InvalidRestfulPathError) Error() string {
-	return fmt.Sprintf("can not find api by path %s with method %s", e.Path, strings.ToUpper(e.Method))
+	lowerProduct := e.Product.GetLowerCode()
+	var msg string
+	if e.pathMissing {
+		msg = fmt.Sprintf("can not find api by path %s", e.Path)
+		msg += fmt.Sprintf("\nUse `aliyun %s --help` to confirm the correct ApiName and METHOD+path for this product.", lowerProduct)
+	} else {
+		msg = fmt.Sprintf("can not find api by path %s with method %s",
+			e.Path, strings.ToUpper(e.Method))
+	}
+	pluginInstalled := e.localPlugin != nil
+	msg += restfulInvokeHint(lowerProduct, pluginInstalled, e.pluginName)
+	return msg
 }
 
 func (e *InvalidRestfulPathError) GetSuggestions() []string {
-	suggestions := make([]string, 0, len(e.matches))
+	lowerProduct := e.Product.GetLowerCode()
+	seen := make(map[string]struct{})
+	suggestions := make([]string, 0)
+
+	add := func(line string) {
+		if _, dup := seen[line]; dup {
+			return
+		}
+		seen[line] = struct{}{}
+		suggestions = append(suggestions, line)
+	}
+
 	for _, api := range e.matches {
-		suggestions = append(suggestions, fmt.Sprintf("%s %s (%s)",
-			strings.ToUpper(api.Method), api.PathPattern, api.Name))
+		add(fmt.Sprintf("aliyun %s %s  [built-in OpenAPI ApiName]", lowerProduct, api.Name))
+		add(fmt.Sprintf("aliyun %s %s %s [built-in RESTful Style for %s]",
+			lowerProduct, strings.ToUpper(api.Method), api.PathPattern, api.Name))
+		for _, cmd := range pluginCmdsMatchingApiName(api.Name, e.localPlugin) {
+			add(fmt.Sprintf("aliyun %s %s  [product plugin command]", lowerProduct, cmd))
+		}
 	}
 	return suggestions
 }

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -288,14 +288,23 @@ func newInvalidRestfulPathError(
 	}
 }
 
-func restfulInvokeHint(productCode string, pluginInstalled bool, pluginName string) string {
+func restfulInvokeHint(productCode string, pluginInstalled bool, pluginName string, includeMethodPath bool) string {
 	lowerProduct := strings.ToLower(productCode)
-	msg := fmt.Sprintf(`
+	var msg string
+	if includeMethodPath {
+		msg = fmt.Sprintf(`
 
 Invocation options for restful product '%s':
   · ApiName form  : aliyun %s <ApiName> --parameter1 value1 ...
   · METHOD + path : aliyun %s [GET|PUT|POST|DELETE] <path> ...
   · kebab-case    : aliyun %s <kebab-cmd> --parameter1 value1 ... from external product plugins`, lowerProduct, lowerProduct, lowerProduct, lowerProduct)
+	} else {
+		msg = fmt.Sprintf(`
+
+Invocation options for restful product '%s':
+  · ApiName form  : aliyun %s <ApiName> --parameter1 value1 ...
+  · kebab-case    : aliyun %s <kebab-cmd> --parameter1 value1 ... from external product plugins`, lowerProduct, lowerProduct, lowerProduct)
+	}
 	if !pluginInstalled && pluginName != "" {
 		msg += fmt.Sprintf(" (run aliyun plugin install --name %s first)", pluginName)
 	}
@@ -313,7 +322,7 @@ func (e *InvalidRestfulPathError) Error() string {
 			e.Path, strings.ToUpper(e.Method))
 	}
 	pluginInstalled := e.localPlugin != nil
-	msg += restfulInvokeHint(lowerProduct, pluginInstalled, e.pluginName)
+	msg += restfulInvokeHint(lowerProduct, pluginInstalled, e.pluginName, true)
 	return msg
 }
 
@@ -337,6 +346,69 @@ func (e *InvalidRestfulPathError) GetSuggestions() []string {
 		for _, cmd := range pluginCmdsMatchingApiName(api.Name, e.localPlugin) {
 			add(fmt.Sprintf("aliyun %s %s  [product plugin command]", lowerProduct, cmd))
 		}
+	}
+	return suggestions
+}
+
+// RestfulBroadPathError is returned when aliyun <product> <METHOD> / matches an API
+// but root path "/" is too broad for OpenAPI invocation.
+type RestfulBroadPathError struct {
+	Method      string
+	Path        string
+	Product     *meta.Product
+	api         meta.Api
+	pluginName  string
+	localPlugin *plugin.LocalPlugin
+}
+
+func newRestfulBroadPathError(
+	product *meta.Product,
+	method, path string,
+	api meta.Api,
+	pluginName string,
+	localPlugin *plugin.LocalPlugin,
+) *RestfulBroadPathError {
+	return &RestfulBroadPathError{
+		Method:      method,
+		Path:        path,
+		Product:     product,
+		api:         api,
+		pluginName:  pluginName,
+		localPlugin: localPlugin,
+	}
+}
+
+func (e *RestfulBroadPathError) Error() string {
+	lowerProduct := e.Product.GetLowerCode()
+	msg := fmt.Sprintf("path %q is too broad for METHOD+path invocation with %s.",
+		e.Path, strings.ToUpper(e.Method))
+	msg += fmt.Sprintf("\nUse a specific ApiName instead of the root path %q.", e.Path)
+	msg += fmt.Sprintf("\nUse `aliyun %s --help` to confirm the correct ApiName for this product.", lowerProduct)
+	pluginInstalled := e.localPlugin != nil
+	msg += restfulInvokeHint(lowerProduct, pluginInstalled, e.pluginName, false)
+	return msg
+}
+
+func (e *RestfulBroadPathError) GetSuggestions() []string {
+	lowerProduct := e.Product.GetLowerCode()
+	suggestions := make([]string, 0, 3)
+
+	add := func(line string) {
+		for _, existing := range suggestions {
+			if existing == line {
+				return
+			}
+		}
+		suggestions = append(suggestions, line)
+	}
+
+	add(fmt.Sprintf("aliyun %s %s  [built-in OpenAPI ApiName]", lowerProduct, e.api.Name))
+	if e.api.PathPattern != "" && e.api.PathPattern != "/" {
+		add(fmt.Sprintf("aliyun %s %s %s [built-in RESTful Style for %s]",
+			lowerProduct, strings.ToUpper(e.api.Method), e.api.PathPattern, e.api.Name))
+	}
+	for _, cmd := range pluginCmdsMatchingApiName(e.api.Name, e.localPlugin) {
+		add(fmt.Sprintf("aliyun %s %s  [product plugin command]", lowerProduct, cmd))
 	}
 	return suggestions
 }

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -138,15 +138,18 @@ func (e *InvalidUnifiedApiError) GetSuggestions() []string {
 
 const apiNamingRulesHintKebabSuffix = "plugin command of external product plugins"
 
-func apiNamingRulesHint(pluginInstalled bool, pluginName string) string {
+func apiNamingRulesHint(pluginInstalled bool, pluginName string, includeMethodPath bool) string {
 	kebabLine := apiNamingRulesHintKebabSuffix
 	if !pluginInstalled && pluginName != "" {
 		kebabLine = fmt.Sprintf("%s (run aliyun plugin install --name %s first)", apiNamingRulesHintKebabSuffix, pluginName)
 	}
-	return fmt.Sprintf(`Naming rules in Aliyun CLI:
+	msg := fmt.Sprintf(`Naming rules in Aliyun CLI:
   · CamelCase     → OpenAPI API name of built-in products
-  · kebab-case    → %s
-  · METHOD + path → REST shortcut for built-in restful products`, kebabLine)
+  · kebab-case    → %s`, kebabLine)
+	if includeMethodPath {
+		msg += "\n  · METHOD + path → REST shortcut for built-in restful products"
+	}
+	return msg
 }
 
 // GetSuggestions scans built-in ApiNames and installed plugin CmdNames (three-way scan subset).
@@ -188,7 +191,7 @@ func (e *InvalidApiOrCmdNotFoundError) Error() string {
 	msg := fmt.Sprintf("'%s' is not a valid api/command for product '%s'.",
 		e.Name, e.product.GetLowerCode())
 	pluginInstalled := e.localPlugin != nil
-	msg += "\n\n" + apiNamingRulesHint(pluginInstalled, e.pluginName)
+	msg += "\n\n" + apiNamingRulesHint(pluginInstalled, e.pluginName, true)
 	if !pluginInstalled && e.pluginName != "" {
 		msg += fmt.Sprintf(
 			"\n\nExternal product plugins must be installed before kebab-case commands work:\n"+
@@ -411,6 +414,45 @@ func (e *RestfulBroadPathError) GetSuggestions() []string {
 		add(fmt.Sprintf("aliyun %s %s  [product plugin command]", lowerProduct, cmd))
 	}
 	return suggestions
+}
+
+// RpcMethodPathError is returned when aliyun <rpc-product> <METHOD> <path> is used.
+type RpcMethodPathError struct {
+	Method      string
+	Path        string
+	Product     *meta.Product
+	pluginName  string
+	localPlugin *plugin.LocalPlugin
+}
+
+func newRpcMethodPathError(
+	product *meta.Product,
+	method, path string,
+	pluginName string,
+	localPlugin *plugin.LocalPlugin,
+) *RpcMethodPathError {
+	return &RpcMethodPathError{
+		Method:      method,
+		Path:        path,
+		Product:     product,
+		pluginName:  pluginName,
+		localPlugin: localPlugin,
+	}
+}
+
+func (e *RpcMethodPathError) Error() string {
+	lowerProduct := e.Product.GetLowerCode()
+	msg := fmt.Sprintf("'%s' is an RPC product and does not accept METHOD + path form (got %s %s).",
+		lowerProduct, strings.ToUpper(e.Method), e.Path)
+	msg += fmt.Sprintf("\nUse `aliyun %s <ApiName>` instead. See `aliyun %s --help` for available ApiNames.",
+		lowerProduct, lowerProduct)
+	pluginInstalled := e.localPlugin != nil
+	msg += "\n\n" + apiNamingRulesHint(pluginInstalled, e.pluginName, false)
+	return msg
+}
+
+func (e *RpcMethodPathError) GetSuggestions() []string {
+	return []string{fmt.Sprintf("aliyun %s --help", e.Product.GetLowerCode())}
 }
 
 func removeDuplicates(slice []string) []string {

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -94,7 +94,7 @@ type InvalidProductOrPluginError struct {
 }
 
 func (e *InvalidProductOrPluginError) Error() string {
-	msg := fmt.Sprintf("'%s' is not a valid product. See `aliyun help`.", e.Code)
+	msg := fmt.Sprintf("'%s' is not a valid built-in product or external product plugin. See `aliyun help`.", e.Code)
 	if e.Hint != "" {
 		msg += "\n" + e.Hint
 	}
@@ -106,10 +106,12 @@ func (e *InvalidProductOrPluginError) GetSuggestions() []string {
 	for _, p := range e.plugins {
 		sr.Apply(strings.ToLower(p.ProductCode))
 	}
-	// for _, p := range e.library.GetProducts() {
-	// 	sr.Apply(strings.ToLower(p.Code))
-	// }
-	return sr.GetResults()
+	if e.library != nil {
+		for _, p := range e.library.GetProducts() {
+			sr.Apply(strings.ToLower(p.Code))
+		}
+	}
+	return removeDuplicates(sr.GetResults())
 }
 
 type InvalidUnifiedApiError struct {
@@ -132,6 +134,42 @@ func (e *InvalidUnifiedApiError) GetSuggestions() []string {
 	}
 	results := removeDuplicates(sr.GetResults())
 	return results
+}
+
+// InvalidRestfulPathError is returned when aliyun <product> <METHOD> <path> cannot be resolved.
+// If the path exists for other HTTP methods, GetSuggestions lists them.
+type InvalidRestfulPathError struct {
+	Method  string
+	Path    string
+	Product *meta.Product
+	matches []meta.Api
+}
+
+func newInvalidRestfulPathError(library *Library, product *meta.Product, method, path string) error {
+	matches := library.FindApisByPath(product.Code, product.Version, path)
+	if len(matches) == 0 {
+		return cli.NewErrorWithTip(fmt.Errorf("can not find api by path %s", path),
+			"Please confirm if the API path exists")
+	}
+	return &InvalidRestfulPathError{
+		Method:  method,
+		Path:    path,
+		Product: product,
+		matches: matches,
+	}
+}
+
+func (e *InvalidRestfulPathError) Error() string {
+	return fmt.Sprintf("can not find api by path %s with method %s", e.Path, strings.ToUpper(e.Method))
+}
+
+func (e *InvalidRestfulPathError) GetSuggestions() []string {
+	suggestions := make([]string, 0, len(e.matches))
+	for _, api := range e.matches {
+		suggestions = append(suggestions, fmt.Sprintf("%s %s (%s)",
+			strings.ToUpper(api.Method), api.PathPattern, api.Name))
+	}
+	return suggestions
 }
 
 func removeDuplicates(slice []string) []string {

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -112,7 +112,7 @@ func TestInvalidProductOrPluginError_Error(t *testing.T) {
 		err := &InvalidProductOrPluginError{
 			Code: "fcc",
 		}
-		assert.Equal(t, "'fcc' is not a valid product. See `aliyun help`.", err.Error())
+		assert.Equal(t, "'fcc' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
 	})
 
 	t.Run("hint is appended on its own line", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestInvalidProductOrPluginError_Error(t *testing.T) {
 			Hint: "If you meant an OpenAPI built-in call, the form is 'aliyun <product> <APIName>'.",
 		}
 		assert.Equal(t,
-			"'ecs' is not a valid product. See `aliyun help`.\n"+
+			"'ecs' is not a valid built-in product or external product plugin. See `aliyun help`.\n"+
 				"If you meant an OpenAPI built-in call, the form is 'aliyun <product> <APIName>'.",
 			err.Error(),
 			"hint must follow the legacy line on its own line — single-line legacy users keep their format")
@@ -138,10 +138,32 @@ func TestInvalidProductOrPluginError_GetSuggestions(t *testing.T) {
 				{Name: "aliyun-cli-ecs", ProductCode: "ecs"},
 				{Name: "aliyun-cli-fc", ProductCode: "fc"},
 			},
+			library: &Library{
+				builtinRepo: &meta.Repository{
+					Products: []meta.Product{{Code: "ecs"}},
+				},
+			},
 		}
 		suggestions := err.GetSuggestions()
 		str := strings.Join(suggestions, ",")
 		assert.Contains(t, str, "ecs")
+	})
+
+	t.Run("Dedupes plugin and built-in product codes", func(t *testing.T) {
+		err := &InvalidProductOrPluginError{
+			Code: "ec",
+			plugins: []plugin.PluginInfo{
+				{Name: "aliyun-cli-ecs", ProductCode: "ecs"},
+			},
+			library: &Library{
+				builtinRepo: &meta.Repository{
+					Products: []meta.Product{{Code: "ecs"}},
+				},
+			},
+		}
+		suggestions := err.GetSuggestions()
+		assert.Equal(t, 1, len(suggestions))
+		assert.Equal(t, "ecs", suggestions[0])
 	})
 
 	t.Run("No match", func(t *testing.T) {
@@ -225,6 +247,46 @@ func TestInvalidUnifiedApiError_GetSuggestions(t *testing.T) {
 		}
 		suggestions := err.GetSuggestions()
 		assert.Empty(t, suggestions)
+	})
+}
+
+func TestInvalidRestfulPathError(t *testing.T) {
+	t.Run("path exists wrong method", func(t *testing.T) {
+		repo, err := meta.MockLoadRepository([]meta.Product{{
+			Code:     "cs",
+			Version:  "2015-12-15",
+			ApiNames: []string{"DescribeClusters", "CreateCluster"},
+		}})
+		assert.NoError(t, err)
+		lib := &Library{builtinRepo: repo}
+		product, ok := lib.GetProduct("cs")
+		assert.True(t, ok)
+
+		errObj := newInvalidRestfulPathError(lib, &product, "PUT", "/clusters")
+		rpe, ok := errObj.(*InvalidRestfulPathError)
+		assert.True(t, ok)
+		assert.Contains(t, rpe.Error(), "with method PUT")
+		suggestions := rpe.GetSuggestions()
+		assert.Contains(t, strings.Join(suggestions, "\n"), "GET /clusters (DescribeClusters)")
+		assert.Contains(t, strings.Join(suggestions, "\n"), "POST /clusters (CreateCluster)")
+	})
+
+	t.Run("path not found", func(t *testing.T) {
+		repo, err := meta.MockLoadRepository([]meta.Product{{
+			Code:     "cs",
+			Version:  "2015-12-15",
+			ApiNames: []string{"DescribeClusters"},
+		}})
+		assert.NoError(t, err)
+		lib := &Library{builtinRepo: repo}
+		product, ok := lib.GetProduct("cs")
+		assert.True(t, ok)
+
+		errObj := newInvalidRestfulPathError(lib, &product, "PUT", "/no-such-path")
+		assert.NotNil(t, errObj)
+		_, ok = errObj.(*InvalidRestfulPathError)
+		assert.False(t, ok)
+		assert.Contains(t, errObj.Error(), "can not find api by path /no-such-path")
 	})
 }
 

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -349,6 +349,25 @@ func TestInvalidRestfulPathError(t *testing.T) {
 	})
 }
 
+func TestRestfulBroadPathError(t *testing.T) {
+	product := meta.Product{Code: "sls", Version: "2020-03-20"}
+	api := meta.Api{Name: "ListProjects", Method: "GET", PathPattern: "/"}
+	lp := &plugin.LocalPlugin{CmdNames: []string{"list-projects"}}
+
+	errObj := newRestfulBroadPathError(&product, "GET", "/", api, "aliyun-cli-sls", lp)
+	assert.Contains(t, errObj.Error(), `path "/" is too broad for METHOD+path invocation with GET`)
+	assert.Contains(t, errObj.Error(), "Use a specific ApiName or path instead of the root path")
+	assert.Contains(t, errObj.Error(), "Use `aliyun sls --help` to confirm the correct ApiName and METHOD+path for this product.")
+	assert.Contains(t, errObj.Error(), "ApiName form")
+	assert.NotContains(t, errObj.Error(), "METHOD + path")
+
+	suggestions := errObj.GetSuggestions()
+	joined := strings.Join(suggestions, "\n")
+	assert.Contains(t, joined, "aliyun sls ListProjects  [built-in OpenAPI ApiName]")
+	assert.Contains(t, joined, "aliyun sls list-projects  [product plugin command]")
+	assert.NotContains(t, joined, "[built-in RESTful Style")
+}
+
 func TestRemoveDuplicates(t *testing.T) {
 	t.Run("No duplicates", func(t *testing.T) {
 		result := removeDuplicates([]string{"a", "b", "c"})

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -356,8 +356,8 @@ func TestRestfulBroadPathError(t *testing.T) {
 
 	errObj := newRestfulBroadPathError(&product, "GET", "/", api, "aliyun-cli-sls", lp)
 	assert.Contains(t, errObj.Error(), `path "/" is too broad for METHOD+path invocation with GET`)
-	assert.Contains(t, errObj.Error(), "Use a specific ApiName or path instead of the root path")
-	assert.Contains(t, errObj.Error(), "Use `aliyun sls --help` to confirm the correct ApiName and METHOD+path for this product.")
+	assert.Contains(t, errObj.Error(), `Use a specific ApiName instead of the root path "/"`)
+	assert.Contains(t, errObj.Error(), "Use `aliyun sls --help` to confirm the correct ApiName for this product.")
 	assert.Contains(t, errObj.Error(), "ApiName form")
 	assert.NotContains(t, errObj.Error(), "METHOD + path")
 

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -297,14 +297,37 @@ func TestInvalidRestfulPathError(t *testing.T) {
 		lib := &Library{builtinRepo: repo}
 		product, ok := lib.GetProduct("cs")
 		assert.True(t, ok)
+		matches := lib.FindApisByPath(product.Code, product.Version, "/clusters")
 
-		errObj := newInvalidRestfulPathError(lib, &product, "PUT", "/clusters")
-		rpe, ok := errObj.(*InvalidRestfulPathError)
-		assert.True(t, ok)
-		assert.Contains(t, rpe.Error(), "with method PUT")
-		suggestions := rpe.GetSuggestions()
-		assert.Contains(t, strings.Join(suggestions, "\n"), "GET /clusters (DescribeClusters)")
-		assert.Contains(t, strings.Join(suggestions, "\n"), "POST /clusters (CreateCluster)")
+		errObj := newInvalidRestfulPathError(&product, "PUT", "/clusters", matches, "aliyun-cli-cs", nil)
+		assert.Contains(t, errObj.Error(), "with method PUT")
+		assert.Contains(t, errObj.Error(), "ApiName form")
+		assert.Contains(t, errObj.Error(), "METHOD + path")
+		assert.Contains(t, errObj.Error(), "aliyun plugin install --name aliyun-cli-cs")
+
+		suggestions := errObj.GetSuggestions()
+		joined := strings.Join(suggestions, "\n")
+		assert.Contains(t, joined, "aliyun cs GET /clusters [built-in RESTful Style for DescribeClusters]")
+		assert.Contains(t, joined, "aliyun cs POST /clusters [built-in RESTful Style for CreateCluster]")
+		assert.Contains(t, joined, "[built-in OpenAPI ApiName]")
+	})
+
+	t.Run("path exists wrong method with plugin", func(t *testing.T) {
+		product := meta.Product{Code: "cs", Version: "2015-12-15"}
+		matches := []meta.Api{
+			{Name: "DescribeClusters", Method: "GET", PathPattern: "/clusters"},
+			{Name: "CreateCluster", Method: "POST", PathPattern: "/clusters"},
+		}
+		lp := &plugin.LocalPlugin{
+			CmdNames: []string{"describe-clusters", "create-cluster", "delete-cluster"},
+		}
+
+		errObj := newInvalidRestfulPathError(&product, "PUT", "/clusters", matches, "aliyun-cli-cs", lp)
+		suggestions := errObj.GetSuggestions()
+		joined := strings.Join(suggestions, "\n")
+		assert.Contains(t, joined, "aliyun cs describe-clusters  [product plugin command]")
+		assert.Contains(t, joined, "aliyun cs create-cluster  [product plugin command]")
+		assert.NotContains(t, joined, "delete-cluster")
 	})
 
 	t.Run("path not found", func(t *testing.T) {
@@ -318,11 +341,11 @@ func TestInvalidRestfulPathError(t *testing.T) {
 		product, ok := lib.GetProduct("cs")
 		assert.True(t, ok)
 
-		errObj := newInvalidRestfulPathError(lib, &product, "PUT", "/no-such-path")
-		assert.NotNil(t, errObj)
-		_, ok = errObj.(*InvalidRestfulPathError)
-		assert.False(t, ok)
+		errObj := newInvalidRestfulPathError(&product, "PUT", "/no-such-path", nil, "", nil)
 		assert.Contains(t, errObj.Error(), "can not find api by path /no-such-path")
+		assert.Contains(t, errObj.Error(), "Use `aliyun cs --help` to confirm the correct ApiName and METHOD+path for this product.")
+		assert.Contains(t, errObj.Error(), "ApiName form")
+		assert.Empty(t, errObj.GetSuggestions())
 	})
 }
 

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -112,7 +112,7 @@ func TestInvalidProductOrPluginError_Error(t *testing.T) {
 		err := &InvalidProductOrPluginError{
 			Code: "fcc",
 		}
-		assert.Equal(t, "'fcc' is not a valid built-in product or external product plugin. See `aliyun help`.", err.Error())
+		assert.Equal(t, "'fcc' is not a valid built-in product or external product plugin. See `aliyun --help`.", err.Error())
 	})
 
 	t.Run("hint is appended on its own line", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestInvalidProductOrPluginError_Error(t *testing.T) {
 			Hint: "If you meant an OpenAPI built-in call, the form is 'aliyun <product> <APIName>'.",
 		}
 		assert.Equal(t,
-			"'ecs' is not a valid built-in product or external product plugin. See `aliyun help`.\n"+
+			"'ecs' is not a valid built-in product or external product plugin. See `aliyun --help`.\n"+
 				"If you meant an OpenAPI built-in call, the form is 'aliyun <product> <APIName>'.",
 			err.Error(),
 			"hint must follow the legacy line on its own line — single-line legacy users keep their format")
@@ -248,6 +248,42 @@ func TestInvalidUnifiedApiError_GetSuggestions(t *testing.T) {
 		suggestions := err.GetSuggestions()
 		assert.Empty(t, suggestions)
 	})
+}
+
+func TestInvalidApiOrCmdNotFoundError_GetSuggestions(t *testing.T) {
+	product := &meta.Product{
+		Code:     "ecs",
+		ApiNames: []string{"DescribeInstances", "DescribeRegions"},
+	}
+	lp := &plugin.LocalPlugin{
+		CmdNames: []string{"describe-instances", "list-images"},
+	}
+
+	t.Run("plugin installed", func(t *testing.T) {
+		err := newApiOrCmdNotFoundError(product, "describeinstances", lp, "aliyun-cli-ecs")
+		assert.Contains(t, err.Error(), "CamelCase")
+		assert.Contains(t, err.Error(), "kebab-case")
+		assert.NotContains(t, err.Error(), "aliyun plugin install --name")
+		assert.NotContains(t, err.Error(), "must be installed")
+
+		suggestions := err.GetSuggestions()
+		joined := strings.Join(suggestions, "\n")
+		assert.Contains(t, joined, "DescribeInstances")
+		assert.Contains(t, joined, "[built-in OpenAPI]")
+	})
+
+	t.Run("plugin not installed", func(t *testing.T) {
+		err := newApiOrCmdNotFoundError(product, "describeinstances", nil, "aliyun-cli-ecs")
+		assert.Contains(t, err.Error(), "aliyun plugin install --name aliyun-cli-ecs")
+		assert.Contains(t, err.Error(), "must be installed")
+	})
+}
+
+func TestPluginCmdMatches(t *testing.T) {
+	lp := &plugin.LocalPlugin{CmdNames: []string{"list-functions"}}
+	assert.True(t, pluginCmdMatches("list-functions", lp))
+	assert.False(t, pluginCmdMatches("List-Functions", lp))
+	assert.False(t, pluginCmdMatches("DescribeRegions", lp))
 }
 
 func TestInvalidRestfulPathError(t *testing.T) {

--- a/openapi/errors_test.go
+++ b/openapi/errors_test.go
@@ -368,6 +368,19 @@ func TestRestfulBroadPathError(t *testing.T) {
 	assert.NotContains(t, joined, "[built-in RESTful Style")
 }
 
+func TestRpcMethodPathError(t *testing.T) {
+	product := meta.Product{Code: "ecs", Version: "2014-05-26", ApiStyle: "rpc"}
+	errObj := newRpcMethodPathError(&product, "GET", "/instances", "aliyun-cli-ecs", nil)
+
+	assert.Contains(t, errObj.Error(), "'ecs' is an RPC product and does not accept METHOD + path form")
+	assert.Contains(t, errObj.Error(), "got GET /instances")
+	assert.Contains(t, errObj.Error(), "Use `aliyun ecs <ApiName>` instead")
+	assert.Contains(t, errObj.Error(), "aliyun ecs --help")
+	assert.Contains(t, errObj.Error(), "CamelCase")
+	assert.NotContains(t, errObj.Error(), "REST shortcut")
+	assert.Equal(t, []string{"aliyun ecs --help"}, errObj.GetSuggestions())
+}
+
 func TestRemoveDuplicates(t *testing.T) {
 	t.Run("No duplicates", func(t *testing.T) {
 		result := removeDuplicates([]string{"a", "b", "c"})

--- a/openapi/library.go
+++ b/openapi/library.go
@@ -51,6 +51,10 @@ func (a *Library) GetApiByPath(productCode string, version string, method string
 
 }
 
+func (a *Library) FindApisByPath(productCode string, version string, path string) []meta.Api {
+	return a.builtinRepo.FindApisByPath(productCode, version, path)
+}
+
 func (a *Library) GetStyle(productCode string, version string) (string, bool) {
 	return a.builtinRepo.GetStyle(productCode, version)
 }

--- a/openapi/product_help.go
+++ b/openapi/product_help.go
@@ -63,9 +63,20 @@ func (c *Commando) lookupPluginForProduct(productCode string) (pluginName string
 	return "", false
 }
 
+func (c *Commando) getInstalledLocalPlugin(productCode string) *plugin.LocalPlugin {
+	_, lp, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode)
+	if !ok {
+		return nil
+	}
+	return lp
+}
+
 func (c *Commando) isPluginInstalledForProduct(productCode string) bool {
-	_, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode)
-	return ok
+	return c.getInstalledLocalPlugin(productCode) != nil
+}
+
+func productHasBuiltinApis(product meta.Product) bool {
+	return len(product.ApiNames) > 0
 }
 
 func (c *Commando) planProductLevelHelp(productCode string) (productHelpPlan, meta.Product, string, bool) {
@@ -90,8 +101,8 @@ func (c *Commando) planProductLevelHelp(productCode string) (productHelpPlan, me
 			return plan, product, pluginName, false
 		}
 		plan.abortErr = fmt.Errorf(
-			"'%s' is not a built-in product and requires an external product plugin.\n  aliyun plugin install --name %s",
-			productCode, pluginName)
+			"'%s' is not a built-in product and requires an external product plugin.\n  aliyun plugin install --name %s\n  After installation, run `aliyun %s --help` to view product help.",
+			productCode, pluginName, strings.ToLower(productCode))
 		return plan, product, pluginName, false
 	}
 
@@ -139,14 +150,15 @@ func (c *Commando) printBuiltInProductUsage(ctx *cli.Context, product meta.Produ
 	cli.Printf(ctx.Stdout(), "Version: %s \n", product.Version)
 	cli.Printf(ctx.Stdout(), "\n")
 
-	if len(product.ApiNames) == 0 {
-		return nil
-	}
 	if product.ApiStyle == "rpc" {
 		cli.Printf(ctx.Stdout(), "\nUsage:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ...\n", strings.ToLower(product.Code))
 	} else {
 		cli.Printf(ctx.Stdout(), "\nUsage 1:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ... --body \"...\"\n", strings.ToLower(product.Code))
 		cli.Printf(ctx.Stdout(), "\nUsage 2:\n  aliyun %s [GET|PUT|POST|DELETE] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
+	}
+
+	if len(product.ApiNames) == 0 {
+		return nil
 	}
 
 	cli.PrintfWithColor(ctx.Stdout(), cli.ColorOff, "\nAvailable Api List: \n")

--- a/openapi/product_help.go
+++ b/openapi/product_help.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-cli/v3/newmeta"
+)
+
+type productHelpPlan struct {
+	deliverPluginHelp  bool
+	deliverBuiltInHelp bool
+	showInstallHint    bool
+	abortErr           error
+}
+
+func showOriginalProductHelp() bool {
+	v := os.Getenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP")
+	return v == "true" || v == "1"
+}
+
+func pluginArgsFromOS(productCode string, fallback []string) []string {
+	cmdIndex := -1
+	for i, arg := range os.Args {
+		if strings.EqualFold(arg, productCode) {
+			cmdIndex = i
+			break
+		}
+	}
+	if cmdIndex != -1 && cmdIndex < len(os.Args) {
+		return os.Args[cmdIndex:]
+	}
+	return fallback
+}
+
+func (c *Commando) lookupPluginForProduct(productCode string) (pluginName string, found bool) {
+	for _, pInfo := range c.pluginIndex.Plugins {
+		if strings.EqualFold(pInfo.ProductCode, productCode) {
+			return pInfo.Name, true
+		}
+	}
+	if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
+		return n, true
+	}
+	return "", false
+}
+
+func (c *Commando) isPluginInstalledForProduct(productCode string) bool {
+	_, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode)
+	return ok
+}
+
+func (c *Commando) planProductLevelHelp(productCode string) (productHelpPlan, meta.Product, string, bool) {
+	pluginName, hasPlugin := c.lookupPluginForProduct(productCode)
+	isInstalled := hasPlugin && c.isPluginInstalledForProduct(productCode)
+
+	product, hasBuiltIn := c.library.GetProduct(productCode)
+	showOriginal := showOriginalProductHelp()
+
+	plan := productHelpPlan{}
+
+	if !hasBuiltIn && !hasPlugin {
+		plan.abortErr = &InvalidProductOrPluginError{
+			Code: productCode, library: c.library, plugins: c.pluginIndex.Plugins,
+		}
+		return plan, product, pluginName, false
+	}
+
+	if !hasBuiltIn && hasPlugin {
+		if isInstalled {
+			plan.deliverPluginHelp = true
+			return plan, product, pluginName, false
+		}
+		plan.abortErr = fmt.Errorf(
+			"'%s' is not a built-in product and requires an external product plugin.\n  aliyun plugin install --name %s",
+			productCode, pluginName)
+		return plan, product, pluginName, false
+	}
+
+	// Built-in product exists.
+	if hasPlugin && isInstalled && !showOriginal {
+		plan.deliverPluginHelp = true
+		return plan, product, pluginName, true
+	}
+
+	if hasPlugin && !isInstalled {
+		plan.showInstallHint = true
+	}
+	plan.deliverBuiltInHelp = true
+	return plan, product, pluginName, true
+}
+
+func (c *Commando) printPluginInstallSuggestion(ctx *cli.Context, productCode, pluginName string) {
+	cli.PrintfWithColor(ctx.Stdout(), cli.Green,
+		"\n[Suggestion] A dedicated product plugin '%s' is available for '%s'.\n", pluginName, productCode)
+	cli.PrintfWithColor(ctx.Stdout(), cli.Green,
+		"Run 'aliyun plugin install --name %s' to install it for enhanced features.\n\n", pluginName)
+}
+
+func (c *Commando) executePluginProductHelp(ctx *cli.Context, productCode, pluginName string, pluginArgs []string, hasBuiltIn bool) (bool, error) {
+	if !hasBuiltIn {
+		cli.Printf(ctx.Stdout(), "Product '%s' is provided by plugin '%s'\n", productCode, pluginName)
+	} else {
+		cli.Printf(ctx.Stdout(),
+			"Note: The help information for product '%s' is provided by the installed plugin '%s'.\n",
+			productCode, pluginName)
+		cli.Printf(ctx.Stdout(),
+			"To view legacy built-in help, set ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP=true\n")
+	}
+	c.setLangEnv(ctx)
+	ok, err := plugin.ExecutePlugin(productCode, pluginArgs, ctx)
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+func (c *Commando) printBuiltInProductUsage(ctx *cli.Context, product meta.Product) error {
+	productName, _ := newmeta.GetProductName(i18n.GetLanguage(), product.Code)
+	cli.Printf(ctx.Stdout(), "\nProduct: %s (%s)\n", product.Code, productName)
+	cli.Printf(ctx.Stdout(), "Version: %s \n", product.Version)
+	cli.Printf(ctx.Stdout(), "\n")
+
+	if len(product.ApiNames) == 0 {
+		return nil
+	}
+	if product.ApiStyle == "rpc" {
+		cli.Printf(ctx.Stdout(), "\nUsage:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ...\n", strings.ToLower(product.Code))
+	} else {
+		cli.Printf(ctx.Stdout(), "\nUsage 1:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ... --body \"...\"\n", strings.ToLower(product.Code))
+		cli.Printf(ctx.Stdout(), "\nUsage 2:\n  aliyun %s [GET|PUT|POST|DELETE] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
+	}
+
+	cli.PrintfWithColor(ctx.Stdout(), cli.ColorOff, "\nAvailable Api List: \n")
+
+	maxNameLen := 0
+	for _, apiName := range product.ApiNames {
+		if len(apiName) > maxNameLen {
+			maxNameLen = len(apiName)
+		}
+	}
+
+	for _, apiName := range product.ApiNames {
+		if product.ApiStyle == "restful" {
+			api, _ := c.library.GetApi(product.Code, product.Version, apiName)
+			ptn := fmt.Sprintf("  %%-%ds : %%s %%s\n", maxNameLen+1)
+			cli.PrintfWithColor(ctx.Stdout(), cli.Green, ptn, apiName, api.Method, api.PathPattern)
+		} else {
+			api, _ := newmeta.GetAPI(i18n.GetLanguage(), product.Code, apiName)
+			if api != nil {
+				apiDetail, _ := newmeta.GetAPIDetail(i18n.GetLanguage(), product.Code, apiName)
+				if api.Deprecated {
+					fmtStr := fmt.Sprintf("  %%-%ds [Deprecated]%%s\n", maxNameLen+1)
+					cli.PrintfWithColor(ctx.Stdout(), cli.Green, fmtStr, apiName, api.Summary)
+				} else if apiDetail.IsAnonymousAPI() {
+					fmtStr := fmt.Sprintf("  %%-%ds [Anonymous]%%s\n", maxNameLen+1)
+					cli.PrintfWithColor(ctx.Stdout(), cli.Green, fmtStr, apiName, api.Summary)
+				} else {
+					fmtStr := fmt.Sprintf("  %%-%ds %%s\n", maxNameLen+1)
+					cli.PrintfWithColor(ctx.Stdout(), cli.Green, fmtStr, apiName, api.Summary)
+				}
+			} else {
+				cli.PrintfWithColor(ctx.Stdout(), cli.Green, "  %s\n", apiName)
+			}
+		}
+	}
+
+	cli.Printf(ctx.Stdout(), "\nRun `aliyun %s <ApiName> --help` to get more information about this API\n", product.GetLowerCode())
+
+	return nil
+}
+
+func (c *Commando) renderProductLevelHelp(ctx *cli.Context, productCode string, pluginArgs []string) error {
+	c.loadPlugins()
+	c.printHelpContextHints(ctx)
+
+	plan, product, pluginName, hasBuiltIn := c.planProductLevelHelp(productCode)
+	if plan.abortErr != nil {
+		return plan.abortErr
+	}
+
+	pluginArgs = ensurePluginHelpArgs(productCode, pluginArgs)
+
+	if plan.deliverPluginHelp {
+		executed, err := c.executePluginProductHelp(ctx, productCode, pluginName, pluginArgs, hasBuiltIn)
+		if err != nil {
+			if !hasBuiltIn {
+				return nil
+			}
+			// Installed plugin delegate failed; fall through to legacy built-in help.
+		} else if executed {
+			return nil
+		} else if !hasBuiltIn {
+			return nil
+		}
+		// Installed plugin delegate failed; fall through to legacy built-in help.
+	} else if plan.showInstallHint {
+		c.printPluginInstallSuggestion(ctx, productCode, pluginName)
+	}
+
+	if plan.deliverBuiltInHelp {
+		return c.printBuiltInProductUsage(ctx, product)
+	}
+	return nil
+}
+
+func ensurePluginHelpArgs(productCode string, args []string) []string {
+	hasHelp := false
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			hasHelp = true
+			break
+		}
+	}
+	if !hasHelp {
+		args = append(append([]string{}, args...), "--help")
+	}
+	return args
+}

--- a/openapi/product_help_test.go
+++ b/openapi/product_help_test.go
@@ -1,0 +1,89 @@
+package openapi
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlanProductLevelHelp_BuiltinPluginNotInstalled(t *testing.T) {
+	c := NewCommando(new(bytes.Buffer), config.Profile{Language: "en"})
+	c.library.builtinRepo = getRepository()
+	c.pluginIndex = &plugin.Index{
+		Plugins: []plugin.PluginInfo{{Name: "aliyun-cli-ecs", ProductCode: "ecs"}},
+	}
+	c.localManifest = &plugin.LocalManifest{Plugins: map[string]plugin.LocalPlugin{}}
+
+	plan, _, pluginName, hasBuiltIn := c.planProductLevelHelp("ecs")
+	assert.True(t, hasBuiltIn)
+	assert.Equal(t, "aliyun-cli-ecs", pluginName)
+	assert.True(t, plan.deliverBuiltInHelp)
+	assert.True(t, plan.showInstallHint)
+	assert.False(t, plan.deliverPluginHelp)
+	assert.Nil(t, plan.abortErr)
+}
+
+func TestPlanProductLevelHelp_BuiltinPluginInstalled(t *testing.T) {
+	c := NewCommando(new(bytes.Buffer), config.Profile{Language: "en"})
+	c.library.builtinRepo = getRepository()
+	c.pluginIndex = &plugin.Index{
+		Plugins: []plugin.PluginInfo{{Name: "aliyun-cli-ecs", ProductCode: "ecs"}},
+	}
+	c.localManifest = &plugin.LocalManifest{
+		Plugins: map[string]plugin.LocalPlugin{"aliyun-cli-ecs": {Name: "aliyun-cli-ecs"}},
+	}
+
+	plan, _, _, hasBuiltIn := c.planProductLevelHelp("ecs")
+	assert.True(t, hasBuiltIn)
+	assert.True(t, plan.deliverPluginHelp)
+	assert.False(t, plan.deliverBuiltInHelp)
+}
+
+func TestPlanProductLevelHelp_ShowOriginalWithInstalledPlugin(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_ORIGINAL_PRODUCT_HELP", "1")
+	c := NewCommando(new(bytes.Buffer), config.Profile{Language: "en"})
+	c.library.builtinRepo = getRepository()
+	c.pluginIndex = &plugin.Index{
+		Plugins: []plugin.PluginInfo{{Name: "aliyun-cli-ecs", ProductCode: "ecs"}},
+	}
+	c.localManifest = &plugin.LocalManifest{
+		Plugins: map[string]plugin.LocalPlugin{"aliyun-cli-ecs": {Name: "aliyun-cli-ecs"}},
+	}
+
+	plan, _, _, hasBuiltIn := c.planProductLevelHelp("ecs")
+	assert.True(t, hasBuiltIn)
+	assert.False(t, plan.deliverPluginHelp)
+	assert.True(t, plan.deliverBuiltInHelp)
+}
+
+func TestPlanProductLevelHelp_UnknownProduct(t *testing.T) {
+	repo, _ := meta.MockLoadRepository([]meta.Product{})
+	c := NewCommando(new(bytes.Buffer), config.Profile{Language: "en"})
+	c.library.builtinRepo = repo
+	c.pluginIndex = &plugin.Index{}
+
+	plan, _, _, hasBuiltIn := c.planProductLevelHelp("nope")
+	assert.False(t, hasBuiltIn)
+	assert.Error(t, plan.abortErr)
+	assert.IsType(t, &InvalidProductOrPluginError{}, plan.abortErr)
+}
+
+func TestInvalidProductOrPluginError_SuggestsBuiltinAndPlugin(t *testing.T) {
+	err := &InvalidProductOrPluginError{
+		Code: "ec",
+		plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-ecs", ProductCode: "ecs"},
+		},
+		library: &Library{
+			builtinRepo: &meta.Repository{
+				Products: []meta.Product{{Code: "ecs"}, {Code: "eci"}},
+			},
+		},
+	}
+	suggestions := err.GetSuggestions()
+	assert.Contains(t, suggestions, "ecs")
+}


### PR DESCRIPTION
**Description**

Unifies product- and API-level `--help` and unknown-command errors with naming rules (CamelCase / METHOD+path / kebab-case) and clearer `Did you mean` suggestions across built-in APIs and plugins. Restful and RPC routing errors are more specific (wrong method, missing path, broad /, RPC misuse of METHOD+path) so agents and users need fewer help retries.