### PR TITLE
feat(config): support STS endpoint override for OIDC and role auth

### DIFF
--- a/config/configure_get.go
+++ b/config/configure_get.go
@@ -75,6 +75,8 @@ func doConfigureGet(c *cli.Context, args []string) error {
 			cli.Printf(c.Stdout(), "sts-token=%s\n", profile.StsToken)
 		case StsRegionFlagName:
 			cli.Printf(c.Stdout(), "sts-region=%s\n", profile.StsRegion)
+		case StsEndpointFlagName:
+			cli.Printf(c.Stdout(), "sts-endpoint=%s\n", profile.StsEndpoint)
 		case RamRoleNameFlagName:
 			cli.Printf(c.Stdout(), "ram-role-name=%s\n", profile.RamRoleName)
 		case RamRoleArnFlagName:

--- a/config/configure_get_test.go
+++ b/config/configure_get_test.go
@@ -313,3 +313,92 @@ func TestDoConfigureGetExternalAccountType(t *testing.T) {
 	doConfigureGet(ctx, []string{ExternalAccountTypeFlagName})
 	assert.Equal(t, "external-account-type=\n\n", stdout.String())
 }
+
+func TestDoConfigureGetStsEndpoint(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	AddFlags(ctx.Flags())
+	originhook := hookLoadConfigurationWithContext
+	defer func() {
+		hookLoadConfigurationWithContext = originhook
+	}()
+
+	hookLoadConfigurationWithContext = func(fn func(ctx *cli.Context) (*Configuration, error)) func(ctx *cli.Context) (*Configuration, error) {
+		return func(ctx *cli.Context) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{
+						Name:        "default",
+						Mode:        OIDC,
+						StsEndpoint: "sts-vpc.cn-hangzhou.aliyuncs.com",
+						StsRegion:   "cn-hangzhou",
+					},
+				},
+			}, nil
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	doConfigureGet(ctx, []string{StsEndpointFlagName})
+	assert.Equal(t, "sts-endpoint=sts-vpc.cn-hangzhou.aliyuncs.com\n\n", stdout.String())
+
+	stdout.Reset()
+	stderr.Reset()
+	doConfigureGet(ctx, []string{StsRegionFlagName})
+	assert.Equal(t, "sts-region=cn-hangzhou\n\n", stdout.String())
+
+	hookLoadConfigurationWithContext = func(fn func(ctx *cli.Context) (*Configuration, error)) func(ctx *cli.Context) (*Configuration, error) {
+		return func(ctx *cli.Context) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{
+						Name:        "default",
+						Mode:        OIDC,
+						StsEndpoint: "",
+						StsRegion:   "",
+					},
+				},
+			}, nil
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	doConfigureGet(ctx, []string{StsEndpointFlagName, StsRegionFlagName})
+	assert.Equal(t, "sts-endpoint=\nsts-region=\n\n", stdout.String())
+}
+
+func TestDoConfigureGetStsEndpointInProfileJSON(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	AddFlags(ctx.Flags())
+	originhook := hookLoadConfigurationWithContext
+	defer func() {
+		hookLoadConfigurationWithContext = originhook
+	}()
+
+	hookLoadConfigurationWithContext = func(fn func(ctx *cli.Context) (*Configuration, error)) func(ctx *cli.Context) (*Configuration, error) {
+		return func(ctx *cli.Context) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{
+						Name:        "default",
+						Mode:        OIDC,
+						StsEndpoint: "sts-vpc.cn-hangzhou.aliyuncs.com",
+						RegionId:    "cn-hangzhou",
+					},
+				},
+			}, nil
+		}
+	}
+
+	err := doConfigureGet(ctx, []string{})
+	assert.NoError(t, err)
+	assert.Contains(t, stdout.String(), `"sts_endpoint": "sts-vpc.cn-hangzhou.aliyuncs.com"`)
+}

--- a/config/configure_set.go
+++ b/config/configure_set.go
@@ -130,6 +130,7 @@ func doConfigureSet(ctx *cli.Context) error {
 	profile.ConnectTimeout = ConnectTimeoutFlag(flags).GetIntegerOrDefault(profile.ConnectTimeout)
 	profile.RetryCount = RetryCountFlag(flags).GetIntegerOrDefault(profile.RetryCount)
 	profile.StsRegion = StsRegionFlag(flags).GetStringOrDefault(profile.StsRegion)
+	profile.StsEndpoint = StsEndpointFlag(flags).GetStringOrDefault(profile.StsEndpoint)
 	profile.EndpointType = EndpointTypeFlag(flags).GetStringOrDefault(profile.EndpointType)
 	profile.Endpoint = EndpointFlag(flags).GetStringOrDefault(profile.Endpoint)
 	profile.ExternalAccountType = ExternalAccountTypeFlag(flags).GetStringOrDefault(profile.ExternalAccountType)

--- a/config/flags.go
+++ b/config/flags.go
@@ -26,6 +26,7 @@ const (
 	AccessKeySecretFlagName            = "access-key-secret"
 	StsTokenFlagName                   = "sts-token"
 	StsRegionFlagName                  = "sts-region"
+	StsEndpointFlagName                = "sts-endpoint"
 	RamRoleNameFlagName                = "ram-role-name"
 	RamRoleArnFlagName                 = "ram-role-arn"
 	RoleSessionNameFlagName            = "role-session-name"
@@ -69,6 +70,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(NewAccessKeySecretFlag())
 	fs.Add(NewStsTokenFlag())
 	fs.Add(NewStsRegionFlag())
+	fs.Add(NewStsEndpointFlag())
 	fs.Add(NewRamRoleNameFlag())
 	fs.Add(NewRamRoleArnFlag())
 	fs.Add(NewSourceProfileFlag())
@@ -123,6 +125,10 @@ func StsTokenFlag(fs *cli.FlagSet) *cli.Flag {
 
 func StsRegionFlag(fs *cli.FlagSet) *cli.Flag {
 	return fs.Get(StsRegionFlagName)
+}
+
+func StsEndpointFlag(fs *cli.FlagSet) *cli.Flag {
+	return fs.Get(StsEndpointFlagName)
 }
 
 func RamRoleNameFlag(fs *cli.FlagSet) *cli.Flag {
@@ -282,6 +288,17 @@ func NewStsRegionFlag() *cli.Flag {
 		Short: i18n.T(
 			"use `--sts-region <StsRegion>` to assign StsRegion",
 			"使用 `--sts-region <StsRegion>` 指定StsRegion"),
+	}
+}
+
+func NewStsEndpointFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "config",
+		Name:         StsEndpointFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Short: i18n.T(
+			"use `--sts-endpoint <StsEndpoint>` to assign STS endpoint, e.g. sts-vpc.cn-hangzhou.aliyuncs.com",
+			"使用 `--sts-endpoint <StsEndpoint>` 指定 STS endpoint，例如 sts-vpc.cn-hangzhou.aliyuncs.com"),
 	}
 }
 

--- a/config/hello.go
+++ b/config/hello.go
@@ -34,7 +34,7 @@ func doHello(ctx *cli.Context, profile *Profile) (err error) {
 		Credential: credential,
 	}
 
-	config.Endpoint = tea.String(getSTSEndpoint(profile.StsRegion))
+	config.Endpoint = tea.String(resolveSTSEndpoint(profile))
 	client, err := openapi.NewClient(config)
 	if err != nil {
 		return

--- a/config/profile.go
+++ b/config/profile.go
@@ -97,6 +97,7 @@ type Profile struct {
 	AccessKeySecret            string           `json:"access_key_secret,omitempty"`
 	StsToken                   string           `json:"sts_token,omitempty"`
 	StsRegion                  string           `json:"sts_region,omitempty"`
+	StsEndpoint                string           `json:"sts_endpoint,omitempty"`
 	RamRoleName                string           `json:"ram_role_name,omitempty"`
 	RamRoleArn                 string           `json:"ram_role_arn,omitempty"`
 	RoleSessionName            string           `json:"ram_session_name,omitempty"`
@@ -271,6 +272,7 @@ func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
 	cp.AccessKeySecret = AccessKeySecretFlag(ctx.Flags()).GetStringOrDefault(cp.AccessKeySecret)
 	cp.StsToken = StsTokenFlag(ctx.Flags()).GetStringOrDefault(cp.StsToken)
 	cp.StsRegion = StsRegionFlag(ctx.Flags()).GetStringOrDefault(cp.StsRegion)
+	cp.StsEndpoint = StsEndpointFlag(ctx.Flags()).GetStringOrDefault(cp.StsEndpoint)
 	cp.RamRoleName = RamRoleNameFlag(ctx.Flags()).GetStringOrDefault(cp.RamRoleName)
 	cp.RamRoleArn = RamRoleArnFlag(ctx.Flags()).GetStringOrDefault(cp.RamRoleArn)
 	cp.ExternalId = ExternalIdFlag(ctx.Flags()).GetStringOrDefault(cp.ExternalId)
@@ -311,8 +313,20 @@ func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
 		cp.RegionId = util.GetFromEnv("ALIBABA_CLOUD_REGION_ID", "ALIBABACLOUD_REGION_ID", "ALICLOUD_REGION_ID", "REGION_ID", "REGION")
 	}
 
+	if cp.StsRegion == "" {
+		cp.StsRegion = util.GetFromEnv("ALIBABA_CLOUD_STS_REGION", "ALIBABACLOUD_STS_REGION")
+	}
+
+	if cp.StsEndpoint == "" {
+		cp.StsEndpoint = util.GetFromEnv("ALIBABA_CLOUD_STS_ENDPOINT", "ALIBABACLOUD_STS_ENDPOINT")
+	}
+
 	if cp.EndpointType == "" {
 		cp.EndpointType = util.GetFromEnv("ALIBABA_CLOUD_ENDPOINT_TYPE", "ALIBABACLOUD_ENDPOINT_TYPE", "ALICLOUD_ENDPOINT_TYPE", "ENDPOINT_TYPE")
+	}
+
+	if cp.EndpointType == "" && isVpcEndpointEnabled() {
+		cp.EndpointType = "vpc"
 	}
 
 	if cp.Endpoint == "" {
@@ -413,6 +427,43 @@ func getSTSEndpoint(regionId string) string {
 	return "sts.aliyuncs.com"
 }
 
+func isVpcEndpointEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")))
+	return v == "true" || v == "1"
+}
+
+func isVpcSTSEndpoint(cp *Profile) bool {
+	if strings.EqualFold(cp.EndpointType, "vpc") {
+		return true
+	}
+	return isVpcEndpointEnabled()
+}
+
+func stsRegionForProfile(cp *Profile) string {
+	if cp.StsRegion != "" {
+		return cp.StsRegion
+	}
+	return cp.RegionId
+}
+
+func normalizeSTSEndpointHost(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	return strings.TrimSuffix(endpoint, "/")
+}
+
+func resolveSTSEndpoint(cp *Profile) string {
+	if cp.StsEndpoint != "" {
+		return normalizeSTSEndpointHost(cp.StsEndpoint)
+	}
+	regionId := stsRegionForProfile(cp)
+	if isVpcSTSEndpoint(cp) && regionId != "" {
+		return fmt.Sprintf("sts-vpc.%s.aliyuncs.com", regionId)
+	}
+	return getSTSEndpoint(regionId)
+}
+
 // mergeProfileAfterCredentialRefresh persists STS / OAuth token fields from the in-memory profile onto the on-disk profile.
 // in-memory profile may include one-off CLI overrides(e.g. --endpoint) merged via OverwriteWithFlags; those must not overwrite stored settings.
 func mergeProfileAfterCredentialRefresh(disk Profile, cp *Profile) Profile {
@@ -462,7 +513,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			SetRoleSessionName(cp.RoleSessionName).
 			SetRoleSessionExpiration(cp.ExpiredSeconds).
 			SetExternalId(cp.ExternalId).
-			SetSTSEndpoint(getSTSEndpoint(cp.StsRegion))
+			SetSTSEndpoint(resolveSTSEndpoint(cp))
 
 		if cp.StsToken != "" {
 			config.SetSecurityToken(cp.StsToken)
@@ -477,7 +528,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			SetPrivateKeyFile(cp.PrivateKey).
 			SetPublicKeyId(cp.KeyPairName).
 			SetSessionExpiration(cp.ExpiredSeconds).
-			SetSTSEndpoint(getSTSEndpoint(cp.StsRegion))
+			SetSTSEndpoint(resolveSTSEndpoint(cp))
 
 	case RamRoleArnWithEcs:
 		config.SetType("ecs_ram_role").
@@ -500,7 +551,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			SetRoleArn(cp.RamRoleArn).
 			SetRoleSessionName(cp.RoleSessionName).
 			SetRoleSessionExpiration(cp.ExpiredSeconds).
-			SetSTSEndpoint(getSTSEndpoint(cp.StsRegion))
+			SetSTSEndpoint(resolveSTSEndpoint(cp))
 
 	case ChainableRamRoleArn:
 		profileName := cp.SourceProfile
@@ -536,7 +587,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			SetRoleSessionName(cp.RoleSessionName).
 			SetRoleSessionExpiration(cp.ExpiredSeconds).
 			SetExternalId(cp.ExternalId).
-			SetSTSEndpoint(getSTSEndpoint(cp.StsRegion))
+			SetSTSEndpoint(resolveSTSEndpoint(cp))
 
 		if model.SecurityToken != nil {
 			config.SetSecurityToken(*model.SecurityToken)
@@ -634,7 +685,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			SetOIDCTokenFilePath(cp.OIDCTokenFile).
 			SetRoleArn(cp.RamRoleArn).
 			SetRoleSessionName(cp.RoleSessionName).
-			SetSTSEndpoint(getSTSEndpoint(cp.StsRegion)).
+			SetSTSEndpoint(resolveSTSEndpoint(cp)).
 			SetSessionExpiration(3600)
 
 	case CloudSSO:
@@ -799,6 +850,15 @@ func (cp *Profile) GetRuntimeEnv(ctx *cli.Context) (map[string]string, error) {
 	}
 	if cp.Endpoint != "" {
 		envs["ALIBABA_CLOUD_ENDPOINT"] = cp.Endpoint
+	}
+	if cp.StsEndpoint != "" {
+		envs["ALIBABA_CLOUD_STS_ENDPOINT"] = cp.StsEndpoint
+	}
+	if cp.StsRegion != "" {
+		envs["ALIBABA_CLOUD_STS_REGION"] = cp.StsRegion
+	}
+	if isVpcSTSEndpoint(cp) {
+		envs["ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED"] = "true"
 	}
 	if cp.ExternalAccountType != "" {
 		envs["ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE"] = cp.ExternalAccountType

--- a/config/profile.go
+++ b/config/profile.go
@@ -313,20 +313,12 @@ func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
 		cp.RegionId = util.GetFromEnv("ALIBABA_CLOUD_REGION_ID", "ALIBABACLOUD_REGION_ID", "ALICLOUD_REGION_ID", "REGION_ID", "REGION")
 	}
 
-	if cp.StsRegion == "" {
-		cp.StsRegion = util.GetFromEnv("ALIBABA_CLOUD_STS_REGION", "ALIBABACLOUD_STS_REGION")
-	}
-
 	if cp.StsEndpoint == "" {
-		cp.StsEndpoint = util.GetFromEnv("ALIBABA_CLOUD_STS_ENDPOINT", "ALIBABACLOUD_STS_ENDPOINT")
+		cp.StsEndpoint = os.Getenv("ALIBABA_CLOUD_STS_ENDPOINT")
 	}
 
 	if cp.EndpointType == "" {
 		cp.EndpointType = util.GetFromEnv("ALIBABA_CLOUD_ENDPOINT_TYPE", "ALIBABACLOUD_ENDPOINT_TYPE", "ALICLOUD_ENDPOINT_TYPE", "ENDPOINT_TYPE")
-	}
-
-	if cp.EndpointType == "" && isVpcEndpointEnabled() {
-		cp.EndpointType = "vpc"
 	}
 
 	if cp.Endpoint == "" {
@@ -427,25 +419,6 @@ func getSTSEndpoint(regionId string) string {
 	return "sts.aliyuncs.com"
 }
 
-func isVpcEndpointEnabled() bool {
-	v := strings.ToLower(strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")))
-	return v == "true" || v == "1"
-}
-
-func isVpcSTSEndpoint(cp *Profile) bool {
-	if strings.EqualFold(cp.EndpointType, "vpc") {
-		return true
-	}
-	return isVpcEndpointEnabled()
-}
-
-func stsRegionForProfile(cp *Profile) string {
-	if cp.StsRegion != "" {
-		return cp.StsRegion
-	}
-	return cp.RegionId
-}
-
 func normalizeSTSEndpointHost(endpoint string) string {
 	endpoint = strings.TrimSpace(endpoint)
 	endpoint = strings.TrimPrefix(endpoint, "https://")
@@ -457,11 +430,7 @@ func resolveSTSEndpoint(cp *Profile) string {
 	if cp.StsEndpoint != "" {
 		return normalizeSTSEndpointHost(cp.StsEndpoint)
 	}
-	regionId := stsRegionForProfile(cp)
-	if isVpcSTSEndpoint(cp) && regionId != "" {
-		return fmt.Sprintf("sts-vpc.%s.aliyuncs.com", regionId)
-	}
-	return getSTSEndpoint(regionId)
+	return getSTSEndpoint(cp.StsRegion)
 }
 
 // mergeProfileAfterCredentialRefresh persists STS / OAuth token fields from the in-memory profile onto the on-disk profile.
@@ -853,12 +822,6 @@ func (cp *Profile) GetRuntimeEnv(ctx *cli.Context) (map[string]string, error) {
 	}
 	if cp.StsEndpoint != "" {
 		envs["ALIBABA_CLOUD_STS_ENDPOINT"] = cp.StsEndpoint
-	}
-	if cp.StsRegion != "" {
-		envs["ALIBABA_CLOUD_STS_REGION"] = cp.StsRegion
-	}
-	if isVpcSTSEndpoint(cp) {
-		envs["ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED"] = "true"
 	}
 	if cp.ExternalAccountType != "" {
 		envs["ALIBABA_CLOUD_EXTERNAL_ACCOUNT_TYPE"] = cp.ExternalAccountType

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -573,6 +573,54 @@ func TestGetStsEndpoint(t *testing.T) {
 	assert.Equal(t, "sts.cn-hangzhou.aliyuncs.com", getSTSEndpoint("cn-hangzhou"))
 }
 
+func TestResolveStsEndpoint(t *testing.T) {
+	cp := &Profile{RegionId: "cn-hangzhou"}
+	assert.Equal(t, "sts.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
+
+	cp = &Profile{StsRegion: "cn-beijing"}
+	assert.Equal(t, "sts.cn-beijing.aliyuncs.com", resolveSTSEndpoint(cp))
+
+	cp = &Profile{RegionId: "cn-hangzhou", EndpointType: "vpc"}
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
+
+	cp = &Profile{StsRegion: "cn-shanghai", EndpointType: "VPC"}
+	assert.Equal(t, "sts-vpc.cn-shanghai.aliyuncs.com", resolveSTSEndpoint(cp))
+
+	cp = &Profile{RegionId: "cn-hangzhou", StsEndpoint: "https://sts-vpc.cn-hangzhou.aliyuncs.com/"}
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
+
+	cp = &Profile{RegionId: "cn-hangzhou", EndpointType: "vpc"}
+	os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true")
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
+	os.Unsetenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")
+
+	cp = &Profile{RegionId: "cn-hangzhou"}
+	os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true")
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
+	os.Unsetenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")
+}
+
+func TestOverwriteWithFlagsStsEndpointEnv(t *testing.T) {
+	ctx := newCtx()
+	actual := &Profile{Name: "default", RegionId: "cn-hangzhou"}
+
+	os.Setenv("ALIBABA_CLOUD_STS_ENDPOINT", "sts-vpc.cn-hangzhou.aliyuncs.com")
+	actual.OverwriteWithFlags(ctx)
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", actual.StsEndpoint)
+	os.Unsetenv("ALIBABA_CLOUD_STS_ENDPOINT")
+
+	os.Setenv("ALIBABA_CLOUD_STS_REGION", "cn-beijing")
+	actual.OverwriteWithFlags(ctx)
+	assert.Equal(t, "cn-beijing", actual.StsRegion)
+	os.Unsetenv("ALIBABA_CLOUD_STS_REGION")
+
+	os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true")
+	actual.EndpointType = ""
+	actual.OverwriteWithFlags(ctx)
+	assert.Equal(t, "vpc", actual.EndpointType)
+	os.Unsetenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")
+}
+
 func TestNormalizeMode(t *testing.T) {
 	assert.Equal(t, OAuth, NormalizeMode("oauth"))
 	assert.Equal(t, OAuth, NormalizeMode("OAuth"))

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -574,30 +574,17 @@ func TestGetStsEndpoint(t *testing.T) {
 }
 
 func TestResolveStsEndpoint(t *testing.T) {
-	cp := &Profile{RegionId: "cn-hangzhou"}
+	cp := &Profile{StsRegion: "cn-hangzhou"}
 	assert.Equal(t, "sts.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
 
 	cp = &Profile{StsRegion: "cn-beijing"}
 	assert.Equal(t, "sts.cn-beijing.aliyuncs.com", resolveSTSEndpoint(cp))
 
-	cp = &Profile{RegionId: "cn-hangzhou", EndpointType: "vpc"}
+	cp = &Profile{StsRegion: "cn-hangzhou", StsEndpoint: "https://sts-vpc.cn-hangzhou.aliyuncs.com/"}
 	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
 
-	cp = &Profile{StsRegion: "cn-shanghai", EndpointType: "VPC"}
-	assert.Equal(t, "sts-vpc.cn-shanghai.aliyuncs.com", resolveSTSEndpoint(cp))
-
-	cp = &Profile{RegionId: "cn-hangzhou", StsEndpoint: "https://sts-vpc.cn-hangzhou.aliyuncs.com/"}
+	cp = &Profile{StsRegion: "cn-hangzhou", StsEndpoint: "sts-vpc.cn-hangzhou.aliyuncs.com"}
 	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
-
-	cp = &Profile{RegionId: "cn-hangzhou", EndpointType: "vpc"}
-	os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true")
-	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
-	os.Unsetenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")
-
-	cp = &Profile{RegionId: "cn-hangzhou"}
-	os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true")
-	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
-	os.Unsetenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")
 }
 
 func TestOverwriteWithFlagsStsEndpointEnv(t *testing.T) {
@@ -609,16 +596,11 @@ func TestOverwriteWithFlagsStsEndpointEnv(t *testing.T) {
 	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", actual.StsEndpoint)
 	os.Unsetenv("ALIBABA_CLOUD_STS_ENDPOINT")
 
-	os.Setenv("ALIBABA_CLOUD_STS_REGION", "cn-beijing")
+	os.Setenv("ALIBABACLOUD_STS_ENDPOINT", "sts-vpc.cn-shanghai.aliyuncs.com")
+	actual.StsEndpoint = ""
 	actual.OverwriteWithFlags(ctx)
-	assert.Equal(t, "cn-beijing", actual.StsRegion)
-	os.Unsetenv("ALIBABA_CLOUD_STS_REGION")
-
-	os.Setenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED", "true")
-	actual.EndpointType = ""
-	actual.OverwriteWithFlags(ctx)
-	assert.Equal(t, "vpc", actual.EndpointType)
-	os.Unsetenv("ALIBABA_CLOUD_VPC_ENDPOINT_ENABLED")
+	assert.Equal(t, "", actual.StsEndpoint)
+	os.Unsetenv("ALIBABACLOUD_STS_ENDPOINT")
 }
 
 func TestNormalizeMode(t *testing.T) {

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -22,10 +22,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
 
+	credentialsv2 "github.com/aliyun/credentials-go/credentials"
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cloudsso"
 
@@ -573,6 +575,12 @@ func TestGetStsEndpoint(t *testing.T) {
 	assert.Equal(t, "sts.cn-hangzhou.aliyuncs.com", getSTSEndpoint("cn-hangzhou"))
 }
 
+func TestNormalizeStsEndpointHost(t *testing.T) {
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", normalizeSTSEndpointHost("  https://sts-vpc.cn-hangzhou.aliyuncs.com/  "))
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", normalizeSTSEndpointHost("http://sts-vpc.cn-hangzhou.aliyuncs.com"))
+	assert.Equal(t, "sts.aliyuncs.com", normalizeSTSEndpointHost("sts.aliyuncs.com"))
+}
+
 func TestResolveStsEndpoint(t *testing.T) {
 	cp := &Profile{StsRegion: "cn-hangzhou"}
 	assert.Equal(t, "sts.cn-hangzhou.aliyuncs.com", resolveSTSEndpoint(cp))
@@ -601,6 +609,113 @@ func TestOverwriteWithFlagsStsEndpointEnv(t *testing.T) {
 	actual.OverwriteWithFlags(ctx)
 	assert.Equal(t, "", actual.StsEndpoint)
 	os.Unsetenv("ALIBABACLOUD_STS_ENDPOINT")
+}
+
+func TestOverwriteWithFlagsStsEndpointFlag(t *testing.T) {
+	ctx := newCtx()
+	StsEndpointFlag(ctx.Flags()).SetAssigned(true)
+	StsEndpointFlag(ctx.Flags()).SetValue("sts-vpc.cn-beijing.aliyuncs.com")
+	actual := &Profile{Name: "default", StsEndpoint: "sts-vpc.cn-hangzhou.aliyuncs.com"}
+	actual.OverwriteWithFlags(ctx)
+	assert.Equal(t, "sts-vpc.cn-beijing.aliyuncs.com", actual.StsEndpoint)
+}
+
+func credentialSTSEndpoint(t *testing.T, cred credentialsv2.Credential) string {
+	t.Helper()
+	rv := reflect.ValueOf(cred)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		t.Fatal("credential must be a non-nil pointer")
+	}
+	rv = rv.Elem()
+	providerField := rv.FieldByName("provider")
+	if !providerField.IsValid() {
+		providerField = rv
+	}
+	for providerField.Kind() == reflect.Ptr || providerField.Kind() == reflect.Interface {
+		if providerField.IsNil() {
+			t.Fatal("credential provider is nil")
+		}
+		providerField = providerField.Elem()
+	}
+	if stsField := providerField.FieldByName("stsEndpoint"); stsField.IsValid() {
+		return stsField.String()
+	}
+	if runtimeField := providerField.FieldByName("runtime"); runtimeField.IsValid() && !runtimeField.IsNil() {
+		if runtimeField.Kind() == reflect.Ptr {
+			runtimeField = runtimeField.Elem()
+		}
+		if endpoint := runtimeField.FieldByName("STSEndpoint"); endpoint.IsValid() {
+			return endpoint.String()
+		}
+	}
+	t.Fatal("provider has no sts endpoint field")
+	return ""
+}
+
+func TestGetCredentialWithOIDCStsEndpoint(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "oidc-token-*")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.WriteString("dummy-oidc-token")
+	assert.NoError(t, err)
+	tmpFile.Close()
+
+	actual := newProfile()
+	actual.Mode = OIDC
+	actual.OIDCProviderARN = "acs:ram::123456789:oidc-provider/test"
+	actual.OIDCTokenFile = tmpFile.Name()
+	actual.RamRoleArn = "acs:ram::123456789:role/test"
+	actual.RoleSessionName = "ack-session"
+	actual.StsEndpoint = "https://sts-vpc.cn-hangzhou.aliyuncs.com/"
+
+	credential, err := actual.GetCredential(newCtx(), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, credential)
+	assert.Equal(t, "oidc_role_arn", *credential.GetType())
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", credentialSTSEndpoint(t, credential))
+}
+
+func TestGetCredentialWithRamRoleArnStsEndpoint(t *testing.T) {
+	actual := newProfile()
+	actual.Mode = RamRoleArn
+	actual.AccessKeyId = "akid"
+	actual.AccessKeySecret = "skid"
+	actual.RamRoleArn = "ramRoleArn"
+	actual.RoleSessionName = "roleSessionName"
+	actual.ExpiredSeconds = 3600
+	actual.StsEndpoint = "sts-vpc.cn-hangzhou.aliyuncs.com"
+
+	credential, err := actual.GetCredential(newCtx(), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, credential)
+	assert.Equal(t, "ram_role_arn", *credential.GetType())
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", credentialSTSEndpoint(t, credential))
+}
+
+func TestGetRuntimeEnv_StsEndpoint(t *testing.T) {
+	p := newProfile()
+	p.Mode = AK
+	p.AccessKeyId = "ak"
+	p.AccessKeySecret = "sk"
+	p.RegionId = "cn-hangzhou"
+	p.StsEndpoint = "sts-vpc.cn-hangzhou.aliyuncs.com"
+
+	envs, err := p.GetRuntimeEnv(newCtx())
+	assert.NoError(t, err)
+	assert.Equal(t, "sts-vpc.cn-hangzhou.aliyuncs.com", envs["ALIBABA_CLOUD_STS_ENDPOINT"])
+}
+
+func TestGetRuntimeEnv_StsEndpointOmitted(t *testing.T) {
+	p := newProfile()
+	p.Mode = AK
+	p.AccessKeyId = "ak"
+	p.AccessKeySecret = "sk"
+	p.RegionId = "cn-hangzhou"
+
+	envs, err := p.GetRuntimeEnv(newCtx())
+	assert.NoError(t, err)
+	_, has := envs["ALIBABA_CLOUD_STS_ENDPOINT"]
+	assert.False(t, has)
 }
 
 func TestNormalizeMode(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `--sts-endpoint` profile/flag and `ALIBABA_CLOUD_STS_ENDPOINT` env to override STS host for credential refresh (OIDC, RamRoleArn, etc.).
- When unset, STS endpoint resolution keeps the existing default behavior (`sts.<region>.aliyuncs.com`).
- Backward compatible: no change unless an explicit STS endpoint is configured.