### PR TITLE
feat: show unified and legacy CLI examples in API help output

### DIFF
--- a/newmeta/meta.go
+++ b/newmeta/meta.go
@@ -101,6 +101,13 @@ type APIDetail struct {
 	Method      string             `json:"method"`
 	PathPattern string             `json:"pathPattern"`
 	Parameters  []RequestParameter `json:"parameters"`
+	Example     *APIExample        `json:"example,omitempty"`
+}
+
+// APIExample holds recommended CLI examples in both unified (new) and legacy formats.
+type APIExample struct {
+	UnifiedCli string `json:"unifiedCli,omitempty"`
+	LegacyCli  string `json:"legacyCli,omitempty"`
 }
 
 func (api *APIDetail) IsAnonymousAPI() bool {

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -404,6 +404,17 @@ func (c *Commando) printApiUsage(ctx *cli.Context, productCode string, apiName s
 	printParameters(w, api.Parameters, "", detail)
 	w.Flush()
 
+	// Print example if available
+	if detail != nil && detail.Example != nil {
+		cli.Printf(ctx.Stdout(), "\nExample:\n")
+		if detail.Example.UnifiedCli != "" {
+			cli.Printf(ctx.Stdout(), "  (Recommended) New CLI:\n  %s\n", detail.Example.UnifiedCli)
+		}
+		if detail.Example.LegacyCli != "" {
+			cli.Printf(ctx.Stdout(), "  Legacy CLI:\n  %s\n", detail.Example.LegacyCli)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
- Add APIExample struct and Example field to APIDetail in newmeta/meta.go
- Display (Recommended) New CLI and Legacy CLI examples in printApiUsage
- Examples sourced from embedded aliyun-openapi-meta JSON data
- Only show Example section when example data is available