### PR TITLE
feat(openapi): add --estimate-cost-context to pass PricingContext to quotes

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -170,6 +170,15 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				"        run `aliyun --list-supported-pricing-apis` to see every API that supports cost estimation")
 	}
 
+	// --estimate-cost-context only makes sense alongside --estimate-cost (it
+	// supplies PricingContext for the quote). Reject it standalone so a
+	// forgotten --estimate-cost doesn't silently run the real API.
+	if EstimateCostContextFlag(ctx.Flags()).IsAssigned() && !EstimateCostFlag(ctx.Flags()).IsAssigned() {
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost-context requires --estimate-cost"),
+			"add --estimate-cost, e.g. aliyun ecs RunInstances ... --estimate-cost --estimate-cost-context EstimatedInternetTrafficOutGB=100")
+	}
+
 	// aliyun
 	if len(args) == 0 {
 		c.printUsage(ctx)

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -3701,3 +3701,26 @@ func TestMain_SafetyPolicyEnforcement(t *testing.T) {
 		assert.Contains(t, err.Error(), "fc:create-function")
 	})
 }
+
+func TestEstimateCostContextRequiresEstimateCost(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	profile := config.Profile{Mode: config.AK, AccessKeyId: "id", AccessKeySecret: "secret", RegionId: "cn-hangzhou"}
+	command := NewCommando(w, profile)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	command.InitWithCommand(cmd)
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	// context assigned but --estimate-cost NOT assigned → must fail loudly.
+	f := EstimateCostContextFlag(ctx.Flags())
+	f.SetAssigned(true)
+	f.SetValues([]string{"EstimatedInternetTrafficOutGB=100"})
+
+	err := command.main(ctx, []string{"ecs", "RunInstances"})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--estimate-cost-context requires --estimate-cost")
+}

--- a/openapi/estimate_cost.go
+++ b/openapi/estimate_cost.go
@@ -33,12 +33,12 @@ import (
 //	ALIBABA_CLOUD_PRICING_ENDPOINT — default cloudcontrol.aliyuncs.com
 //	ALIBABA_CLOUD_PRICING_HOST     — Host header when endpoint is a CNAME
 const (
-	estimateCostApiVersion   = "2022-08-30"
-	estimateCostQuotePath    = "/api/v1/price/quote"
-	estimateCostEndpointEnv  = "ALIBABA_CLOUD_PRICING_ENDPOINT"
-	estimateCostHostEnv      = "ALIBABA_CLOUD_PRICING_HOST"
-	defaultEstimateCostHost  = "cloudcontrol.aliyuncs.com"
-	estimateCostProductCode  = "cloudcontrol"
+	estimateCostApiVersion  = "2022-08-30"
+	estimateCostQuotePath   = "/api/v1/price/quote"
+	estimateCostEndpointEnv = "ALIBABA_CLOUD_PRICING_ENDPOINT"
+	estimateCostHostEnv     = "ALIBABA_CLOUD_PRICING_HOST"
+	defaultEstimateCostHost = "cloudcontrol.aliyuncs.com"
+	estimateCostProductCode = "cloudcontrol"
 )
 
 type estimateCostRequest struct {
@@ -63,6 +63,18 @@ func (c *Commando) processEstimateCost(ctx *cli.Context, inv Invoker) error {
 	parameters, err := buildEstimateCostParameters(req)
 	if err != nil {
 		return err
+	}
+
+	// PricingContext (--estimate-cost-context): pricing-only assumptions/state
+	// overrides. Nested inside `parameters` as a sibling of the API params —
+	// the quote service reads the whole parameters object as `request` and
+	// mapping expressions reference request.PricingContext.<key>.
+	pricingContext, err := buildPricingContext(ctx)
+	if err != nil {
+		return err
+	}
+	if len(pricingContext) > 0 {
+		parameters["PricingContext"] = pricingContext
 	}
 
 	out, err := invokeEstimateCost(ctx, &c.profile, req.Product, req.Version, apiName, parameters)
@@ -131,6 +143,30 @@ func buildEstimateCostParameters(req *requests.CommonRequest) (map[string]interf
 		}
 	}
 	return parameters, nil
+}
+
+// buildPricingContext collects `--estimate-cost-context Key=Value` entries into
+// a map for nesting under parameters.PricingContext. Repeatable and multi-value
+// (`--estimate-cost-context K1=V1 K2=V2`). Split on the FIRST `=` so values may
+// contain `=`. Keys are not validated — PricingContext is mapping-defined and
+// evolving; the quote service validates. Empty value allowed; empty key rejected.
+// Returns (nil, nil) when the flag is absent.
+func buildPricingContext(ctx *cli.Context) (map[string]interface{}, error) {
+	f := EstimateCostContextFlag(ctx.Flags())
+	if f == nil || !f.IsAssigned() {
+		return nil, nil
+	}
+	pc := make(map[string]interface{})
+	for _, s := range f.GetValues() {
+		k, v, ok := cli.SplitStringWithPrefix(s, "=")
+		if !ok || k == "" {
+			return nil, cli.NewErrorWithTip(
+				fmt.Errorf("invalid --estimate-cost-context `%s`", s),
+				"use `--estimate-cost-context Key=Value`, e.g. --estimate-cost-context EstimatedInternetTrafficOutGB=100")
+		}
+		pc[k] = v
+	}
+	return pc, nil
 }
 
 func estimateCostEndpoint() string {

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -287,3 +287,125 @@ func TestMainEstimateCostMissingProductOrApi(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "--estimate-cost requires a product and an API name")
 }
+
+// helper: build a context with flags and assign --estimate-cost-context values.
+func ctxWithPricingContext(values []string) *cli.Context {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	if values != nil {
+		f := EstimateCostContextFlag(ctx.Flags())
+		f.SetAssigned(true)
+		f.SetValues(values)
+	}
+	return ctx
+}
+
+func TestBuildPricingContextMultiValue(t *testing.T) {
+	ctx := ctxWithPricingContext([]string{"EstimatedInternetTrafficOutGB=100", "InternetChargeType=PayByTraffic"})
+	pc, err := buildPricingContext(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"EstimatedInternetTrafficOutGB": "100",
+		"InternetChargeType":            "PayByTraffic",
+	}, pc)
+}
+
+func TestBuildPricingContextFirstEqualsSplit(t *testing.T) {
+	// value may contain '=' — split on the FIRST '=' only.
+	ctx := ctxWithPricingContext([]string{"Expr=a==b"})
+	pc, err := buildPricingContext(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "a==b", pc["Expr"])
+}
+
+func TestBuildPricingContextEmptyValueAllowed(t *testing.T) {
+	ctx := ctxWithPricingContext([]string{"EipAllocationId="})
+	pc, err := buildPricingContext(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "", pc["EipAllocationId"])
+}
+
+func TestBuildPricingContextMalformedNoEquals(t *testing.T) {
+	ctx := ctxWithPricingContext([]string{"novalue"})
+	_, err := buildPricingContext(ctx)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "novalue")
+}
+
+func TestBuildPricingContextEmptyKeyRejected(t *testing.T) {
+	ctx := ctxWithPricingContext([]string{"=100"})
+	_, err := buildPricingContext(ctx)
+	assert.NotNil(t, err)
+}
+
+func TestBuildPricingContextUnassigned(t *testing.T) {
+	ctx := ctxWithPricingContext(nil)
+	pc, err := buildPricingContext(ctx)
+	assert.Nil(t, err)
+	assert.Nil(t, pc)
+}
+
+func TestProcessInvokeEstimateCostWithContext(t *testing.T) {
+	// --estimate-cost + --estimate-cost-context: exercises the PricingContext
+	// nesting in processEstimateCost, then fails on an unresolvable host
+	// (proving the quote request — with the nested context — was assembled and
+	// sent, not the target API).
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	profile := config.NewProfile("test-estimate-cost")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+	command := NewCommando(w, profile)
+
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+	cf := EstimateCostContextFlag(ctx.Flags())
+	cf.SetAssigned(true)
+	cf.SetValues([]string{"EstimatedInternetTrafficOutGB=100", "InternetChargeType=PayByTraffic"})
+
+	err := command.processInvoke(ctx, "ecs", "DescribeRegions", "")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+}
+
+func TestProcessInvokeEstimateCostContextMalformed(t *testing.T) {
+	// A malformed --estimate-cost-context entry must abort before any network
+	// call (buildPricingContext error propagates out of processEstimateCost).
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	profile := config.NewProfile("test-estimate-cost")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+	command := NewCommando(w, profile)
+
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+	cf := EstimateCostContextFlag(ctx.Flags())
+	cf.SetAssigned(true)
+	cf.SetValues([]string{"novalue"})
+
+	err := command.processInvoke(ctx, "ecs", "DescribeRegions", "")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "novalue")
+}

--- a/openapi/flags.go
+++ b/openapi/flags.go
@@ -33,6 +33,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(NewDryRunFlag())
 	fs.Add(NewDryRunJsonFlag())
 	fs.Add(NewEstimateCostFlag())
+	fs.Add(NewEstimateCostContextFlag())
 	fs.Add(NewQuietFlag())
 	fs.Add(NewLogLevelFlag())
 	fs.Add(NewYesFlag())
@@ -45,27 +46,28 @@ func AddFlags(fs *cli.FlagSet) {
 }
 
 const (
-	SecureFlagName        = "secure"
-	InsecureFlagName      = "insecure"
-	ForceFlagName         = "force"
-	VersionFlagName       = "version"
-	HeaderFlagName        = "header"
-	BodyFlagName          = "body"
-	BodyFileFlagName      = "body-file"
-	AcceptFlagName        = "accept"
-	RoaFlagName           = "roa"
-	DryRunFlagName        = "dryrun"
-	CliDryRunJsonFlagName = "cli-dry-run-json"
-	EstimateCostFlagName  = "estimate-cost"
-	QuietFlagName         = "quiet"
-	LogLevelFlagName      = "log-level"
-	YesFlagName           = "yes"
-	QueryFlagName         = "cli-query"
-	OutputFlagName        = "output"
-	MethodFlagName        = "method"
-	UserAgentFlagName     = "user-agent"
-	CliAIModeFlagName     = "cli-ai-mode"
-	CliNoAIModeFlagName   = "no-cli-ai-mode"
+	SecureFlagName              = "secure"
+	InsecureFlagName            = "insecure"
+	ForceFlagName               = "force"
+	VersionFlagName             = "version"
+	HeaderFlagName              = "header"
+	BodyFlagName                = "body"
+	BodyFileFlagName            = "body-file"
+	AcceptFlagName              = "accept"
+	RoaFlagName                 = "roa"
+	DryRunFlagName              = "dryrun"
+	CliDryRunJsonFlagName       = "cli-dry-run-json"
+	EstimateCostFlagName        = "estimate-cost"
+	EstimateCostContextFlagName = "estimate-cost-context"
+	QuietFlagName               = "quiet"
+	LogLevelFlagName            = "log-level"
+	YesFlagName                 = "yes"
+	QueryFlagName               = "cli-query"
+	OutputFlagName              = "output"
+	MethodFlagName              = "method"
+	UserAgentFlagName           = "user-agent"
+	CliAIModeFlagName           = "cli-ai-mode"
+	CliNoAIModeFlagName         = "no-cli-ai-mode"
 )
 
 func OutputFlag(fs *cli.FlagSet) *cli.Flag {
@@ -299,6 +301,28 @@ func NewEstimateCostFlag() *cli.Flag {
 
 func EstimateCostFlag(fs *cli.FlagSet) *cli.Flag {
 	return fs.Get(EstimateCostFlagName)
+}
+
+// NewEstimateCostContextFlag registers `--estimate-cost-context Key=Value`, a
+// companion to --estimate-cost that supplies PricingContext entries (usage
+// assumptions / future-state overrides, e.g. EstimatedInternetTrafficOutGB=100).
+// Repeatable and multi-value: `--estimate-cost-context K1=V1 K2=V2`. Keys are
+// not validated here — PricingContext is mapping-defined and evolving; the
+// server validates. Must accompany --estimate-cost (enforced in commando.go).
+func NewEstimateCostContextFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "caller",
+		Name:         EstimateCostContextFlagName,
+		AssignedMode: cli.AssignedRepeatable,
+		Short: i18n.T(
+			"use `--estimate-cost-context Key=Value` to pass PricingContext entries to --estimate-cost (e.g. EstimatedInternetTrafficOutGB=100), repeatable or multi-value",
+			"配合 `--estimate-cost` 使用 `--estimate-cost-context Key=Value` 传递 PricingContext 询价假设（如 EstimatedInternetTrafficOutGB=100），可多值或多次指定",
+		),
+	}
+}
+
+func EstimateCostContextFlag(fs *cli.FlagSet) *cli.Flag {
+	return fs.Get(EstimateCostContextFlagName)
 }
 
 func NewQuietFlag() *cli.Flag {


### PR DESCRIPTION
## What

Adds `--estimate-cost-context Key=Value`, a companion to `--estimate-cost`. It carries PricingContext entries — pricing-only inputs that are **not** API parameters, such as usage assumptions (`EstimatedInternetTrafficOutGB=100`) or future-state overrides (`InternetChargeType=PayByTraffic`) used to price a step that depends on an earlier one.

Entries nest under `parameters.PricingContext` in the GetApiPrice request body.

## Why

Some quotes need inputs the target API doesn't accept — a pay-by-traffic estimate needs an assumed traffic volume; a multi-step change needs to model the state after prior steps. Before this, users had to bypass the CLI and hand-craft the raw `POST /api/v1/price/quote` JSON. This exposes that capability as a first-class flag.

## Usage

```bash
aliyun ecs ModifyInstanceNetworkSpec --RegionId cn-hangzhou --InstanceId i-xxx \
  --NetworkChargeType PayByTraffic \
  --estimate-cost --estimate-cost-context EstimatedInternetTrafficOutGB=100
```

## Behavior

- Repeatable and multi-value: `--estimate-cost-context K1=V1 K2=V2`
- Split on the first `=` (values may contain `=`); empty value allowed, empty key rejected
- Keys are not validated — PricingContext is mapping-defined and evolving; the server validates
- Errors when used without `--estimate-cost`

## Tests

New unit tests cover the parsing branches, nesting into the request body, and the "requires --estimate-cost" guard.
