### PR TITLE
feat(openapi): add --estimate-cost and list-supported-pricing-apis

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -120,6 +120,8 @@ func newRootCommand(profile config.Profile, stdout io.Writer) *cli.Command {
 	commando.InitWithCommand(rootCmd)
 
 	rootCmd.AddSubCommand(config.NewConfigureCommand())
+	// list-supported-pricing-apis: enumerate every OpenAPI that supports --estimate-cost
+	rootCmd.AddSubCommand(openapi.NewListSupportedPricingApisCommand())
 	// oss old version, duplicate with ossutil, will remove in future
 	rootCmd.AddSubCommand(lib.NewOssCommand())
 	rootCmd.AddSubCommand(cli.NewVersionCommand())

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -158,6 +158,18 @@ var stdin io.Reader = os.Stdin
 
 func (c *Commando) main(ctx *cli.Context, args []string) error {
 	// fmt.Println("commando main", args)
+
+	// --estimate-cost needs a product + api to estimate against. Without an
+	// early fail here, len(args) == 0 below would silently print usage and
+	// exit 0 — users (and Agents) would see "nothing happened" and assume
+	// the flag is broken or unknown. Fail loud with a concrete example.
+	if EstimateCostFlag(ctx.Flags()).IsAssigned() && len(args) < 2 {
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost requires a product and an API name"),
+			"example: aliyun ecs RunInstances --version 2014-05-26 --RegionId cn-hangzhou ... --estimate-cost\n"+
+				"        run `aliyun --list-supported-pricing-apis` to see every API that supports cost estimation")
+	}
+
 	// aliyun
 	if len(args) == 0 {
 		c.printUsage(ctx)
@@ -471,6 +483,15 @@ func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api
 		return fmt.Errorf("invalid product, please check product code")
 	}
 
+	// --estimate-cost: the openapi-invoke path uses apiContext.Call instead
+	// of an Invoker, which estimate_cost.go's parameter extractor doesn't
+	// understand yet. Fail fast rather than silently invoke the target API.
+	if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost is not supported for product %s which uses the openapi invoke path", product.Code),
+			"cost estimation supports RPC and ROA(restful) style products only")
+	}
+
 	apiContext, err := c.createHttpContext(ctx, product, api, method, path)
 	if err != nil {
 		return err
@@ -546,6 +567,11 @@ func (c *Commando) processInvoke(ctx *cli.Context, productCode string, apiOrMeth
 		}
 		cli.Println(ctx.Stdout(), line)
 		return nil
+	}
+	// --estimate-cost: terminal branch. Must come before --dryrun so we don't
+	// hit TransToAcsRequest side effects on the way to a quote.
+	if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+		return c.processEstimateCost(ctx, invoker)
 	}
 	// process --dryrun
 	if DryRunFlag(ctx.Flags()).IsAssigned() {

--- a/openapi/estimate_cost.go
+++ b/openapi/estimate_cost.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+)
+
+// Routes an OpenAPI call to CloudControl GetApiPrice (POST /api/v1/price/quote)
+// for an estimate instead of invoking the target API.
+//
+// Env overrides (match the plugin runtime's naming):
+//
+//	ALIBABA_CLOUD_PRICING_ENDPOINT — default cloudcontrol.aliyuncs.com
+//	ALIBABA_CLOUD_PRICING_HOST     — Host header when endpoint is a CNAME
+const (
+	estimateCostApiVersion   = "2022-08-30"
+	estimateCostQuotePath    = "/api/v1/price/quote"
+	estimateCostEndpointEnv  = "ALIBABA_CLOUD_PRICING_ENDPOINT"
+	estimateCostHostEnv      = "ALIBABA_CLOUD_PRICING_HOST"
+	defaultEstimateCostHost  = "cloudcontrol.aliyuncs.com"
+	estimateCostProductCode  = "cloudcontrol"
+)
+
+type estimateCostRequest struct {
+	PopCode    string                 `json:"popCode"`
+	PopVersion string                 `json:"popVersion"`
+	ApiName    string                 `json:"apiName"`
+	Parameters map[string]interface{} `json:"parameters"`
+}
+
+// processEstimateCost handles --estimate-cost for both RPC and ROA(restful)
+// invokers. Must be called after invoker.Prepare(ctx) so the CommonRequest
+// carries the fully assembled parameters; otherwise required params from
+// `--body` JSON and path templating wouldn't be visible to the quote.
+func (c *Commando) processEstimateCost(ctx *cli.Context, inv Invoker) error {
+	req := inv.getRequest()
+
+	apiName, err := resolveEstimateCostApiName(c.library, inv)
+	if err != nil {
+		return err
+	}
+
+	parameters, err := buildEstimateCostParameters(req)
+	if err != nil {
+		return err
+	}
+
+	out, err := invokeEstimateCost(ctx, &c.profile, req.Product, req.Version, apiName, parameters)
+	if err != nil {
+		return err
+	}
+	return printEstimateCostResult(ctx, out)
+}
+
+// resolveEstimateCostApiName returns the action name of the call being
+// estimated. Pricing is keyed by the api triple, so a bare RESTful call
+// (method + path, no action name) must be resolvable through metadata.
+func resolveEstimateCostApiName(library *Library, inv Invoker) (string, error) {
+	req := inv.getRequest()
+	if req.ApiName != "" {
+		return req.ApiName, nil
+	}
+	if r, ok := inv.(*RestfulInvoker); ok {
+		if r.api != nil && r.api.Name != "" {
+			return r.api.Name, nil
+		}
+		if api, found := meta.HookGetApiByPath(library.GetApiByPath)(req.Product, req.Version, r.method, r.path); found && api.Name != "" {
+			return api.Name, nil
+		}
+		return "", cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost cannot resolve the api name for `%s %s`", r.method, r.path),
+			"cost estimation needs the api name, please use the `aliyun <product> <ApiName>` form")
+	}
+	return "", fmt.Errorf("--estimate-cost cannot resolve the api name for this call")
+}
+
+// buildEstimateCostParameters flattens every parameter slot of the prepared
+// request (query / form-or-body / path / JSON body) into one map. Values stay
+// strings — CLI semantics; the server normalizes dotted keys like `DataDisk.1.Size`.
+func buildEstimateCostParameters(req *requests.CommonRequest) (map[string]interface{}, error) {
+	parameters := make(map[string]interface{})
+	for k, v := range req.QueryParams {
+		if k != "" && v != "" {
+			parameters[k] = v
+		}
+	}
+	for k, v := range req.FormParams {
+		if k != "" && v != "" {
+			parameters[k] = v
+		}
+	}
+	for k, v := range req.PathParams {
+		if k != "" && v != "" {
+			parameters[k] = v
+		}
+	}
+	if len(req.Content) > 0 {
+		body := make(map[string]interface{})
+		if err := json.Unmarshal(req.Content, &body); err != nil {
+			return nil, cli.NewErrorWithTip(
+				fmt.Errorf("--estimate-cost requires the request body to be a JSON object: %v", err),
+				"cost estimation merges the JSON body into pricing parameters, please pass `--body` as a JSON object")
+		}
+		for k, v := range body {
+			parameters[k] = v
+		}
+	}
+	if req.RegionId != "" {
+		if _, ok := parameters["RegionId"]; !ok {
+			parameters["RegionId"] = req.RegionId
+		}
+	}
+	return parameters, nil
+}
+
+func estimateCostEndpoint() string {
+	if v := os.Getenv(estimateCostEndpointEnv); v != "" {
+		return v
+	}
+	return defaultEstimateCostHost
+}
+
+// invokeEstimateCost issues the signed quote request and returns the raw
+// response body. Reuses the standard authenticated client so signing and
+// credential refresh behave identically to a real OpenAPI call.
+func invokeEstimateCost(ctx *cli.Context, profile *config.Profile, popCode string, popVersion string, apiName string, parameters map[string]interface{}) (string, error) {
+	client, err := GetClient(profile, ctx)
+	if err != nil {
+		return "", fmt.Errorf("init estimate-cost client failed: %s", err)
+	}
+
+	content, err := json.Marshal(estimateCostRequest{
+		PopCode:    popCode,
+		PopVersion: popVersion,
+		ApiName:    apiName,
+		Parameters: parameters,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	request := requests.NewCommonRequest()
+	request.Product = estimateCostProductCode
+	request.Version = estimateCostApiVersion
+	request.Method = "POST"
+	request.PathPattern = estimateCostQuotePath
+	request.Domain = estimateCostEndpoint()
+	request.Scheme = "https"
+	if host := os.Getenv(estimateCostHostEnv); host != "" {
+		request.Headers["Host"] = host
+	}
+	request.SetContent(content)
+	request.SetContentType("application/json")
+
+	resp, err := client.ProcessCommonRequest(request)
+	if err != nil {
+		return "", translateEstimateCostError(popCode, popVersion, apiName, err)
+	}
+	return resp.GetHttpContentString(), nil
+}
+
+// translateEstimateCostError turns ccapi-side server errors into actionable
+// CLI tips. PricingNotSupported is the common "this API isn't billable"
+// signal — surface that as a friendly hint rather than a raw error string,
+// since users mistake it for a misconfiguration otherwise.
+func translateEstimateCostError(popCode string, popVersion string, apiName string, err error) error {
+	if serverErr, ok := err.(*sdkerrors.ServerError); ok {
+		switch serverErr.ErrorCode() {
+		case "PricingNotSupported":
+			return cli.NewErrorWithTip(
+				fmt.Errorf("no pricing information for %s/%s/%s", popCode, popVersion, apiName),
+				"this OpenAPI either incurs no cost or has no pricing mapping registered yet")
+		case "InvalidParameter":
+			return cli.NewErrorWithTip(err,
+				"cost estimation rejected the parameters, please check them against the target API")
+		}
+	}
+	return err
+}
+
+// printEstimateCostResult reuses the standard output pipeline so `--quiet`,
+// `--cli-query` and `--output` keep working on the estimate JSON.
+func printEstimateCostResult(ctx *cli.Context, out string) error {
+	if QuietFlag(ctx.Flags()).IsAssigned() {
+		return nil
+	}
+	var err error
+	if QueryFlag(ctx.Flags()).IsAssigned() {
+		out, err = ApplyQueryFilter(ctx, out)
+		if err != nil {
+			return err
+		}
+	}
+	if filter := GetOutputFilter(ctx); filter != nil {
+		out, err = filter.FilterOutput(out)
+		if err != nil {
+			return err
+		}
+	}
+	out = sortJSON(out)
+	cli.Println(ctx.Stdout(), out)
+	return nil
+}

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -1,0 +1,289 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"bytes"
+	"testing"
+
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildEstimateCostParameters(t *testing.T) {
+	req := requests.NewCommonRequest()
+	req.QueryParams["InstanceType"] = "ecs.g6.large"
+	req.QueryParams["SystemDisk.Category"] = "cloud_essd"
+	req.QueryParams["empty"] = ""
+	req.FormParams["Description"] = "from-form"
+	req.PathParams["ClusterId"] = "c-123"
+	req.RegionId = "cn-hangzhou"
+	req.SetContent([]byte(`{"Period": 1, "AutoRenew": true}`))
+
+	parameters, err := buildEstimateCostParameters(req)
+	assert.Nil(t, err)
+	assert.Equal(t, "ecs.g6.large", parameters["InstanceType"])
+	assert.Equal(t, "cloud_essd", parameters["SystemDisk.Category"])
+	assert.Equal(t, "from-form", parameters["Description"])
+	assert.Equal(t, "c-123", parameters["ClusterId"])
+	assert.Equal(t, "cn-hangzhou", parameters["RegionId"])
+	assert.Equal(t, float64(1), parameters["Period"])
+	assert.Equal(t, true, parameters["AutoRenew"])
+	_, ok := parameters["empty"]
+	assert.False(t, ok, "empty-string param should be dropped, otherwise GetApiPrice sees noise")
+}
+
+func TestBuildEstimateCostParametersRegionNotOverridden(t *testing.T) {
+	// RegionId in the body / query wins over the request RegionId fallback —
+	// otherwise users that explicitly switch region via --RegionId would get
+	// quoted against their default profile region by surprise.
+	req := requests.NewCommonRequest()
+	req.QueryParams["RegionId"] = "cn-beijing"
+	req.RegionId = "cn-hangzhou"
+
+	parameters, err := buildEstimateCostParameters(req)
+	assert.Nil(t, err)
+	assert.Equal(t, "cn-beijing", parameters["RegionId"])
+}
+
+func TestBuildEstimateCostParametersBadBody(t *testing.T) {
+	// --body that isn't a JSON object can't be merged into pricing parameters —
+	// fail with an actionable tip rather than silently dropping the body.
+	req := requests.NewCommonRequest()
+	req.SetContent([]byte(`not-json`))
+
+	_, err := buildEstimateCostParameters(req)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "JSON object")
+}
+
+func TestResolveEstimateCostApiName(t *testing.T) {
+	// RPC style: api name already on the request
+	rpc := &RpcInvoker{BasicInvoker: &BasicInvoker{request: requests.NewCommonRequest()}}
+	rpc.request.ApiName = "RunInstances"
+	name, err := resolveEstimateCostApiName(nil, rpc)
+	assert.Nil(t, err)
+	assert.Equal(t, "RunInstances", name)
+
+	// RESTful style with resolved api metadata
+	restful := &RestfulInvoker{
+		BasicInvoker: &BasicInvoker{request: requests.NewCommonRequest()},
+		api:          &meta.Api{Name: "DescribeClusters"},
+	}
+	name, err = resolveEstimateCostApiName(nil, restful)
+	assert.Nil(t, err)
+	assert.Equal(t, "DescribeClusters", name)
+
+	// RESTful style without api metadata and no library match -> clear error
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	AddFlags(ctx.Flags())
+	library := NewLibrary(ctx.Stdout(), "en")
+	bare := &RestfulInvoker{
+		BasicInvoker: &BasicInvoker{request: requests.NewCommonRequest()},
+		method:       "GET",
+		path:         "/no/such/path",
+	}
+	_, err = resolveEstimateCostApiName(library, bare)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "cannot resolve the api name")
+}
+
+func TestTranslateEstimateCostErrorPassthrough(t *testing.T) {
+	// Non-server errors fall through unchanged so callers see the original
+	// network/transport error instead of a misleading "pricing rejected" tip.
+	plain := assert.AnError
+	assert.Equal(t, plain, translateEstimateCostError("Ecs", "2014-05-26", "RunInstances", plain))
+}
+
+func TestTranslateEstimateCostErrorPricingNotSupported(t *testing.T) {
+	// The common "this API isn't billable" case — must be turned into the
+	// friendly hint, not a raw error string with the upstream Code embedded.
+	body := `{"RequestId":"req-pns","Code":"PricingNotSupported","Message":"no pricing","HostId":"host"}`
+	serverErr := sdkerrors.NewServerError(404, body, "")
+	err := translateEstimateCostError("Ecs", "2014-05-26", "DescribeRegions", serverErr)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "no pricing information for Ecs/2014-05-26/DescribeRegions")
+	tip, _ := err.(cli.ErrorWithTip)
+	assert.NotNil(t, tip)
+	assert.Contains(t, tip.GetTip(""), "incurs no cost or has no pricing mapping registered yet")
+}
+
+func TestTranslateEstimateCostErrorInvalidParameter(t *testing.T) {
+	// Parameter-side rejection (bad popCode/version, missing required field)
+	// gets a "check parameters" tip; raw error keeps its detail (the upstream
+	// SDK.ServerError formatted body) so users can see what the server
+	// objected to. Tip is delivered via cli.ErrorWithTip.GetTip, not the
+	// Error() string itself — Error() preserves the wrapped error verbatim.
+	body := `{"RequestId":"req-ip","Code":"InvalidParameter","Message":"bad popVersion","HostId":"host"}`
+	serverErr := sdkerrors.NewServerError(400, body, "")
+	err := translateEstimateCostError("Ecs", "2014-05-26", "RunInstances", serverErr)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "InvalidParameter")
+	tip, _ := err.(cli.ErrorWithTip)
+	assert.NotNil(t, tip)
+	assert.Contains(t, tip.GetTip(""), "check them against the target API")
+}
+
+func TestTranslateEstimateCostErrorUnknownServerCode(t *testing.T) {
+	// Server errors with codes we don't special-case (Throttling, Forbidden,
+	// random new ones) fall through unchanged — better the user sees the
+	// upstream code+message than a vague "pricing failed" wrapper.
+	body := `{"RequestId":"req-th","Code":"Throttling.User","Message":"slow down","HostId":"host"}`
+	serverErr := sdkerrors.NewServerError(429, body, "")
+	got := translateEstimateCostError("Ecs", "2014-05-26", "RunInstances", serverErr)
+	assert.Equal(t, serverErr, got)
+}
+
+func TestPrintEstimateCostResultQuietSkipsOutput(t *testing.T) {
+	// `--quiet` short-circuits before any rendering — otherwise --estimate-cost
+	// combined with -q (e.g. agent piping to /dev/null) would still print the
+	// quote, surprising callers.
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	QuietFlag(ctx.Flags()).SetAssigned(true)
+	defer QuietFlag(ctx.Flags()).SetAssigned(false)
+
+	err := printEstimateCostResult(ctx, `{"price":{"calculatedAmount":42}}`)
+	assert.Nil(t, err)
+	assert.Empty(t, w.String(), "no output should be written under --quiet")
+}
+
+func TestPrintEstimateCostResultPlainJSON(t *testing.T) {
+	// Default path (no quiet/query/output) just sorts and prints the JSON.
+	// Anchor it so a future refactor of the output pipeline can't silently
+	// drop the response.
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	err := printEstimateCostResult(ctx, `{"price":{"calculatedAmount":42},"requestId":"req-1"}`)
+	assert.Nil(t, err)
+	assert.Contains(t, w.String(), "calculatedAmount")
+	assert.Contains(t, w.String(), "42")
+	assert.Contains(t, w.String(), "req-1")
+}
+
+func TestPrintEstimateCostResultWithCliQuery(t *testing.T) {
+	// --cli-query JMESPath filter must apply on top of the estimate JSON. If
+	// this branch silently failed, agents piping `.price.calculatedAmount`
+	// through --cli-query would see the full envelope instead of just the
+	// number they asked for.
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	QueryFlag(ctx.Flags()).SetAssigned(true)
+	QueryFlag(ctx.Flags()).SetValue("price.calculatedAmount")
+	defer func() {
+		QueryFlag(ctx.Flags()).SetAssigned(false)
+	}()
+
+	err := printEstimateCostResult(ctx, `{"price":{"calculatedAmount":42},"requestId":"req-1"}`)
+	assert.Nil(t, err)
+	// Output should be just the number (or string form of it), not the full envelope.
+	assert.Contains(t, w.String(), "42")
+	assert.NotContains(t, w.String(), "req-1")
+}
+
+func TestProcessInvokeEstimateCostFlag(t *testing.T) {
+	// Endpoint pointed at an unresolvable host: the flow must reach the
+	// estimate-cost client call (proving interception) and fail on DNS, not
+	// invoke the target API. If the EstimateCostFlag check were missing or
+	// wrong, the call would go to ecs.cn-hangzhou.aliyuncs.com instead.
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	profile := config.NewProfile("test-estimate-cost")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+	command := NewCommando(w, profile)
+
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+	defer EstimateCostFlag(ctx.Flags()).SetAssigned(false)
+
+	err := command.processInvoke(ctx, "ecs", "DescribeRegions", "")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+}
+
+func TestListSupportedPricingApisEndpointOverride(t *testing.T) {
+	// Endpoint env override must take effect; otherwise users can't target
+	// pre/staging gateways from the main repo side (same expectation as the
+	// plugin runtime — the two share the env name on purpose).
+	t.Setenv(estimateCostEndpointEnv, "pricing.test.example")
+	assert.Equal(t, "pricing.test.example", estimateCostEndpoint())
+
+	t.Setenv(estimateCostEndpointEnv, "")
+	assert.Equal(t, defaultEstimateCostHost, estimateCostEndpoint())
+}
+
+func TestMainEstimateCostMissingProductOrApi(t *testing.T) {
+	// `aliyun --estimate-cost` (no product/api) and `aliyun ecs --estimate-cost`
+	// (product only) must fail loud with an actionable example, otherwise the
+	// flag would be silently dropped on the printUsage / plugin-help branch
+	// and users (especially Agents) would see "nothing happened" and assume
+	// the capability is broken or unknown.
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	profile := config.NewProfile("test-estimate-cost")
+	command := NewCommando(w, profile)
+
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+	defer EstimateCostFlag(ctx.Flags()).SetAssigned(false)
+
+	// no args at all
+	err := command.main(ctx, []string{})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--estimate-cost requires a product and an API name")
+
+	// product only (forgot API name)
+	err = command.main(ctx, []string{"ecs"})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--estimate-cost requires a product and an API name")
+}

--- a/openapi/flags.go
+++ b/openapi/flags.go
@@ -32,6 +32,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(WaiterFlag)
 	fs.Add(NewDryRunFlag())
 	fs.Add(NewDryRunJsonFlag())
+	fs.Add(NewEstimateCostFlag())
 	fs.Add(NewQuietFlag())
 	fs.Add(NewLogLevelFlag())
 	fs.Add(NewYesFlag())
@@ -55,6 +56,7 @@ const (
 	RoaFlagName           = "roa"
 	DryRunFlagName        = "dryrun"
 	CliDryRunJsonFlagName = "cli-dry-run-json"
+	EstimateCostFlagName  = "estimate-cost"
 	QuietFlagName         = "quiet"
 	LogLevelFlagName      = "log-level"
 	YesFlagName           = "yes"
@@ -277,6 +279,26 @@ func NewDryRunJsonFlag() *cli.Flag {
 		),
 		ExcludeWith: []string{PagerFlag.Name, WaiterFlag.Name, DryRunFlagName},
 	}
+}
+
+// NewEstimateCostFlag registers `--estimate-cost`. See estimate_cost.go for
+// the routing details. Cross-product enumeration lives in the top-level
+// `aliyun list-supported-pricing-apis` subcommand (main/main.go), not here.
+func NewEstimateCostFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "caller",
+		Name:         EstimateCostFlagName,
+		AssignedMode: cli.AssignedNone,
+		Short: i18n.T(
+			"use `--estimate-cost` to estimate the cost of an OpenAPI call via CloudControl GetApiPrice without invoking it. Requires a product and an API name, e.g. `aliyun ecs RunInstances ... --estimate-cost`. Output is JSON.",
+			"使用 `--estimate-cost` 跳过实际调用，通过 CloudControl GetApiPrice 预估 OpenAPI 调用费用。需带 product 和 API 名（如 `aliyun ecs RunInstances ... --estimate-cost`），输出 JSON",
+		),
+		ExcludeWith: []string{PagerFlag.Name, WaiterFlag.Name, DryRunFlagName, CliDryRunJsonFlagName},
+	}
+}
+
+func EstimateCostFlag(fs *cli.FlagSet) *cli.Flag {
+	return fs.Get(EstimateCostFlagName)
 }
 
 func NewQuietFlag() *cli.Flag {

--- a/openapi/list_supported_pricing_apis.go
+++ b/openapi/list_supported_pricing_apis.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+)
+
+// Cross-product enumeration: asks CloudControl ListSupportedPricingApis
+// (GET /api/v1/price/supported-apis) for every OpenAPI triple that has a
+// pricing mapping registered, so Agents and humans can discover what supports
+// --estimate-cost without probing each API.
+//
+// Exposed as a top-level `aliyun list-supported-pricing-apis` subcommand
+// (not a flag): the operation is product-agnostic, takes no arguments, and
+// is a standalone action — same shape as `aliyun configure`, `aliyun upgrade`
+// etc. — so a subcommand reads more naturally than a global flag would.
+const (
+	estimateCostListPath = "/api/v1/price/supported-apis"
+)
+
+// NewListSupportedPricingApisCommand returns the top-level subcommand
+// registration. Wired up from main/main.go alongside the other standalone
+// subcommands (configure, plugin, upgrade, ...).
+func NewListSupportedPricingApisCommand() *cli.Command {
+	return &cli.Command{
+		Name: "list-supported-pricing-apis",
+		Short: i18n.T(
+			"List every OpenAPI that supports --estimate-cost. Output is JSON.",
+			"列出所有支持 --estimate-cost 的 OpenAPI 三元组，输出 JSON",
+		),
+		Run: func(ctx *cli.Context, args []string) error {
+			profile, err := config.LoadProfileWithContext(ctx)
+			if err != nil {
+				return cli.NewErrorWithTip(err,
+					"list-supported-pricing-apis needs a configured profile; run `aliyun configure` first")
+			}
+			out, err := invokeListSupportedPricingApis(ctx, &profile)
+			if err != nil {
+				return err
+			}
+			return printEstimateCostResult(ctx, out)
+		},
+	}
+}
+
+// pagedListResponse is the slice of the upstream response we care about for
+// merging across pages. The full response carries more fields (maxResults,
+// etc.) but those are per-page metadata that lose meaning after aggregation.
+type pagedListResponse struct {
+	SupportedApis []json.RawMessage `json:"supportedApis"`
+	NextToken     string            `json:"nextToken"`
+	RequestId     string            `json:"requestId"`
+}
+
+// invokeListSupportedPricingApis builds the authenticated single-page fetcher
+// and hands it to paginateList. Pagination + JSON merge is fetcher-agnostic
+// (see paginateList) so tests can swap in a stub fetcher without standing up
+// an https server.
+func invokeListSupportedPricingApis(ctx *cli.Context, profile *config.Profile) (string, error) {
+	client, err := GetClient(profile, ctx)
+	if err != nil {
+		return "", fmt.Errorf("init list-supported-pricing-apis client failed: %s", err)
+	}
+	return paginateList(func(nextToken string) ([]byte, error) {
+		request := requests.NewCommonRequest()
+		request.Product = estimateCostProductCode
+		request.Version = estimateCostApiVersion
+		request.Method = "GET"
+		request.PathPattern = estimateCostListPath
+		request.Domain = estimateCostEndpoint()
+		request.Scheme = "https"
+		if host := os.Getenv(estimateCostHostEnv); host != "" {
+			request.Headers["Host"] = host
+		}
+		// Pagination is via query string; the upstream contract uses camelCase
+		// nextToken/maxResults (ROA style). We don't pass maxResults — the
+		// server default (100) is fine for an enumeration that runs once.
+		if nextToken != "" {
+			request.QueryParams["nextToken"] = nextToken
+		}
+		request.SetContentType("application/json")
+
+		resp, err := client.ProcessCommonRequest(request)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(resp.GetHttpContentString()), nil
+	})
+}
+
+// paginateList walks every page produced by getPage(nextToken) and emits a
+// single merged JSON document. Users expect `list-*` commands to return the
+// full set, not the first page; pagination is a backend implementation detail
+// (ccapi caps each page at 100), not something to push onto the user.
+//
+// Loop terminates when nextToken comes back empty. The aggregate response keeps
+// the same top-level shape as a single page (supportedApis + nextToken +
+// requestId) so existing JMESPath filters via --cli-query don't have to special-
+// case the merged form; nextToken is fixed to "" since the merged set is by
+// definition complete.
+//
+// Decoupled from the SDK call (getPage is a stub-friendly fetcher) so the
+// looping/merge logic can be tested without setting up an https server.
+func paginateList(getPage func(nextToken string) ([]byte, error)) (string, error) {
+	var aggregated []json.RawMessage
+	var lastRequestId string
+	nextToken := ""
+
+	for {
+		raw, err := getPage(nextToken)
+		if err != nil {
+			return "", err
+		}
+
+		var page pagedListResponse
+		if err := json.Unmarshal(raw, &page); err != nil {
+			// Upstream returned non-JSON or unexpected shape; surface raw to
+			// preserve diagnosability rather than swallowing the body.
+			return "", fmt.Errorf("list-supported-pricing-apis: failed to parse page: %v\nraw response:\n%s", err, string(raw))
+		}
+
+		aggregated = append(aggregated, page.SupportedApis...)
+		lastRequestId = page.RequestId
+		if page.NextToken == "" {
+			break
+		}
+		nextToken = page.NextToken
+	}
+
+	merged := map[string]interface{}{
+		"supportedApis": aggregated,
+		"nextToken":     "", // by definition: merged result IS the full set
+		"requestId":     lastRequestId,
+	}
+	out, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/openapi/list_supported_pricing_apis_test.go
+++ b/openapi/list_supported_pricing_apis_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewListSupportedPricingApisCommand(t *testing.T) {
+	// Top-level subcommand metadata — the Run hook itself touches credentials
+	// + network so we just lock the command shape here. Run-time behavior is
+	// covered by TestInvokeListSupportedPricingApis below.
+	cmd := NewListSupportedPricingApisCommand()
+	assert.Equal(t, "list-supported-pricing-apis", cmd.Name)
+	assert.NotNil(t, cmd.Run)
+	assert.NotEmpty(t, cmd.Short)
+}
+
+func TestInvokeListSupportedPricingApisTransport(t *testing.T) {
+	// Endpoint pointed at an unresolvable host: the call must reach the
+	// signed transport (proving the request shape is built correctly) and
+	// fail on DNS, not silently succeed or short-circuit. Anchors the
+	// pagination loop's first iteration and the surrounding request setup.
+	t.Setenv(estimateCostEndpointEnv, "list.test.invalid")
+
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	profile := config.NewProfile("test-list")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+
+	_, err := invokeListSupportedPricingApis(ctx, &profile)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "list.test.invalid")
+}
+
+func TestPagedListResponseUnmarshal(t *testing.T) {
+	// The merge loop depends on this JSON shape being parsed correctly. Lock
+	// it here so a backend rename of supportedApis/nextToken/requestId would
+	// break this test before silently corrupting the merge.
+	raw := []byte(`{
+		"supportedApis": [
+			{"popCode":"Ecs","popVersion":"2014-05-26","apiName":"RunInstances"},
+			{"popCode":"Rds","popVersion":"2014-08-15","apiName":"RunRCInstances"}
+		],
+		"nextToken": "20",
+		"requestId": "req-1"
+	}`)
+	var page pagedListResponse
+	err := json.Unmarshal(raw, &page)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(page.SupportedApis))
+	assert.Equal(t, "20", page.NextToken)
+	assert.Equal(t, "req-1", page.RequestId)
+}
+
+func TestPagedListResponseUnmarshalEmptyTokenMeansLastPage(t *testing.T) {
+	// Loop termination relies on NextToken == ""; verify zero-value semantics
+	// against an upstream response that omits the field entirely.
+	raw := []byte(`{
+		"supportedApis": [{"popCode":"Ecs","popVersion":"2014-05-26","apiName":"RunInstances"}],
+		"requestId": "req-final"
+	}`)
+	var page pagedListResponse
+	err := json.Unmarshal(raw, &page)
+	assert.Nil(t, err)
+	assert.Equal(t, "", page.NextToken)
+	assert.Equal(t, "req-final", page.RequestId)
+}
+
+func TestPaginateListSinglePage(t *testing.T) {
+	// One page, nextToken empty → loop exits after first fetch. Sanity check
+	// for the trivial case and that requestId from the only page flows
+	// through to the merged document.
+	calls := 0
+	getPage := func(nextToken string) ([]byte, error) {
+		calls++
+		assert.Equal(t, "", nextToken, "first fetch should send empty token")
+		return []byte(`{
+			"supportedApis":[{"popCode":"Ecs","popVersion":"2014-05-26","apiName":"RunInstances"}],
+			"nextToken":"",
+			"requestId":"req-single"
+		}`), nil
+	}
+	out, err := paginateList(getPage)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Contains(t, out, "RunInstances")
+	assert.Contains(t, out, `"requestId": "req-single"`)
+	assert.Contains(t, out, `"nextToken": ""`)
+}
+
+func TestPaginateListMultiPageMergesAcrossPages(t *testing.T) {
+	// Three pages → three fetcher calls, supportedApis aggregated in order,
+	// final merged response carries the LAST page's requestId and a forced-
+	// empty nextToken (the merged result IS the complete set).
+	pages := []string{
+		`{"supportedApis":[{"popCode":"Ecs","apiName":"RunInstances"},{"popCode":"Ecs","apiName":"CreateImage"}],"nextToken":"20","requestId":"req-1"}`,
+		`{"supportedApis":[{"popCode":"Rds","apiName":"RunRCInstances"}],"nextToken":"40","requestId":"req-2"}`,
+		`{"supportedApis":[{"popCode":"Alb","apiName":"CreateLoadBalancer"}],"nextToken":"","requestId":"req-3-last"}`,
+	}
+	tokensSeen := []string{}
+	idx := 0
+	getPage := func(nextToken string) ([]byte, error) {
+		tokensSeen = append(tokensSeen, nextToken)
+		page := pages[idx]
+		idx++
+		return []byte(page), nil
+	}
+	out, err := paginateList(getPage)
+	assert.Nil(t, err)
+	// Loop walks first→second→third using the token chain from each page.
+	assert.Equal(t, []string{"", "20", "40"}, tokensSeen)
+	// Aggregated set: 2 + 1 + 1 = 4 entries, original order preserved.
+	assert.Contains(t, out, "RunInstances")
+	assert.Contains(t, out, "CreateImage")
+	assert.Contains(t, out, "RunRCInstances")
+	assert.Contains(t, out, "CreateLoadBalancer")
+	// Merged doc keeps the LAST page's requestId — that's the audit anchor
+	// users would want to grep against if pagination misbehaved.
+	assert.Contains(t, out, `"requestId": "req-3-last"`)
+	// nextToken forced to "" — the merged set is complete by construction;
+	// echoing the intermediate token would falsely imply "more pages".
+	assert.Contains(t, out, `"nextToken": ""`)
+}
+
+func TestPaginateListFetcherErrorPropagates(t *testing.T) {
+	// Mid-loop fetcher failure must surface upward, not be swallowed (e.g.
+	// network blip on page 2 of 5: better to fail loud than silently truncate
+	// the listing to the pages already fetched).
+	calls := 0
+	getPage := func(nextToken string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return []byte(`{"supportedApis":[{"popCode":"Ecs"}],"nextToken":"20","requestId":"req-1"}`), nil
+		}
+		return nil, assert.AnError
+	}
+	_, err := paginateList(getPage)
+	assert.NotNil(t, err)
+	assert.Equal(t, assert.AnError, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestPaginateListBadJSONShowsRawBody(t *testing.T) {
+	// Unparseable upstream body must keep the raw text in the error message
+	// so debugging doesn't require turning on transport logging — common case
+	// is an HTML error page from a misrouted proxy.
+	getPage := func(nextToken string) ([]byte, error) {
+		return []byte(`<html>oops 502</html>`), nil
+	}
+	_, err := paginateList(getPage)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "failed to parse page")
+	assert.Contains(t, err.Error(), "<html>oops 502</html>")
+}
+
+func TestNewListSupportedPricingApisCommandRunWithoutProfileFailsCleanly(t *testing.T) {
+	// Profile loading fails (no config file, no env creds) → the command
+	// should return a tip pointing at `aliyun configure`, not panic and not
+	// silently swallow the error.
+	t.Setenv(estimateCostEndpointEnv, "should-not-be-reached")
+	t.Setenv("ALIBABACLOUD_PROFILE", "no-such-profile-zz")
+	// explicitly clear env creds so LoadProfileWithContext can't fall through
+	// to env-credential mode
+	t.Setenv("ALIBABACLOUD_ACCESS_KEY_ID", "")
+	t.Setenv("ALIBABACLOUD_ACCESS_KEY_SECRET", "")
+	t.Setenv("ALIBABACLOUD_REGION_ID", "")
+
+	cmd := NewListSupportedPricingApisCommand()
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	parent := &cli.Command{}
+	parent.EnableUnknownFlag = true
+	config.AddFlags(parent.Flags())
+	ctx.EnterCommand(parent)
+
+	err := cmd.Run(ctx, []string{})
+	// Either profile load fails (clear tip) or transport fails ("should-not-
+	// be-reached" host) — both prove the Run closure executed and reported.
+	// Silent nil here would mean the command did nothing without telling the user.
+	assert.NotNil(t, err)
+}
+
+func TestNewListSupportedPricingApisCommandRunReachesTransport(t *testing.T) {
+	// The Run closure has to wire LoadProfileWithContext + invoke + print
+	// together correctly — easy to introduce a typo there that silently
+	// returns nil. Drive it end-to-end against an unresolvable host so the
+	// closure executes and the failure surfaces at the transport layer
+	// (proving we reached invokeListSupportedPricingApis), not at config
+	// load.
+	t.Setenv(estimateCostEndpointEnv, "list-cmd.test.invalid")
+	t.Setenv("ALIBABACLOUD_ACCESS_KEY_ID", "test-ak")
+	t.Setenv("ALIBABACLOUD_ACCESS_KEY_SECRET", "test-secret")
+	t.Setenv("ALIBABACLOUD_REGION_ID", "cn-hangzhou")
+
+	cmd := NewListSupportedPricingApisCommand()
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	parent := &cli.Command{}
+	parent.EnableUnknownFlag = true
+	config.AddFlags(parent.Flags())
+	ctx.EnterCommand(parent)
+
+	err := cmd.Run(ctx, []string{})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "list-cmd.test.invalid")
+}


### PR DESCRIPTION
## What

Add `--estimate-cost` global flag and `list-supported-pricing-apis` subcommand for cost discovery via CloudControl pricing service.

## Usage

```bash
# Estimate cost without invoking the target API
aliyun ecs RunInstances --version 2014-05-26 \
    --RegionId cn-hangzhou \
    --InstanceType ecs.g6.xlarge \
    --InstanceChargeType PrePaid --PeriodUnit Month --Period 1 \
    ... \
    --estimate-cost

# List all OpenAPIs that support --estimate-cost
aliyun list-supported-pricing-apis
```

## Notes

- Output is JSON, compatible with `--quiet` / `--cli-query` / `--output`.
- `list-supported-pricing-apis` auto-paginates the underlying response.
- Endpoint override via `ALIBABA_CLOUD_PRICING_ENDPOINT` / `ALIBABA_CLOUD_PRICING_HOST`.

## Tests

`go test ./openapi/` passes including new unit tests.