### PR TITLE
{plugin} Add alias support for plugin

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -75,6 +75,20 @@ func (c *Command) AddSubCommand(cmd *Command) {
 	c.subCommands = append(c.subCommands, cmd)
 }
 
+func (c *Command) SubCommandNames() []string {
+	if c == nil || len(c.subCommands) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(c.subCommands))
+	for _, sub := range c.subCommands {
+		if sub == nil {
+			continue
+		}
+		names = append(names, sub.Name)
+	}
+	return names
+}
+
 func (c *Command) Flags() *FlagSet {
 	if c.flags == nil {
 		c.flags = NewFlagSet()

--- a/cli/plugin/execution.go
+++ b/cli/plugin/execution.go
@@ -36,7 +36,8 @@ func IsPluginInstalled(command string) (bool, string, error) {
 	return true, pluginName, nil
 }
 
-// Plugins explicitly opt out of host profile enforcement by setting `"profileRequired": false` in their manifest.json. 
+// Plugins explicitly opt out of host profile enforcement by setting `"profileRequired": false` in their manifest.json.
+// 走同一份 findLocalPlugin 查找，因此 alias 触发的命令也会读到与主命令一致的 profileRequired 配置。
 func IsProfileRequiredForCommand(command string) bool {
 	mgr, err := NewManager()
 	if err != nil {
@@ -60,6 +61,8 @@ func ExecutePlugin(command string, args []string, ctx *cli.Context) (bool, error
 		return false, nil
 	}
 
+	// findLocalPlugin -> FindInstalledPluginInManifest 已经涵盖 alias 匹配；
+	// 插件自身在 Cobra command 上声明 Aliases，用户敲的 alias 名字通过 args 原样透传，plugin runtime 侧的 --help / usage 会显示对应命令。
 	_, plugin, err := mgr.findLocalPlugin(command)
 	if err != nil {
 		var notFoundErr *ErrPluginNotFound

--- a/cli/plugin/install_validation.go
+++ b/cli/plugin/install_validation.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"strings"
+)
+
+// 对 manifest 声明的 alias 列表做规范化和去重：
+//   - 每个 alias 单独 trim + 小写
+//   - 空 alias、与主 command 相同、与已保留过的 alias 相同的都会被剔除
+func sanitizeCommandAliases(command string, raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	cmdKey := normalizeCommandName(command)
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, a := range raw {
+		key := normalizeCommandName(a)
+		if key == "" || key == cmdKey {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+//  1. Command 不能为空（新插件必须显式声明；已安装的历史插件不走此路径）
+//  2. Command 不能是内置顶层命令
+//  3. Command 不能出现在自身 alias 列表里（sanitize 已剔除，此处再校验一次防绕过）
+//  4. 每个 alias 不能是内置命令
+//  5. 该插件的任何 command/alias 不得与本地已装的“其他”插件的 command/alias 冲突
+//  6. 与其他插件的 plugin name / short name 冲突时同样拒绝，避免歧义（如新插件 command="fc" 与已装的 aliyun-cli-fc 冲突）
+//
+// 允许同名插件覆盖自己（升级场景）：本地 plugin key == actualPluginName 时视为同一插件，跳过跨插件冲突。
+func validatePluginCommandAndAliases(local *LocalManifest, actualPluginName, incomingCommand string, incomingAliases []string) error {
+	cmdKey := normalizeCommandName(incomingCommand)
+	if cmdKey == "" {
+		return fmt.Errorf("plugin manifest: command is empty (a top-level CLI subcommand name is required)")
+	}
+	if IsReservedTopLevelCommand(cmdKey) {
+		return fmt.Errorf("plugin manifest: command %q conflicts with a built-in top-level command", cmdKey)
+	}
+
+	// 逐个 alias 做规则 3/4 校验。sanitize 保证 alias 已小写且非空，再挡一道，防止绕过 sanitize 直接调用。
+	seen := map[string]struct{}{cmdKey: {}}
+	for _, a := range incomingAliases {
+		key := normalizeCommandName(a)
+		if key == "" {
+			return fmt.Errorf("plugin manifest: alias is empty")
+		}
+		if key == cmdKey {
+			return fmt.Errorf("plugin manifest: alias %q duplicates its command", key)
+		}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("plugin manifest: alias %q is duplicated", key)
+		}
+		if IsReservedTopLevelCommand(key) {
+			return fmt.Errorf("plugin manifest: alias %q conflicts with a built-in top-level command", key)
+		}
+		seen[key] = struct{}{}
+	}
+
+	if local == nil || len(local.Plugins) == 0 {
+		return nil
+	}
+
+	// 遍历本地其他插件（同名视为自身升级，跳过）；
+	// 把它们的 command / aliases / 短名都汇入一张查询表进行冲突校验。
+	actualPluginNameKey := strings.ToLower(strings.TrimSpace(actualPluginName))
+	for name, p := range local.Plugins {
+		if strings.ToLower(strings.TrimSpace(name)) == actualPluginNameKey {
+			continue
+		}
+		otherKeys := collectPluginRoutingKeys(name, p)
+		for key := range seen {
+			if src, dup := otherKeys[key]; dup {
+				return fmt.Errorf("plugin manifest: command/alias %q conflicts with installed plugin %q (%s)", key, name, src)
+			}
+		}
+	}
+
+	return nil
+}
+
+// command、每个 alias、plugin name 本身以及去掉 "aliyun-cli-" 前缀后的短名。
+// value 是可读的来源描述，用于冲突错误信息。
+func collectPluginRoutingKeys(name string, lp LocalPlugin) map[string]string {
+	keys := make(map[string]string, 4)
+	if cmd := normalizeCommandName(lp.Command); cmd != "" {
+		keys[cmd] = "command"
+	}
+	for _, a := range lp.CommandAliases {
+		if key := normalizeCommandName(a); key != "" {
+			if _, exists := keys[key]; !exists {
+				keys[key] = "alias"
+			}
+		}
+	}
+	if n := normalizeCommandName(name); n != "" {
+		if _, exists := keys[n]; !exists {
+			keys[n] = "plugin name"
+		}
+	}
+	if short := normalizeCommandName(strings.TrimPrefix(strings.ToLower(strings.TrimSpace(name)), "aliyun-cli-")); short != "" && short != normalizeCommandName(name) {
+		if _, exists := keys[short]; !exists {
+			keys[short] = "plugin short name"
+		}
+	}
+	return keys
+}

--- a/cli/plugin/install_validation_test.go
+++ b/cli/plugin/install_validation_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeCommandAliases(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		raw     []string
+		want    []string
+	}{
+		{"nil input returns nil", "hologram", nil, nil},
+		{"empty entries removed", "hologram", []string{"", "  ", "hologres"}, []string{"hologres"}},
+		{"self-alias stripped", "hologram", []string{"hologram", "hologres"}, []string{"hologres"}},
+		{"duplicates removed case-insensitively", "hologram", []string{"hologres", "Hologres", "HOLOGRES"}, []string{"hologres"}},
+		{"all invalid returns nil", "hologram", []string{"", "hologram", "HOLOGRAM"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeCommandAliases(tc.command, tc.raw))
+		})
+	}
+}
+
+func TestValidatePluginCommandAndAliases(t *testing.T) {
+	// A local manifest that already has one plugin whose command / short-name / alias should trigger conflicts.
+	local := &LocalManifest{
+		Plugins: map[string]LocalPlugin{
+			"aliyun-cli-fc": {
+				Name:           "aliyun-cli-fc",
+				Command:        "fc",
+				CommandAliases: []string{"functions"},
+			},
+		},
+	}
+
+	t.Run("empty command rejected", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "", nil)
+		assert.ErrorContains(t, err, "command is empty")
+	})
+
+	t.Run("reserved command rejected", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "configure", nil)
+		assert.ErrorContains(t, err, "conflicts with a built-in top-level command")
+	})
+
+	t.Run("alias equal to command rejected", func(t *testing.T) {
+		// sanitize would normally strip this; keep the direct call to prove the second line of defense holds.
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "hologram", []string{"hologram"})
+		assert.ErrorContains(t, err, "duplicates its command")
+	})
+
+	t.Run("duplicate alias rejected", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "hologram", []string{"hologres", "hologres"})
+		assert.ErrorContains(t, err, "is duplicated")
+	})
+
+	t.Run("empty alias rejected", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "hologram", []string{""})
+		assert.ErrorContains(t, err, "alias is empty")
+	})
+
+	t.Run("alias equal to reserved rejected", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "hologram", []string{"plugin"})
+		assert.ErrorContains(t, err, "conflicts with a built-in top-level command")
+	})
+
+	t.Run("command conflicts with other plugin command", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-newfc", "fc", nil)
+		assert.ErrorContains(t, err, `command/alias "fc" conflicts with installed plugin "aliyun-cli-fc"`)
+	})
+
+	t.Run("alias conflicts with other plugin alias", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "hologram", []string{"functions"})
+		assert.ErrorContains(t, err, `command/alias "functions" conflicts with installed plugin "aliyun-cli-fc"`)
+	})
+
+	t.Run("alias conflicts with other plugin short name", func(t *testing.T) {
+		// short name of aliyun-cli-fc is "fc"; using it as alias for a new plugin must be rejected.
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-x", "hologram", []string{"fc"})
+		assert.ErrorContains(t, err, `command/alias "fc" conflicts with installed plugin "aliyun-cli-fc"`)
+	})
+
+	t.Run("same plugin overwrite skips cross-plugin checks", func(t *testing.T) {
+		// Upgrading aliyun-cli-fc to a new version: its own command/alias must not clash with itself.
+		err := validatePluginCommandAndAliases(local, "aliyun-cli-fc", "fc", []string{"functions"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("no local plugins", func(t *testing.T) {
+		err := validatePluginCommandAndAliases(nil, "aliyun-cli-x", "hologram", []string{"hologres"})
+		assert.NoError(t, err)
+
+		err = validatePluginCommandAndAliases(&LocalManifest{Plugins: map[string]LocalPlugin{}}, "aliyun-cli-x", "hologram", []string{"hologres"})
+		assert.NoError(t, err)
+	})
+}

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -305,12 +305,34 @@ func matchPluginName(pluginName, userInput string) bool {
 	return false
 }
 
+// 新增的唯一路由 key：主命令继续靠 matchPluginName（plugin name / short-name）覆盖，
+// 因为 plugin name = "aliyun-cli-" + normalize(productCode) 且 Command = normalize(productCode)，short-name 匹配天然覆盖新旧两种 manifest；
+// alias 是不派生自 plugin name 的新入口，必须显式匹配。
+func matchPluginAlias(lp LocalPlugin, userInput string) bool {
+	if len(lp.CommandAliases) == 0 {
+		return false
+	}
+	key := strings.ToLower(strings.TrimSpace(userInput))
+	if key == "" {
+		return false
+	}
+	for _, alias := range lp.CommandAliases {
+		if strings.ToLower(strings.TrimSpace(alias)) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// 匹配顺序：matchPluginName（覆盖主命令 / 完整插件名 / 历史 short-name）→ matchPluginAlias（覆盖产品方 alias）。
+// 说明：这是唯一的本地 manifest 查找入口，同时服务于执行链路和管理命令。管理命令（plugin uninstall/update/show）沿用与本函数相同的匹配语义，
+// 因此 `plugin uninstall hologres` 能命中 aliyun-cli-hologram
 func FindInstalledPluginInManifest(manifest *LocalManifest, userInput string) (pluginName string, lp *LocalPlugin, ok bool) {
 	if manifest == nil || manifest.Plugins == nil {
 		return "", nil, false
 	}
 	for name, p := range manifest.Plugins {
-		if matchPluginName(name, userInput) {
+		if matchPluginName(name, userInput) || matchPluginAlias(p, userInput) {
 			pl := p
 			return name, &pl, true
 		}
@@ -460,13 +482,31 @@ func (m *Manager) findPluginInIndex(pluginName string) (*PluginInfo, error) {
 		return nil, err
 	}
 
+	// 支持三种用户输入形式：完整 plugin name（"aliyun-cli-hologram"）、short-name（"hologram"）、 以及产品方 alias（"hologres"）。
+	// 若字段缺失，行为回退到既有的 matchPluginName 语义，不会误命中。
 	for _, p := range index.Plugins {
-		if matchPluginName(p.Name, pluginName) {
+		if matchPluginName(p.Name, pluginName) || matchPluginInfoAlias(p, pluginName) {
 			return &p, nil
 		}
 	}
 
 	return nil, fmt.Errorf("plugin %s not found", pluginName)
+}
+
+func matchPluginInfoAlias(p PluginInfo, userInput string) bool {
+	if len(p.CommandAliases) == 0 {
+		return false
+	}
+	key := strings.ToLower(strings.TrimSpace(userInput))
+	if key == "" {
+		return false
+	}
+	for _, alias := range p.CommandAliases {
+		if strings.ToLower(strings.TrimSpace(alias)) == key {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) validateVersionAndPlatform(ctx *cli.Context, targetPlugin *PluginInfo, version, actualPluginName string) (*PlatformInfo, error) {
@@ -975,12 +1015,19 @@ func (m *Manager) savePluginToManifest(actualPluginName, version, extractDir str
 		return err
 	}
 
+	// 规范化 alias 后先做冲突校验，任何冲突都 fail-fast 阻止落盘，避免生成后 host 路由不可预测。允许同名插件覆盖自身（升级路径）。
+	aliases := sanitizeCommandAliases(pManifest.Command, pManifest.CommandAliases)
+	if err := validatePluginCommandAndAliases(localManifest, actualPluginName, pManifest.Command, aliases); err != nil {
+		return err
+	}
+
 	localManifest.Plugins[actualPluginName] = LocalPlugin{
 		Name:             actualPluginName,
 		Version:          version,
 		Path:             extractDir,
 		ProductCode:      pManifest.ProductCode,
 		Command:          pManifest.Command,
+		CommandAliases:   aliases,
 		ShortDescription: pManifest.ShortDescription,
 		Description:      pManifest.Description,
 		CmdNames:         pManifest.CmdNames,
@@ -1058,9 +1105,11 @@ func (m *Manager) Upgrade(ctx *cli.Context, pluginName string, enablePre bool) e
 		return err
 	}
 
-	targetPlugin, err := m.findPluginInIndex(pluginName)
+	// 用户可能通过 short-name / alias（e.g. "hologres"）触发升级，此处必须走标准 plugin name 去远端索引查，否则远端根本没有 alias 这个 key。
+	// 使用 findLocalPlugin 已经解出来的 canonical name。
+	targetPlugin, err := m.findPluginInIndex(actualPluginName)
 	if err != nil {
-		return fmt.Errorf("plugin %s not found in repository", pluginName)
+		return fmt.Errorf("plugin %s not found in repository", actualPluginName)
 	}
 
 	latestVersion, err := getLatestVersion(targetPlugin, enablePre)

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -296,7 +296,8 @@ func TestInstallFromPackageFile_saveLocalManifestFails(t *testing.T) {
 
 func TestFindInstalledPluginInManifest(t *testing.T) {
 	m := &LocalManifest{Plugins: map[string]LocalPlugin{
-		"aliyun-cli-x": {Name: "aliyun-cli-x"},
+		"aliyun-cli-x":        {Name: "aliyun-cli-x"},
+		"aliyun-cli-hologram": {Name: "aliyun-cli-hologram", Command: "hologram", CommandAliases: []string{"hologres"}},
 	}}
 	n, lp, ok := FindInstalledPluginInManifest(m, "aliyun-cli-x")
 	require.True(t, ok)
@@ -306,6 +307,16 @@ func TestFindInstalledPluginInManifest(t *testing.T) {
 	n, _, ok = FindInstalledPluginInManifest(m, "x")
 	require.True(t, ok)
 	assert.Equal(t, "aliyun-cli-x", n)
+
+	// alias matches the same plugin as the main command
+	n, _, ok = FindInstalledPluginInManifest(m, "hologres")
+	require.True(t, ok)
+	assert.Equal(t, "aliyun-cli-hologram", n)
+
+	// alias matching is case-insensitive, mirroring matchPluginName
+	n, _, ok = FindInstalledPluginInManifest(m, "HOLOGRES")
+	require.True(t, ok)
+	assert.Equal(t, "aliyun-cli-hologram", n)
 
 	_, _, ok = FindInstalledPluginInManifest(m, "nosuch")
 	assert.False(t, ok)

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -542,6 +542,60 @@ func TestManager_findPluginInIndex(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "plugin aliyun-cli-fc not found")
 	})
+
+	// 覆盖 `plugin install --name <alias>` 场景：假设索引侧已按 design 落盘 CommandAliases，
+	// findPluginInIndex 应能通过 alias 命中同一个 PluginInfo。缺失该字段的旧索引不会命中 alias 分支。
+	t.Run("Success - alias match", func(t *testing.T) {
+		validIndex := Index{
+			Plugins: []PluginInfo{
+				{
+					Name:           "aliyun-cli-hologram",
+					Command:        "hologram",
+					CommandAliases: []string{"hologres"},
+					Description:    "Hologram plugin",
+				},
+				{
+					Name:        "aliyun-cli-fc",
+					Description: "FC plugin",
+				},
+			},
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(validIndex)
+		}))
+		defer server.Close()
+
+		mgr := &Manager{
+			rootDir:  t.TempDir(),
+			indexURL: server.URL,
+		}
+
+		// alias 命中主插件
+		p, err := mgr.findPluginInIndex("hologres")
+		assert.NoError(t, err)
+		if assert.NotNil(t, p) {
+			assert.Equal(t, "aliyun-cli-hologram", p.Name)
+		}
+
+		// alias 匹配大小写不敏感，与 matchPluginName 语义一致
+		p, err = mgr.findPluginInIndex("HOLOGRES")
+		assert.NoError(t, err)
+		if assert.NotNil(t, p) {
+			assert.Equal(t, "aliyun-cli-hologram", p.Name)
+		}
+
+		// 主命令 short-name 走 matchPluginName 原有路径
+		p, err = mgr.findPluginInIndex("hologram")
+		assert.NoError(t, err)
+		if assert.NotNil(t, p) {
+			assert.Equal(t, "aliyun-cli-hologram", p.Name)
+		}
+
+		// 没声明 alias 的插件不会被误命中
+		_, err = mgr.findPluginInIndex("hologres-not-existing")
+		assert.Error(t, err)
+	})
 }
 
 func TestZipSlipProtection(t *testing.T) {
@@ -1518,6 +1572,62 @@ func TestSavePluginToManifest(t *testing.T) {
 		assert.True(t, *got.ProfileRequired)
 		assert.True(t, got.IsProfileRequired())
 	})
+
+	// Verify manifest.commandAliases round-trips to LocalPlugin, and that sanitize/validate
+	// run at save time so downstream lookup and persistence stay consistent.
+	t.Run("persists sanitized commandAliases", func(t *testing.T) {
+		aliasHome := t.TempDir()
+		aliasMgr := &Manager{rootDir: aliasHome}
+		aliasDir := filepath.Join(aliasHome, "hologram-extract")
+		if err := os.MkdirAll(aliasDir, 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		pm := &PluginManifest{
+			Name:    "aliyun-cli-hologram",
+			Command: "hologram",
+			// Purposely include noise (self-alias, dup, case, blank) so we prove sanitize runs before persistence.
+			CommandAliases: []string{"hologres", "hologram", "HOLOGRES", "", "hg"},
+		}
+		assert.NoError(t, aliasMgr.savePluginToManifest(pm.Name, "1.0.0", aliasDir, pm))
+		lm, err := aliasMgr.GetLocalManifest()
+		assert.NoError(t, err)
+		got, ok := lm.Plugins[pm.Name]
+		assert.True(t, ok)
+		assert.Equal(t, []string{"hologres", "hg"}, got.CommandAliases)
+	})
+
+	t.Run("rejects install when command clashes with reserved", func(t *testing.T) {
+		freshMgr := &Manager{rootDir: t.TempDir()}
+		err := freshMgr.savePluginToManifest("aliyun-cli-conflict", "1.0.0", extractDir, &PluginManifest{
+			Name:    "aliyun-cli-conflict",
+			Command: "plugin",
+		})
+		assert.ErrorContains(t, err, "conflicts with a built-in top-level command")
+	})
+
+	t.Run("rejects install when command missing", func(t *testing.T) {
+		freshMgr := &Manager{rootDir: t.TempDir()}
+		err := freshMgr.savePluginToManifest("aliyun-cli-empty", "1.0.0", extractDir, &PluginManifest{
+			Name: "aliyun-cli-empty",
+		})
+		assert.ErrorContains(t, err, "command is empty")
+	})
+
+	t.Run("rejects install when alias clashes with existing plugin short name", func(t *testing.T) {
+		crossMgr := &Manager{rootDir: t.TempDir()}
+		// Seed a plugin so cross-plugin conflict logic has something to compare against.
+		assert.NoError(t, crossMgr.saveLocalManifest(&LocalManifest{
+			Plugins: map[string]LocalPlugin{
+				"aliyun-cli-fc": {Name: "aliyun-cli-fc", Command: "fc"},
+			},
+		}))
+		err := crossMgr.savePluginToManifest("aliyun-cli-newone", "1.0.0", extractDir, &PluginManifest{
+			Name:           "aliyun-cli-newone",
+			Command:        "newone",
+			CommandAliases: []string{"fc"}, // conflicts with aliyun-cli-fc's command / short name
+		})
+		assert.ErrorContains(t, err, `command/alias "fc" conflicts with installed plugin "aliyun-cli-fc"`)
+	})
 }
 
 func TestManager_downloadAndVerifyPlugin(t *testing.T) {
@@ -2432,6 +2542,52 @@ func TestManager_Upgrade(t *testing.T) {
 		err := mgr.Upgrade(ctx, "test-plugin", false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "plugin test-plugin not found in repository")
+	})
+
+	// 覆盖用户通过 alias 触发 update 的路径：findLocalPlugin 命中本地插件后，Upgrade
+	// 必须用 canonical plugin name 去远端查（而不是把原始 alias 原样透传），否则远端索引
+	// 里根本没有 alias 这个 key 会直接 fail。
+	t.Run("Success - upgrade by alias", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mgr := &Manager{rootDir: tmpDir}
+
+		pluginDir := filepath.Join(tmpDir, "aliyun-cli-hologram")
+		os.MkdirAll(pluginDir, 0755)
+		localManifest := &LocalManifest{
+			Plugins: map[string]LocalPlugin{
+				"aliyun-cli-hologram": {
+					Name:           "aliyun-cli-hologram",
+					Version:        "1.0.0",
+					Path:           pluginDir,
+					Command:        "hologram",
+					CommandAliases: []string{"hologres"},
+				},
+			},
+		}
+		mgr.saveLocalManifest(localManifest)
+
+		// 只声明 canonical plugin name 到最新版本，模拟远端索引没有单独的 alias PluginInfo。
+		indexJSON := `{
+			"plugins": [
+				{
+					"name": "aliyun-cli-hologram",
+					"versions": {"2.0.0": {}}
+				}
+			]
+		}`
+		indexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(indexJSON))
+		}))
+		defer indexServer.Close()
+		mgr.indexURL = indexServer.URL
+
+		ctx := newTestContext()
+		// 用户敲的是 alias，Upgrade 内部需要转成 canonical name 再去远端查
+		err := mgr.Upgrade(ctx, "hologres", false)
+		// 到这里能拿到 2.0.0 说明远端查找用的是 canonical name；实际 install 会在下载阶段失败
+		// （因为没提供 platform URL），但那已经在 findPluginInIndex 之后，不影响本用例要验证的错误路径。
+		assert.NotContains(t, fmt.Sprint(err), "not found in repository")
 	})
 
 	t.Run("Success - plugin already up to date", func(t *testing.T) {

--- a/cli/plugin/reserved.go
+++ b/cli/plugin/reserved.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"sort"
+	"strings"
+)
+
+// 内置顶层命令注册表。产品方 alias 与 plugin command 都不允许覆盖内置命令，
+// 默认包含 CLI 自带且不会随build 变化的核心命令。
+// 对于按需注册的 cliext 命令，`main` 在构建 rootCmd 之后会调用 RegisterReservedTopLevelCommands 追加进来，避免维护列表漂移。
+// 并发契约：约定 RegisterReservedTopLevelCommands 只在进程启动阶段（rootCmd 构建期）调用；之后所有访问都视为只读。
+// 如果未来有并发写入需求（例如懒加载 cliext / 异步插件发现），需要引入 Mutex
+var reservedTopLevelCommands = map[string]struct{}{
+	"aliyun":          {},
+	"configure":       {},
+	"version":         {},
+	"auto-completion": {},
+	"help":            {},
+	"plugin":          {},
+	"upgrade":         {},
+	"oss":             {},
+	"ossutil":         {},
+	"mcp":             {},
+	"mock":            {},
+}
+
+func RegisterReservedTopLevelCommands(names []string) {
+	for _, n := range names {
+		key := normalizeCommandName(n)
+		if key == "" {
+			continue
+		}
+		reservedTopLevelCommands[key] = struct{}{}
+	}
+}
+
+func IsReservedTopLevelCommand(name string) bool {
+	key := normalizeCommandName(name)
+	if key == "" {
+		return false
+	}
+	_, ok := reservedTopLevelCommands[key]
+	return ok
+}
+
+func ReservedTopLevelCommands() []string {
+	names := make([]string, 0, len(reservedTopLevelCommands))
+	for n := range reservedTopLevelCommands {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func normalizeCommandName(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/cli/plugin/reserved_test.go
+++ b/cli/plugin/reserved_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsReservedTopLevelCommand_Defaults(t *testing.T) {
+	// The defaults hard-coded in reserved.go cover CLI-owned commands that must never be shadowed by a plugin.
+	// If any of these regress to non-reserved, plugin install could silently mask a first-class command.
+	for _, name := range []string{"configure", "plugin", "version", "upgrade", "oss", "ossutil", "mcp", "mock"} {
+		assert.Truef(t, IsReservedTopLevelCommand(name), "expected %q to be reserved by default", name)
+	}
+}
+
+func TestIsReservedTopLevelCommand_NormalizesInput(t *testing.T) {
+	assert.True(t, IsReservedTopLevelCommand("Configure"))
+	assert.True(t, IsReservedTopLevelCommand("  PLUGIN  "))
+	assert.False(t, IsReservedTopLevelCommand(""))
+	assert.False(t, IsReservedTopLevelCommand("   "))
+}
+
+func TestRegisterReservedTopLevelCommands_AppendsAndDedupes(t *testing.T) {
+	// Register a fresh name and confirm it now counts as reserved.
+	// The plugin package is process-global, so use a made-up name to avoid interfering with other tests.
+	name := "aliyun-cli-reserved-test-name"
+	assert.False(t, IsReservedTopLevelCommand(name))
+	RegisterReservedTopLevelCommands([]string{name, name, "", "  "})
+	assert.True(t, IsReservedTopLevelCommand(name))
+
+	// The exported dump should be sorted and include our newly registered name exactly once.
+	dump := ReservedTopLevelCommands()
+	count := 0
+	for _, n := range dump {
+		if n == name {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "registered name should appear exactly once")
+}

--- a/cli/plugin/types.go
+++ b/cli/plugin/types.go
@@ -10,12 +10,20 @@ type Index struct {
 }
 
 type PluginInfo struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	ProductName map[string]string      `json:"productName"` // en, zh
-	ProductCode string                 `json:"productCode"`
-	Homepage    string                 `json:"homepage"`
-	Versions    map[string]VersionInfo `json:"versions"` // version -> VersionInfo
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	ProductName map[string]string `json:"productName"` // en, zh
+	ProductCode string            `json:"productCode"`
+	Homepage    string            `json:"homepage"`
+	// Command 是插件在 host CLI 里的主二级命令名（例如 "hologram"）。
+	// 由索引发布侧从 manifest.command 汇总，此处保留字段以便 client 展示 / 匹配。
+	Command string `json:"command,omitempty"`
+	// CommandAliases 是产品方声明的额外二级命令入口（例如 hologram 插件的 ["hologres"]）。
+	// 与 LocalPlugin.CommandAliases 语义一致，索引发布侧从 manifest.commandAliases 汇总落盘；
+	// findPluginInIndex 在 plugin name / short-name 匹配之外再叠加 alias 匹配，支持
+	// `aliyun plugin install --name <alias>`。索引侧未落盘时该字段为 nil，行为退化为纯 name 匹配。
+	CommandAliases []string               `json:"commandAliases,omitempty"`
+	Versions       map[string]VersionInfo `json:"versions"` // version -> VersionInfo
 }
 
 type VersionInfo struct {
@@ -79,11 +87,21 @@ type LocalManifest struct {
 }
 
 type LocalPlugin struct {
-	Name             string   `json:"name"`
-	Version          string   `json:"version"`
-	Path             string   `json:"path"` // 插件目录路径
-	ProductCode      string   `json:"productCode,omitempty"`
-	Command          string   `json:"command"` // 触发命令，not used for now
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Path        string `json:"path"` // 插件目录路径
+	ProductCode string `json:"productCode,omitempty"`
+	// Command is the top-level CLI subcommand this plugin serves (e.g. "hologram" for `aliyun hologram ...`).
+	// 本期 runtime 不直接把 Command 当作查找 key —— 因为 plugin name 与 Command 都派生自 productCode
+	// (plugin name = "aliyun-cli-" + normalize(productCode), Command = normalize(productCode))，
+	// matchPluginName 的 short-name 分支已经等价覆盖了主命令。Command 目前只用于安装期冲突校验和展示。
+	// 未来若 plugin name 与 Command 解耦，需要同步把 Command 加进 FindInstalledPluginInManifest 的匹配。
+	Command string `json:"command"`
+	// CommandAliases 是产品方声明的额外二级命令入口（例如 hologram 插件的 ["hologres"]），
+	// 是本期真正“新增”的查找 key，由 matchPluginAlias 在 FindInstalledPluginInManifest 里显式匹配。
+	// 与主命令一样落到同一份查找路径，因此 execute / help / 管理命令（install/uninstall/update）
+	// 都天然识别 alias；管理命令按 alias 定位到插件后仍以 plugin Name 为准做增删。
+	CommandAliases []string `json:"commandAliases,omitempty"`
 	CmdNames         []string `json:"cmdNames"`
 	ShortDescription string   `json:"shortDescription"`
 	Description      string   `json:"description"`
@@ -116,10 +134,14 @@ type PluginAPIVersionInfo struct {
 }
 
 type PluginManifest struct {
-	Name             string             `json:"name"`
-	Version          string             `json:"version"`
-	ProductCode      string             `json:"productCode,omitempty"`
-	Command          string             `json:"command"`
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	ProductCode string `json:"productCode,omitempty"`
+	// Command is the top-level CLI subcommand this plugin exposes to end users.
+	// See LocalPlugin.Command for the runtime semantics.
+	Command string `json:"command"`
+	// CommandAliases 声明该插件在 host CLI 上的额外二级命令入口，与 Command 一起在安装期做冲突校验并落盘。
+	CommandAliases   []string           `json:"commandAliases,omitempty"`
 	ShortDescription string             `json:"shortDescription"`
 	Description      string             `json:"description"`
 	Inner            bool               `json:"inner,omitempty"`
@@ -127,8 +149,8 @@ type PluginManifest struct {
 	Bin              struct {
 		Path string `json:"path"` // 二进制文件相对路径
 	} `json:"bin"`
-	CmdNames []string `json:"cmdNames"`
-	ProfileRequired *bool `json:"profileRequired,omitempty"`
+	CmdNames        []string `json:"cmdNames"`
+	ProfileRequired *bool    `json:"profileRequired,omitempty"`
 }
 
 // Key: kebab-case command name (e.g., "fc create-alias")

--- a/main/main.go
+++ b/main/main.go
@@ -17,19 +17,20 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"github.com/aliyun/aliyun-cli/v3/cliext/kmscli"
-	"github.com/aliyun/aliyun-cli/v3/cliext/lindormcli"
 	"io"
 	"os"
 	"path"
 	"strings"
 
-	"github.com/aliyun/aliyun-cli/v3/cliext/agentbay"
+	"github.com/aliyun/aliyun-cli/v3/cliext/kmscli"
+	"github.com/aliyun/aliyun-cli/v3/cliext/lindormcli"
+
 	aliyunopenapimeta "github.com/aliyun/aliyun-cli/v3/aliyun-openapi-meta"
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
 	"github.com/aliyun/aliyun-cli/v3/cli/upgrade"
 	"github.com/aliyun/aliyun-cli/v3/cliext/acrutil"
+	"github.com/aliyun/aliyun-cli/v3/cliext/agentbay"
 	"github.com/aliyun/aliyun-cli/v3/cliext/appmanagerutil"
 	"github.com/aliyun/aliyun-cli/v3/cliext/cms2"
 	"github.com/aliyun/aliyun-cli/v3/cliext/codeup"
@@ -39,9 +40,9 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/cliext/maxc"
 	"github.com/aliyun/aliyun-cli/v3/cliext/ossutil"
 	"github.com/aliyun/aliyun-cli/v3/cliext/otsutil"
-	"github.com/aliyun/aliyun-cli/v3/cliext/sparksubmit"
 	"github.com/aliyun/aliyun-cli/v3/cliext/rostran"
 	"github.com/aliyun/aliyun-cli/v3/cliext/saectl"
+	"github.com/aliyun/aliyun-cli/v3/cliext/sparksubmit"
 	"github.com/aliyun/aliyun-cli/v3/config"
 	go_migrate "github.com/aliyun/aliyun-cli/v3/go-migrate"
 	"github.com/aliyun/aliyun-cli/v3/i18n"
@@ -169,6 +170,8 @@ func newRootCommand(profile config.Profile, stdout io.Writer) *cli.Command {
 	rootCmd.AddSubCommand(upgrade.NewUpgradeCommand())
 	// mock command
 	rootCmd.AddSubCommand(mock.NewMockCommand(config.GetConfigPath))
+
+	plugin.RegisterReservedTopLevelCommands(rootCmd.SubCommandNames())
 
 	return rootCmd
 }

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -199,7 +199,9 @@ func (c *Commando) printProductUsage(ctx *cli.Context, productCode string) error
 			}
 		}
 	}
-	// Locally installed plugin (e.g. plugin install --package) not in remote index
+	// Locally installed plugin (e.g. plugin install --package) not in remote index.
+	// FindInstalledPluginInManifest 已经把 plugin name / short-name / manifest.commandAliases 一起纳入匹配，
+	// 与 ExecutePlugin 使用的查找路径一致，因此 alias（例如 "hologres"）也能命中对应插件。
 	if pluginName == "" && c.localManifest != nil {
 		if n, _, ok := plugin.FindInstalledPluginInManifest(c.localManifest, productCode); ok {
 			pluginName = n


### PR DESCRIPTION
**Description**

Add plugin command alias support: plugins can declare commandAliases in their manifest to expose additional top-level entry points on the host CLI (e.g. `aliyun hologres` → `aliyun-cli-hologram`), with a unified alias-aware lookup shared by execution, help, and management commands, plus install-time conflict validation against built-in commands and other installed plugins.