### PR TITLE
feat(mock): add delay_ms field to simulate command execution latency

### DIFF
--- a/mock/command.go
+++ b/mock/command.go
@@ -72,7 +72,7 @@ Workflow:
 func newAddCommand(defaultConfigDir func() string) *cli.Command {
 	cmd := &cli.Command{
 		Name:  "add",
-		Usage: "add --name <name> --cmd <rule> --exit-code <code> --times <count> [--stdout <text>] [--stderr <text>]",
+		Usage: "add --name <name> --cmd <rule> --exit-code <code> --times <count> [--stdout <text>] [--stderr <text>] [--delay-ms <milliseconds>]",
 		Short: i18n.T("add one mock record", "添加一条 mock 记录"),
 		Run: func(ctx *cli.Context, args []string) error {
 			if len(args) > 0 {
@@ -141,6 +141,7 @@ func addRecordFlags(cmd *cli.Command) {
 		{"stdout", i18n.T("mock command stdout", "模拟命令标准输出")},
 		{"stderr", i18n.T("mock command stderr", "模拟命令标准错误")},
 		{"times", i18n.T("match count; 0 means unlimited", "匹配次数；0 表示不限次数")},
+		{"delay-ms", i18n.T("mock command execution delay in milliseconds; 0 means no delay", "模拟命令执行延迟（毫秒）；0 表示不延迟")},
 	} {
 		cmd.Flags().Add(&cli.Flag{
 			Name:         flag.name,
@@ -196,6 +197,16 @@ func recordFromFlags(ctx *cli.Context) (sysmock.Record, error) {
 		Stderr:   stderr,
 		Times:    times,
 	}
+	if delayFlag := ctx.Flags().Get("delay-ms"); delayFlag != nil && delayFlag.IsAssigned() {
+		delayText, _ := delayFlag.GetValue()
+		if delayText != "" {
+			delayMs, err := strconv.Atoi(delayText)
+			if err != nil {
+				return sysmock.Record{}, fmt.Errorf("invalid --delay-ms %q", delayText)
+			}
+			record.DelayMs = delayMs
+		}
+	}
 	if err := sysmock.ValidateRecord(record); err != nil {
 		return sysmock.Record{}, err
 	}
@@ -240,7 +251,7 @@ func addMissingFlagsMessage(missing []string) string {
 	return fmt.Sprintf(`missing required flags: %s
 
 Example:
-  aliyun mock add --name mock-ecs-version --cmd 'ecs *' --exit-code 0 --stdout 'ecs 1.0.0\n' --stderr 'mock stderr\n' --times 10`, strings.Join(missing, ", "))
+  aliyun mock add --name mock-ecs-version --cmd 'ecs *' --exit-code 0 --stdout 'ecs 1.0.0\n' --stderr 'mock stderr\n' --times 10 --delay-ms 500`, strings.Join(missing, ", "))
 }
 
 func requiredFlag(ctx *cli.Context, name string) (string, error) {
@@ -272,6 +283,7 @@ Fields:
   stdout    required mocked command stdout
   stderr    required mocked command stderr
   times     required match count; 0 means unlimited
+  delay_ms  optional execution delay in milliseconds before returning output; 0 means no delay
 
 Example:
 [
@@ -281,7 +293,8 @@ Example:
     "exit_code": 0,
     "stdout": "ecs 1.0.0\n",
     "stderr": "",
-    "times": 10
+    "times": 10,
+    "delay_ms": 500
   }
 ]`, `
 JSON 输入格式:
@@ -295,6 +308,7 @@ JSON 输入格式:
   stdout    必填的模拟命令标准输出
   stderr    必填的模拟命令标准错误
   times     必填的匹配次数；0 表示不限次数
+  delay_ms  可选的执行延迟（毫秒），在返回输出前等待；0 表示不延迟
 
 示例:
 [
@@ -304,7 +318,8 @@ JSON 输入格式:
     "exit_code": 0,
     "stdout": "ecs 1.0.0\n",
     "stderr": "",
-    "times": 10
+    "times": 10,
+    "delay_ms": 500
   }
 ]`).Text())
 	cmd.PrintTail(ctx)

--- a/mock/command_test.go
+++ b/mock/command_test.go
@@ -41,7 +41,7 @@ func TestMockAddFlagsAreNotPersistent(t *testing.T) {
 		t.Fatal("add subcommand is nil")
 	}
 
-	for _, name := range []string{"name", "cmd", "exit-code", "stdout", "stderr", "times"} {
+	for _, name := range []string{"name", "cmd", "exit-code", "stdout", "stderr", "times", "delay-ms"} {
 		flag := add.Flags().Get(name)
 		if flag == nil {
 			t.Fatalf("%s flag is nil", name)
@@ -66,6 +66,7 @@ func TestMockImportHelpShowsFlatJSONInputFormat(t *testing.T) {
 		`"stdout": "ecs 1.0.0\n"`,
 		`"stderr": ""`,
 		`"times": 10`,
+		`"delay_ms": 500`,
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("help stdout = %q, want contain %q", stdout, want)
@@ -109,6 +110,50 @@ func TestMockRootHelpShowsEnvironmentSetup(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("root help stdout = %q, want contain %q", stdout, want)
 		}
+	}
+}
+
+func TestMockAddWithDelayMs(t *testing.T) {
+	mockPath := filepath.Join(t.TempDir(), "mocks.json")
+	t.Setenv(sysmock.EnvMockPath, mockPath)
+
+	stdout, stderr := executeMockCommand(t, "mock", "add",
+		"--name", "delayed",
+		"--cmd", "ecs DescribeInstances",
+		"--exit-code", "0",
+		"--stdout", "ok",
+		"--stderr", "warn",
+		"--times", "10",
+		"--delay-ms", "2500",
+	)
+	if stdout != "" || stderr != "" {
+		t.Fatalf("add stdout = %q stderr = %q, want both empty", stdout, stderr)
+	}
+
+	stdout, stderr = executeMockCommand(t, "mock", "list")
+	if stderr != "" {
+		t.Fatalf("list stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"delay_ms": 2500`) {
+		t.Fatalf("list stdout = %q, want delay_ms field", stdout)
+	}
+}
+
+func TestMockAddRejectsInvalidDelayMs(t *testing.T) {
+	stdout, stderr := executeMockCommand(t, "mock", "add",
+		"--name", "bad-delay",
+		"--cmd", "ecs *",
+		"--exit-code", "0",
+		"--stdout", "ok",
+		"--stderr", "warn",
+		"--times", "0",
+		"--delay-ms", "bad",
+	)
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "invalid --delay-ms") {
+		t.Fatalf("stderr = %q, want invalid delay-ms error", stderr)
 	}
 }
 

--- a/sysconfig/mock/interceptor.go
+++ b/sysconfig/mock/interceptor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 type Options struct {
@@ -21,6 +22,7 @@ type Result struct {
 var (
 	loadRecords = Load
 	saveRecords = Save
+	sleep       = time.Sleep
 )
 
 func Intercept(opts Options) Result {
@@ -44,6 +46,10 @@ func Intercept(opts Options) Result {
 	if err := saveRecords(opts.MockPath, records); err != nil {
 		writef(opts.Stderr, "ERROR: save mock data failed %s\n", err)
 		return Result{Handled: true, ExitCode: 1}
+	}
+
+	if record.DelayMs > 0 {
+		sleep(time.Duration(record.DelayMs) * time.Millisecond)
 	}
 
 	if record.Stdout != "" {

--- a/sysconfig/mock/interceptor_test.go
+++ b/sysconfig/mock/interceptor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestInterceptDisabled(t *testing.T) {
@@ -39,6 +40,84 @@ func TestInterceptDisabled(t *testing.T) {
 	}
 	if string(data) != original {
 		t.Fatalf("file content changed: %q", string(data))
+	}
+}
+
+func TestInterceptHitAppliesDelayBeforeOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mocks.json")
+	if err := Save(path, []Record{{
+		Name:    "delayed",
+		Cmd:     "ecs *",
+		Stdout:  "mock stdout\n",
+		Times:   0,
+		DelayMs: 200,
+	}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	t.Setenv(EnvMockEnabled, "true")
+
+	var slept time.Duration
+	originalSleep := sleep
+	sleep = func(d time.Duration) {
+		slept = d
+	}
+	t.Cleanup(func() {
+		sleep = originalSleep
+	})
+
+	var stdout, stderr bytes.Buffer
+	result := Intercept(Options{
+		Args:     []string{"ecs", "DescribeRegions"},
+		Stdout:   &stdout,
+		Stderr:   &stderr,
+		MockPath: path,
+	})
+
+	if !result.Handled {
+		t.Fatalf("Handled = false, want true")
+	}
+	if slept != 200*time.Millisecond {
+		t.Fatalf("sleep duration = %v, want 200ms", slept)
+	}
+	if stdout.String() != "mock stdout\n" {
+		t.Fatalf("stdout = %q, want mock stdout", stdout.String())
+	}
+}
+
+func TestInterceptZeroDelaySkipsSleep(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mocks.json")
+	if err := Save(path, []Record{{
+		Name:   "instant",
+		Cmd:    "ecs *",
+		Stdout: "mock stdout\n",
+		Times:  0,
+	}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	t.Setenv(EnvMockEnabled, "true")
+
+	called := false
+	originalSleep := sleep
+	sleep = func(time.Duration) {
+		called = true
+	}
+	t.Cleanup(func() {
+		sleep = originalSleep
+	})
+
+	var stdout, stderr bytes.Buffer
+	result := Intercept(Options{
+		Args:     []string{"ecs", "DescribeRegions"},
+		Stdout:   &stdout,
+		Stderr:   &stderr,
+		MockPath: path,
+	})
+
+	if !result.Handled {
+		t.Fatalf("Handled = false, want true")
+	}
+	if called {
+		t.Fatal("sleep called, want skipped for zero delay")
 	}
 }
 

--- a/sysconfig/mock/store.go
+++ b/sysconfig/mock/store.go
@@ -119,6 +119,12 @@ func validateRecord(record Record) error {
 	if record.Times < 0 {
 		return fmt.Errorf("mock record times must be greater than or equal to 0")
 	}
+	if record.DelayMs < 0 {
+		return fmt.Errorf("mock record delay_ms must be greater than or equal to 0")
+	}
+	if record.DelayMs > MaxDelayMs {
+		return fmt.Errorf("mock record delay_ms must be less than or equal to %d", MaxDelayMs)
+	}
 	return nil
 }
 

--- a/sysconfig/mock/store_test.go
+++ b/sysconfig/mock/store_test.go
@@ -105,6 +105,22 @@ func TestSaveCreatesParentDirsAndWritesIndentedJSON(t *testing.T) {
 	}
 }
 
+func TestDecodeInputAcceptsOptionalDelayMs(t *testing.T) {
+	records, err := DecodeInput([]byte(`{"name":"delayed","cmd":"ecs *","exit_code":0,"stdout":"","stderr":"","times":0,"delay_ms":1500}`))
+	if err != nil {
+		t.Fatalf("DecodeInput(delay_ms) returned error: %v", err)
+	}
+	if len(records) != 1 || records[0].DelayMs != 1500 {
+		t.Fatalf("records = %#v, want delay_ms 1500", records)
+	}
+}
+
+func TestDecodeInputRejectsNegativeDelayMs(t *testing.T) {
+	if records, err := DecodeInput([]byte(`{"name":"bad","cmd":"ecs *","exit_code":0,"stdout":"","stderr":"","times":0,"delay_ms":-1}`)); err == nil {
+		t.Fatalf("DecodeInput(negative delay_ms) = %#v, nil error", records)
+	}
+}
+
 func TestReadInputAcceptsFlatSingleObjectAndArray(t *testing.T) {
 	one, err := DecodeInput([]byte(`{"name":"one","cmd":"ecs *","exit_code":0,"stdout":"","stderr":"","times":0}`))
 	if err != nil || len(one) != 1 || one[0].Name != "one" {
@@ -178,6 +194,18 @@ func TestAppendAndClearRecords(t *testing.T) {
 	}
 	if string(data) != "[]\n" {
 		t.Fatalf("clear content = %q, want [] newline", string(data))
+	}
+}
+
+func TestValidateRecordRejectsInvalidDelayMs(t *testing.T) {
+	if err := ValidateRecord(Record{Name: "bad", Cmd: "ecs *", Times: 0, DelayMs: -1}); err == nil {
+		t.Fatal("ValidateRecord negative delay_ms returned nil error")
+	}
+	if err := ValidateRecord(Record{Name: "bad", Cmd: "ecs *", Times: 0, DelayMs: MaxDelayMs + 1}); err == nil {
+		t.Fatal("ValidateRecord excessive delay_ms returned nil error")
+	}
+	if err := ValidateRecord(Record{Name: "ok", Cmd: "ecs *", Times: 0, DelayMs: 500}); err != nil {
+		t.Fatalf("ValidateRecord valid delay_ms returned error: %v", err)
 	}
 }
 

--- a/sysconfig/mock/types.go
+++ b/sysconfig/mock/types.go
@@ -14,6 +14,8 @@ const (
 	MockFileName   = "mocks.json"
 )
 
+const MaxDelayMs = 3600000 // 1 hour
+
 type Record struct {
 	Name     string `json:"name"`
 	Cmd      string `json:"cmd"`
@@ -21,6 +23,7 @@ type Record struct {
 	Stdout   string `json:"stdout"`
 	Stderr   string `json:"stderr"`
 	Times    int    `json:"times"`
+	DelayMs  int    `json:"delay_ms,omitempty"`
 }
 
 func (r *Record) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
## Summary

- Add optional `delay_ms` field to mock records for simulating command execution latency in stress tests.
- Interceptor waits before returning mocked output; CLI `mock add` accepts `--delay-ms` and JSON import supports `delay_ms`.
- Backward compatible: omitted or zero delay preserves existing zero-latency mock behavior.