### PR TITLE
feat(mock): add response_body_size for controllable mock stdout size

### DIFF
--- a/mock/command.go
+++ b/mock/command.go
@@ -72,7 +72,7 @@ Workflow:
 func newAddCommand(defaultConfigDir func() string) *cli.Command {
 	cmd := &cli.Command{
 		Name:  "add",
-		Usage: "add --name <name> --cmd <rule> --exit-code <code> --times <count> [--stdout <text>] [--stderr <text>] [--delay-ms <milliseconds>]",
+		Usage: "add --name <name> --cmd <rule> --exit-code <code> --times <count> [--stdout <text>] [--stderr <text>] [--delay-ms <milliseconds>] [--response-body-size <bytes>]",
 		Short: i18n.T("add one mock record", "添加一条 mock 记录"),
 		Run: func(ctx *cli.Context, args []string) error {
 			if len(args) > 0 {
@@ -142,6 +142,7 @@ func addRecordFlags(cmd *cli.Command) {
 		{"stderr", i18n.T("mock command stderr", "模拟命令标准错误")},
 		{"times", i18n.T("match count; 0 means unlimited", "匹配次数；0 表示不限次数")},
 		{"delay-ms", i18n.T("mock command execution delay in milliseconds; 0 means no delay", "模拟命令执行延迟（毫秒）；0 表示不延迟")},
+		{"response-body-size", i18n.T("mock stdout size in bytes; pads or truncates stdout to this length; 0 means use stdout as-is", "模拟标准输出字节大小；将 stdout 填充或截断到该长度；0 表示原样使用 stdout")},
 	} {
 		cmd.Flags().Add(&cli.Flag{
 			Name:         flag.name,
@@ -207,6 +208,16 @@ func recordFromFlags(ctx *cli.Context) (sysmock.Record, error) {
 			record.DelayMs = delayMs
 		}
 	}
+	if sizeFlag := ctx.Flags().Get("response-body-size"); sizeFlag != nil && sizeFlag.IsAssigned() {
+		sizeText, _ := sizeFlag.GetValue()
+		if sizeText != "" {
+			size, err := strconv.Atoi(sizeText)
+			if err != nil {
+				return sysmock.Record{}, fmt.Errorf("invalid --response-body-size %q", sizeText)
+			}
+			record.ResponseBodySize = size
+		}
+	}
 	if err := sysmock.ValidateRecord(record); err != nil {
 		return sysmock.Record{}, err
 	}
@@ -251,7 +262,7 @@ func addMissingFlagsMessage(missing []string) string {
 	return fmt.Sprintf(`missing required flags: %s
 
 Example:
-  aliyun mock add --name mock-ecs-version --cmd 'ecs *' --exit-code 0 --stdout 'ecs 1.0.0\n' --stderr 'mock stderr\n' --times 10 --delay-ms 500`, strings.Join(missing, ", "))
+  aliyun mock add --name mock-ecs-version --cmd 'ecs *' --exit-code 0 --stdout 'ecs 1.0.0\n' --stderr 'mock stderr\n' --times 10 --delay-ms 500 --response-body-size 1024`, strings.Join(missing, ", "))
 }
 
 func requiredFlag(ctx *cli.Context, name string) (string, error) {
@@ -277,13 +288,14 @@ JSON input format:
   Import replaces all existing mock records after the file is validated.
 
 Fields:
-  name      required record name
-  cmd       required command match rule; "*" and "?" wildcards are supported
-  exit_code required mocked command exit code
-  stdout    required mocked command stdout
-  stderr    required mocked command stderr
-  times     required match count; 0 means unlimited
-  delay_ms  optional execution delay in milliseconds before returning output; 0 means no delay
+  name                required record name
+  cmd                 required command match rule; "*" and "?" wildcards are supported
+  exit_code           required mocked command exit code
+  stdout              required mocked command stdout
+  stderr              required mocked command stderr
+  times               required match count; 0 means unlimited
+  delay_ms            optional execution delay in milliseconds before returning output; 0 means no delay
+  response_body_size  optional mocked stdout size in bytes; pads or truncates stdout to this length; 0 means use stdout as-is
 
 Example:
 [
@@ -294,7 +306,8 @@ Example:
     "stdout": "ecs 1.0.0\n",
     "stderr": "",
     "times": 10,
-    "delay_ms": 500
+    "delay_ms": 500,
+    "response_body_size": 1024
   }
 ]`, `
 JSON 输入格式:
@@ -302,13 +315,14 @@ JSON 输入格式:
   import 会先校验文件，校验通过后覆盖所有现有 mock 记录。
 
 字段:
-  name      必填的记录名称
-  cmd       必填的命令匹配规则，支持 "*" 和 "?" 通配符
-  exit_code 必填的模拟命令退出码
-  stdout    必填的模拟命令标准输出
-  stderr    必填的模拟命令标准错误
-  times     必填的匹配次数；0 表示不限次数
-  delay_ms  可选的执行延迟（毫秒），在返回输出前等待；0 表示不延迟
+  name                必填的记录名称
+  cmd                 必填的命令匹配规则，支持 "*" 和 "?" 通配符
+  exit_code           必填的模拟命令退出码
+  stdout              必填的模拟命令标准输出
+  stderr              必填的模拟命令标准错误
+  times               必填的匹配次数；0 表示不限次数
+  delay_ms            可选的执行延迟（毫秒），在返回输出前等待；0 表示不延迟
+  response_body_size  可选的模拟标准输出字节大小；将 stdout 填充或截断到该长度；0 表示原样使用 stdout
 
 示例:
 [
@@ -319,7 +333,8 @@ JSON 输入格式:
     "stdout": "ecs 1.0.0\n",
     "stderr": "",
     "times": 10,
-    "delay_ms": 500
+    "delay_ms": 500,
+    "response_body_size": 1024
   }
 ]`).Text())
 	cmd.PrintTail(ctx)

--- a/mock/command_test.go
+++ b/mock/command_test.go
@@ -41,7 +41,7 @@ func TestMockAddFlagsAreNotPersistent(t *testing.T) {
 		t.Fatal("add subcommand is nil")
 	}
 
-	for _, name := range []string{"name", "cmd", "exit-code", "stdout", "stderr", "times", "delay-ms"} {
+	for _, name := range []string{"name", "cmd", "exit-code", "stdout", "stderr", "times", "delay-ms", "response-body-size"} {
 		flag := add.Flags().Get(name)
 		if flag == nil {
 			t.Fatalf("%s flag is nil", name)
@@ -67,6 +67,7 @@ func TestMockImportHelpShowsFlatJSONInputFormat(t *testing.T) {
 		`"stderr": ""`,
 		`"times": 10`,
 		`"delay_ms": 500`,
+		`"response_body_size": 1024`,
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("help stdout = %q, want contain %q", stdout, want)
@@ -154,6 +155,50 @@ func TestMockAddRejectsInvalidDelayMs(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "invalid --delay-ms") {
 		t.Fatalf("stderr = %q, want invalid delay-ms error", stderr)
+	}
+}
+
+func TestMockAddWithResponseBodySize(t *testing.T) {
+	mockPath := filepath.Join(t.TempDir(), "mocks.json")
+	t.Setenv(sysmock.EnvMockPath, mockPath)
+
+	stdout, stderr := executeMockCommand(t, "mock", "add",
+		"--name", "sized",
+		"--cmd", "ecs DescribeInstances",
+		"--exit-code", "0",
+		"--stdout", "ok",
+		"--stderr", "warn",
+		"--times", "10",
+		"--response-body-size", "4096",
+	)
+	if stdout != "" || stderr != "" {
+		t.Fatalf("add stdout = %q stderr = %q, want both empty", stdout, stderr)
+	}
+
+	stdout, stderr = executeMockCommand(t, "mock", "list")
+	if stderr != "" {
+		t.Fatalf("list stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"response_body_size": 4096`) {
+		t.Fatalf("list stdout = %q, want response_body_size field", stdout)
+	}
+}
+
+func TestMockAddRejectsInvalidResponseBodySize(t *testing.T) {
+	stdout, stderr := executeMockCommand(t, "mock", "add",
+		"--name", "bad-size",
+		"--cmd", "ecs *",
+		"--exit-code", "0",
+		"--stdout", "ok",
+		"--stderr", "warn",
+		"--times", "0",
+		"--response-body-size", "bad",
+	)
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "invalid --response-body-size") {
+		t.Fatalf("stderr = %q, want invalid response-body-size error", stderr)
 	}
 }
 

--- a/sysconfig/mock/interceptor.go
+++ b/sysconfig/mock/interceptor.go
@@ -52,8 +52,8 @@ func Intercept(opts Options) Result {
 		sleep(time.Duration(record.DelayMs) * time.Millisecond)
 	}
 
-	if record.Stdout != "" {
-		writes(opts.Stdout, record.Stdout)
+	if stdout := ResolveStdout(record); stdout != "" {
+		writes(opts.Stdout, stdout)
 	}
 	if record.Stderr != "" {
 		writes(opts.Stderr, record.Stderr)

--- a/sysconfig/mock/interceptor_test.go
+++ b/sysconfig/mock/interceptor_test.go
@@ -84,6 +84,72 @@ func TestInterceptHitAppliesDelayBeforeOutput(t *testing.T) {
 	}
 }
 
+func TestInterceptHitExpandsResponseBodySize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mocks.json")
+	if err := Save(path, []Record{{
+		Name:             "sized",
+		Cmd:              "ecs *",
+		Stdout:           "hi",
+		Times:            0,
+		ResponseBodySize: 16,
+	}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	t.Setenv(EnvMockEnabled, "true")
+
+	var stdout, stderr bytes.Buffer
+	result := Intercept(Options{
+		Args:     []string{"ecs", "DescribeRegions"},
+		Stdout:   &stdout,
+		Stderr:   &stderr,
+		MockPath: path,
+	})
+
+	if !result.Handled {
+		t.Fatalf("Handled = false, want true")
+	}
+	got := stdout.String()
+	if len(got) != 16 {
+		t.Fatalf("stdout len = %d, want 16", len(got))
+	}
+	if got[:2] != "hi" {
+		t.Fatalf("stdout prefix = %q, want hi", got[:2])
+	}
+	for i := 2; i < 16; i++ {
+		if got[i] != 'x' {
+			t.Fatalf("stdout[%d] = %q, want 'x'", i, got[i])
+		}
+	}
+}
+
+func TestInterceptHitTruncatesWhenStdoutLongerThanResponseBodySize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mocks.json")
+	if err := Save(path, []Record{{
+		Name:             "truncate",
+		Cmd:              "ecs *",
+		Stdout:           "abcdefghij",
+		Times:            0,
+		ResponseBodySize: 4,
+	}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	t.Setenv(EnvMockEnabled, "true")
+
+	var stdout bytes.Buffer
+	result := Intercept(Options{
+		Args:     []string{"ecs", "DescribeRegions"},
+		Stdout:   &stdout,
+		MockPath: path,
+	})
+
+	if !result.Handled {
+		t.Fatalf("Handled = false, want true")
+	}
+	if got := stdout.String(); got != "abcd" {
+		t.Fatalf("stdout = %q, want abcd", got)
+	}
+}
+
 func TestInterceptZeroDelaySkipsSleep(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mocks.json")
 	if err := Save(path, []Record{{

--- a/sysconfig/mock/store.go
+++ b/sysconfig/mock/store.go
@@ -125,6 +125,12 @@ func validateRecord(record Record) error {
 	if record.DelayMs > MaxDelayMs {
 		return fmt.Errorf("mock record delay_ms must be less than or equal to %d", MaxDelayMs)
 	}
+	if record.ResponseBodySize < 0 {
+		return fmt.Errorf("mock record response_body_size must be greater than or equal to 0")
+	}
+	if record.ResponseBodySize > MaxResponseBodySize {
+		return fmt.Errorf("mock record response_body_size must be less than or equal to %d", MaxResponseBodySize)
+	}
 	return nil
 }
 

--- a/sysconfig/mock/store_test.go
+++ b/sysconfig/mock/store_test.go
@@ -121,6 +121,22 @@ func TestDecodeInputRejectsNegativeDelayMs(t *testing.T) {
 	}
 }
 
+func TestDecodeInputAcceptsOptionalResponseBodySize(t *testing.T) {
+	records, err := DecodeInput([]byte(`{"name":"sized","cmd":"ecs *","exit_code":0,"stdout":"","stderr":"","times":0,"response_body_size":1024}`))
+	if err != nil {
+		t.Fatalf("DecodeInput(response_body_size) returned error: %v", err)
+	}
+	if len(records) != 1 || records[0].ResponseBodySize != 1024 {
+		t.Fatalf("records = %#v, want response_body_size 1024", records)
+	}
+}
+
+func TestDecodeInputRejectsNegativeResponseBodySize(t *testing.T) {
+	if records, err := DecodeInput([]byte(`{"name":"bad","cmd":"ecs *","exit_code":0,"stdout":"","stderr":"","times":0,"response_body_size":-1}`)); err == nil {
+		t.Fatalf("DecodeInput(negative response_body_size) = %#v, nil error", records)
+	}
+}
+
 func TestReadInputAcceptsFlatSingleObjectAndArray(t *testing.T) {
 	one, err := DecodeInput([]byte(`{"name":"one","cmd":"ecs *","exit_code":0,"stdout":"","stderr":"","times":0}`))
 	if err != nil || len(one) != 1 || one[0].Name != "one" {
@@ -206,6 +222,18 @@ func TestValidateRecordRejectsInvalidDelayMs(t *testing.T) {
 	}
 	if err := ValidateRecord(Record{Name: "ok", Cmd: "ecs *", Times: 0, DelayMs: 500}); err != nil {
 		t.Fatalf("ValidateRecord valid delay_ms returned error: %v", err)
+	}
+}
+
+func TestValidateRecordRejectsInvalidResponseBodySize(t *testing.T) {
+	if err := ValidateRecord(Record{Name: "bad", Cmd: "ecs *", Times: 0, ResponseBodySize: -1}); err == nil {
+		t.Fatal("ValidateRecord negative response_body_size returned nil error")
+	}
+	if err := ValidateRecord(Record{Name: "bad", Cmd: "ecs *", Times: 0, ResponseBodySize: MaxResponseBodySize + 1}); err == nil {
+		t.Fatal("ValidateRecord excessive response_body_size returned nil error")
+	}
+	if err := ValidateRecord(Record{Name: "ok", Cmd: "ecs *", Times: 0, ResponseBodySize: 1024}); err != nil {
+		t.Fatalf("ValidateRecord valid response_body_size returned error: %v", err)
 	}
 }
 

--- a/sysconfig/mock/types.go
+++ b/sysconfig/mock/types.go
@@ -14,16 +14,46 @@ const (
 	MockFileName   = "mocks.json"
 )
 
-const MaxDelayMs = 3600000 // 1 hour
+const (
+	MaxDelayMs           = 3600000          // 1 hour
+	MaxResponseBodySize  = 100 * 1024 * 1024 // 100 MiB
+	responseBodyPadByte  = 'x'
+)
 
 type Record struct {
-	Name     string `json:"name"`
-	Cmd      string `json:"cmd"`
-	ExitCode int    `json:"exit_code"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
-	Times    int    `json:"times"`
-	DelayMs  int    `json:"delay_ms,omitempty"`
+	Name             string `json:"name"`
+	Cmd              string `json:"cmd"`
+	ExitCode         int    `json:"exit_code"`
+	Stdout           string `json:"stdout"`
+	Stderr           string `json:"stderr"`
+	Times            int    `json:"times"`
+	DelayMs          int    `json:"delay_ms,omitempty"`
+	ResponseBodySize int    `json:"response_body_size,omitempty"`
+}
+
+// ExpandToSize returns content truncated or padded to exactly size bytes.
+// Padding uses a fixed ASCII byte so mock body length is deterministic for load tests.
+func ExpandToSize(content string, size int) string {
+	if size <= 0 {
+		return content
+	}
+	if len(content) >= size {
+		return content[:size]
+	}
+	buf := make([]byte, size)
+	n := copy(buf, content)
+	for i := n; i < size; i++ {
+		buf[i] = responseBodyPadByte
+	}
+	return string(buf)
+}
+
+// ResolveStdout returns the mock stdout, expanding to ResponseBodySize when set.
+func ResolveStdout(record Record) string {
+	if record.ResponseBodySize > 0 {
+		return ExpandToSize(record.Stdout, record.ResponseBodySize)
+	}
+	return record.Stdout
 }
 
 func (r *Record) UnmarshalJSON(data []byte) error {

--- a/sysconfig/mock/types_test.go
+++ b/sysconfig/mock/types_test.go
@@ -37,3 +37,27 @@ func TestRecordUnmarshalRejectsInvalidJSON(t *testing.T) {
 		t.Fatal("Unmarshal invalid JSON returned nil error")
 	}
 }
+
+func TestExpandToSizePadsAndTruncates(t *testing.T) {
+	if got := ExpandToSize("ab", 5); got != "abxxx" {
+		t.Fatalf("ExpandToSize pad = %q, want abxxx", got)
+	}
+	if got := ExpandToSize("abcdef", 3); got != "abc" {
+		t.Fatalf("ExpandToSize truncate = %q, want abc", got)
+	}
+	if got := ExpandToSize("keep", 0); got != "keep" {
+		t.Fatalf("ExpandToSize zero = %q, want keep", got)
+	}
+	if got := ExpandToSize("", 4); got != "xxxx" {
+		t.Fatalf("ExpandToSize empty = %q, want xxxx", got)
+	}
+}
+
+func TestResolveStdoutUsesResponseBodySize(t *testing.T) {
+	if got := ResolveStdout(Record{Stdout: "prefix", ResponseBodySize: 8}); got != "prefixxx" {
+		t.Fatalf("ResolveStdout sized = %q, want prefixxx", got)
+	}
+	if got := ResolveStdout(Record{Stdout: "as-is"}); got != "as-is" {
+		t.Fatalf("ResolveStdout default = %q, want as-is", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add optional `response_body_size` (bytes) on mock records and `--response-body-size` for `aliyun mock add`
- When set, mock stdout is padded or truncated to the exact size for MCP load tests with small/medium/large response distributions
- Unset / `0` keeps existing stdout behavior; max size is 100MiB