### PR TITLE
feat: integrate flow-cli into Aliyun CLI

### DIFF
--- a/cliext/flowcli/flowcli.go
+++ b/cliext/flowcli/flowcli.go
@@ -55,6 +55,20 @@ const (
 
 var VersionCheckTTL = 86400
 
+// ExitError carries the exit code from the child process so the caller
+// can propagate it without calling os.Exit directly (which skips defers).
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("subprocess exited with code %d", e.Code)
+}
+
+func (e *ExitError) ExitCode() int {
+	return e.Code
+}
+
 func NewContext(originContext *cli.Context) *Context {
 	return &Context{originCtx: originContext}
 }
@@ -457,6 +471,9 @@ func (c *Context) ExecuteFlowcli(args []string) error {
 	cmd.Dir = wd
 
 	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return &ExitError{Code: exitErr.ExitCode()}
+		}
 		return fmt.Errorf("failed to execute %s %v: %v", c.execFilePath, args, err)
 	}
 	return nil

--- a/cliext/flowcli/flowcli.go
+++ b/cliext/flowcli/flowcli.go
@@ -80,8 +80,13 @@ func (c *Context) Run(args []string) error {
 	if err := c.EnsureNodeAvailable(); err != nil {
 		return err
 	}
-	if err := c.EnsureNpmAvailable(); err != nil {
-		return err
+	// npm is only needed to install/upgrade the managed copy. When the user
+	// points ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH at an existing binary, honour
+	// that escape hatch even on machines without npm.
+	if !c.usingExecPathOverride() {
+		if err := c.EnsureNpmAvailable(); err != nil {
+			return err
+		}
 	}
 	if err := c.EnsurePrefixAndPackage(); err != nil {
 		return err
@@ -179,7 +184,13 @@ func (c *Context) EnsureNpmAvailable() error {
 }
 
 func (c *Context) EnsurePrefixAndPackage() error {
-	if os.Getenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH") != "" {
+	if c.usingExecPathOverride() {
+		// The user opted out of the managed install; make sure the override
+		// actually resolves so we fail fast with an actionable message
+		// instead of a cryptic exec error later.
+		if !c.installed {
+			return fmt.Errorf("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH=%s does not point to an existing file", c.execFilePath)
+		}
 		return nil
 	}
 
@@ -295,19 +306,31 @@ func (c *Context) applyMainCliFlagsFromArgs(args []string) {
 	flags := c.originCtx.Flags()
 	for i := 0; i < len(args); i++ {
 		a := args[i]
-		if !strings.HasPrefix(a, "--") {
+
+		var f *cli.Flag
+		var value string
+		var hasValue bool
+
+		switch {
+		case strings.HasPrefix(a, "--"):
+			name := a[2:]
+			if idx := strings.Index(a, "="); idx > 0 {
+				name = a[2:idx]
+				value = a[idx+1:]
+				hasValue = true
+			}
+			f = flags.Get(name)
+		case strings.HasPrefix(a, "-") && len(a) > 1:
+			// shorthand form: -p / -p=value / -pvalue (e.g. profile, endpoint)
+			f = flags.GetByShorthand(rune(a[1]))
+			if rest := a[2:]; rest != "" {
+				value = strings.TrimPrefix(rest, "=")
+				hasValue = true
+			}
+		default:
 			continue
 		}
-		var name, value string
-		var hasValue bool
-		if idx := strings.Index(a, "="); idx > 0 {
-			name = a[2:idx]
-			value = a[idx+1:]
-			hasValue = true
-		} else {
-			name = a[2:]
-		}
-		f := flags.Get(name)
+
 		if f == nil || f.Category != "config" {
 			continue
 		}
@@ -509,6 +532,13 @@ func (c *Context) UpdateCheckCacheTime() error {
 func fileExists(p string) bool {
 	_, err := os.Stat(p)
 	return err == nil
+}
+
+// usingExecPathOverride reports whether the user pinned an existing flow-cli
+// binary via ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH, in which case the managed
+// npm install/upgrade path (and the npm requirement) is bypassed.
+func (c *Context) usingExecPathOverride() bool {
+	return strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH")) != ""
 }
 
 var getNodeMajorFunc = getNodeMajor

--- a/cliext/flowcli/flowcli.go
+++ b/cliext/flowcli/flowcli.go
@@ -1,0 +1,515 @@
+package flowcli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
+)
+
+type Context struct {
+	originCtx                 *cli.Context
+	configPath                string
+	checkVersionCacheFilePath string
+	prefixPath                string
+	nodePath                  string
+	npmPath                   string
+	execFilePath              string
+	installed                 bool
+	versionLocal              string
+	versionRemote             string
+	osType                    string
+	osArch                    string
+}
+
+var (
+	getConfigurePathFunc = func() string { return config.GetConfigPath() }
+	execCommandFunc      = exec.Command
+	httpGetFunc          = http.Get
+	timeNowFunc          = time.Now
+	runtimeGOOSFunc      = func() string { return runtime.GOOS }
+	runtimeGOARCHFunc    = func() string { return runtime.GOARCH }
+	lookPathFunc         = exec.LookPath
+)
+
+const (
+	npmPackageName   = "@flow-step/flow-cli"
+	binName          = "flow-cli"
+	prefixDirName    = "flow-cli-prefix"
+	minNodeMajor     = 18
+	versionCacheFile = ".flow_cli_version_check"
+	downloadBaseURL  = "https://aliyun-cli-pub.oss-cn-hangzhou.aliyuncs.com/cli-ext/flow-cli/downloads"
+	defaultRegistry  = "https://registry.npmmirror.com"
+)
+
+var VersionCheckTTL = 86400
+
+func NewContext(originContext *cli.Context) *Context {
+	return &Context{originCtx: originContext}
+}
+
+func (c *Context) Run(args []string) error {
+	if err := c.InitBasicInfo(); err != nil {
+		return err
+	}
+	if err := c.EnsureNodeAvailable(); err != nil {
+		return err
+	}
+	if err := c.EnsureNpmAvailable(); err != nil {
+		return err
+	}
+	if err := c.EnsurePrefixAndPackage(); err != nil {
+		return err
+	}
+
+	c.applyMainCliFlagsFromArgs(args)
+
+	newArgs, err := c.RemoveFlagsForMainCli(args)
+	if err != nil {
+		return err
+	}
+	return c.ExecuteFlowcli(newArgs)
+}
+
+func (c *Context) InitBasicInfo() error {
+	c.osType = runtimeGOOSFunc()
+	c.osArch = runtimeGOARCHFunc()
+	c.configPath = getConfigurePathFunc()
+	c.checkVersionCacheFilePath = filepath.Join(c.configPath, versionCacheFile)
+	c.prefixPath = filepath.Join(c.configPath, prefixDirName)
+
+	// npm prefix install layout:
+	//   unix:    <prefix>/bin/flow-cli
+	//   windows: <prefix>/flow-cli.cmd
+	if c.osType == "windows" {
+		c.execFilePath = filepath.Join(c.prefixPath, binName+".cmd")
+	} else {
+		c.execFilePath = filepath.Join(c.prefixPath, "bin", binName)
+	}
+
+	if envPath := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH")); envPath != "" {
+		c.execFilePath = envPath
+	}
+	c.installed = fileExists(c.execFilePath)
+	return nil
+}
+
+// EnsureNodeAvailable detects system node >= minNodeMajor. Flow-CLI V2 is a
+// Node.js/TypeScript CLI; older runtimes fail with cryptic module errors.
+func (c *Context) EnsureNodeAvailable() error {
+	if envPath := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH")); envPath != "" {
+		c.nodePath = envPath
+		return nil
+	}
+	path, err := lookPathFunc("node")
+	if err != nil {
+		return fmt.Errorf("node >= %d is required for `aliyun flow-cli`.\n"+
+			"  macOS:   brew install node@%d\n"+
+			"  Linux:   https://nodejs.org/en/download (LTS)\n"+
+			"  Windows: https://nodejs.org/en/download\n"+
+			"Or set ALIBABA_CLOUD_FLOW_CLI_NODE_PATH=/path/to/node",
+			minNodeMajor, minNodeMajor)
+	}
+	major, err := getNodeMajorFunc(path)
+	if err != nil {
+		return fmt.Errorf("failed to detect node version at %s: %v", path, err)
+	}
+	if major < minNodeMajor {
+		return fmt.Errorf("node version too old (got %d.x, need >= %d). Install Node %d LTS from https://nodejs.org/",
+			major, minNodeMajor, minNodeMajor)
+	}
+	c.nodePath = path
+	return nil
+}
+
+// EnsureNpmAvailable picks an npm matching the chosen node. On some
+// distros (debian/ubuntu) nodejs and npm are separate packages, so we
+// prefer the npm that ships next to the detected node binary before
+// falling back to PATH.
+func (c *Context) EnsureNpmAvailable() error {
+	if envPath := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_NPM_PATH")); envPath != "" {
+		c.npmPath = envPath
+		return nil
+	}
+	// Look for npm next to node first.
+	nodeDir := filepath.Dir(c.nodePath)
+	candidate := filepath.Join(nodeDir, "npm")
+	if c.osType == "windows" {
+		candidate = filepath.Join(nodeDir, "npm.cmd")
+	}
+	if fileExists(candidate) {
+		c.npmPath = candidate
+		return nil
+	}
+	path, err := lookPathFunc("npm")
+	if err != nil {
+		return fmt.Errorf("npm not found in PATH (looked next to %s and via $PATH).\n"+
+			"  Debian/Ubuntu: sudo apt install npm\n"+
+			"  RHEL/CentOS:   sudo dnf install npm\n"+
+			"Or set ALIBABA_CLOUD_FLOW_CLI_NPM_PATH=/path/to/npm",
+			c.nodePath)
+	}
+	c.npmPath = path
+	return nil
+}
+
+func (c *Context) EnsurePrefixAndPackage() error {
+	if os.Getenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH") != "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(c.prefixPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create prefix %s: %v", c.prefixPath, err)
+	}
+
+	if !c.installed {
+		fmt.Fprintln(c.originCtx.Stderr(), "Installing flow-cli...")
+		if err := c.npmInstall(false); err != nil {
+			return err
+		}
+		c.installed = fileExists(c.execFilePath)
+		if !c.installed {
+			return fmt.Errorf("flow-cli install completed but binary not found at %s", c.execFilePath)
+		}
+		_ = c.UpdateCheckCacheTime()
+		return nil
+	}
+
+	if os.Getenv("ALIBABA_CLOUD_FLOW_CLI_NO_UPDATE_CHECK") == "1" {
+		return nil
+	}
+	if c.NeedCheckVersion() {
+		// upgrade is best-effort: failure must not block existing install
+		_ = c.npmInstall(true)
+		_ = c.UpdateCheckCacheTime()
+	}
+	return nil
+}
+
+// npmInstall resolves a target version (OSS version.txt if available,
+// otherwise the npm "latest" tag) and then runs `npm install --prefix=...`.
+// Official Flow-CLI docs recommend npmmirror; that is the default registry
+// unless ALIBABA_CLOUD_FLOW_CLI_NPM_REGISTRY overrides it.
+func (c *Context) npmInstall(upgrade bool) error {
+	target := npmPackageName
+	if v := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_VERSION")); v != "" {
+		target = npmPackageName + "@" + v
+	} else if v, err := c.fetchOSSVersion(); err == nil && v != "" {
+		c.versionRemote = v
+		target = npmPackageName + "@" + v
+	}
+
+	// -g + --prefix gives global install layout: <prefix>/bin/flow-cli (unix)
+	// or <prefix>/flow-cli.cmd (windows). Without -g, npm creates a local
+	// install whose bin symlinks land in node_modules/.bin instead.
+	args := []string{
+		"install", "-g",
+		"--prefix", c.prefixPath,
+		"--no-fund", "--no-audit",
+		"--loglevel=warn",
+		"--registry", c.effectiveRegistry(),
+		target,
+	}
+
+	cmd := execCommandFunc(c.npmPath, args...)
+	cmd.Stdout = c.originCtx.Stderr()
+	cmd.Stderr = c.originCtx.Stderr()
+	if err := cmd.Run(); err != nil {
+		if upgrade {
+			// upgrade is best-effort — never block on it
+			return nil
+		}
+		return fmt.Errorf("failed to install %s into %s via npm: %v\n"+
+			"Hints:\n"+
+			"  - Use a custom registry: export ALIBABA_CLOUD_FLOW_CLI_NPM_REGISTRY=...\n"+
+			"  - Pin a version:         export ALIBABA_CLOUD_FLOW_CLI_VERSION=x.y.z\n"+
+			"  - Use a local binary:    export ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH=$(which flow-cli)",
+			target, c.prefixPath, err)
+	}
+	return nil
+}
+
+func (c *Context) effectiveRegistry() string {
+	if u := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_NPM_REGISTRY")); u != "" {
+		return u
+	}
+	return defaultRegistry
+}
+
+func (c *Context) fetchOSSVersion() (string, error) {
+	base := strings.TrimRight(c.effectiveBaseURL(), "/")
+	resp, err := httpGetFunc(base + "/version.txt")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("version.txt HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+func (c *Context) effectiveBaseURL() string {
+	if u := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_FLOW_CLI_DOWNLOAD_BASE_URL")); u != "" {
+		return u
+	}
+	return downloadBaseURL
+}
+
+// applyMainCliFlagsFromArgs mirrors esacli: KeepArgs skips flag
+// parsing, so we manually fold aliyun config flags from raw args into
+// ctx.Flags() to make LoadProfileWithContext see command-line overrides.
+func (c *Context) applyMainCliFlagsFromArgs(args []string) {
+	if c.originCtx == nil || c.originCtx.Flags() == nil {
+		return
+	}
+	flags := c.originCtx.Flags()
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "--") {
+			continue
+		}
+		var name, value string
+		var hasValue bool
+		if idx := strings.Index(a, "="); idx > 0 {
+			name = a[2:idx]
+			value = a[idx+1:]
+			hasValue = true
+		} else {
+			name = a[2:]
+		}
+		f := flags.Get(name)
+		if f == nil || f.Category != "config" {
+			continue
+		}
+		needsValue := f.AssignedMode != cli.AssignedNone
+		if needsValue {
+			if !hasValue {
+				if i+1 >= len(args) {
+					continue
+				}
+				value = args[i+1]
+				i++
+			}
+			f.SetAssigned(true)
+			f.SetValue(value)
+		} else {
+			f.SetAssigned(true)
+		}
+	}
+}
+
+func (c *Context) RemoveFlagsForMainCli(args []string) ([]string, error) {
+	longNeedsValue := make(map[string]bool)
+	shortNeedsValue := make(map[string]bool)
+
+	mainCliFs := cli.NewFlagSet()
+	config.AddFlags(mainCliFs)
+	for _, f := range mainCliFs.Flags() {
+		if f.Category != "config" {
+			continue
+		}
+		needsValue := f.AssignedMode != cli.AssignedNone
+		if f.Name != "" {
+			longNeedsValue["--"+f.Name] = needsValue
+		}
+		if f.Shorthand != 0 {
+			shortNeedsValue["-"+string(f.Shorthand)] = needsValue
+		}
+	}
+
+	if c.originCtx != nil && c.originCtx.Flags() != nil && c.originCtx.Flags().Flags() != nil {
+		for _, f := range c.originCtx.Flags().Flags() {
+			if !f.IsAssigned() || f.Category != "config" {
+				continue
+			}
+			needsValue := f.AssignedMode != cli.AssignedNone
+			if f.Name != "" {
+				longNeedsValue["--"+f.Name] = needsValue
+			}
+			if f.Shorthand != 0 {
+				shortNeedsValue["-"+string(f.Shorthand)] = needsValue
+			}
+		}
+	}
+
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if strings.HasPrefix(a, "--") {
+			if idx := strings.Index(a, "="); idx > 0 {
+				if _, ok := longNeedsValue[a[:idx]]; ok {
+					continue
+				}
+			}
+		}
+		if needs, ok := longNeedsValue[a]; ok {
+			if needs && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		if needs, ok := shortNeedsValue[a]; ok {
+			if needs && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// PrepareEnv builds the env for the flow-cli subprocess. Mirrors the
+// esacli approach: profile-derived ALIBABA_CLOUD_* creds (incl.
+// RamRoleArn → STS exchange), region, ai-mode UA injection, and a
+// COMPAT_MODE marker so flow-cli can adapt help/telemetry if needed.
+func (c *Context) PrepareEnv() ([]string, error) {
+	profile, err := config.LoadProfileWithContext(c.originCtx)
+	if err != nil {
+		return nil, fmt.Errorf("config failed: %s", err.Error())
+	}
+	if c.originCtx != nil && c.originCtx.Flags() != nil {
+		profile.OverwriteWithFlags(c.originCtx)
+	}
+
+	var accessKeyId, accessKeySecret, stsToken string
+
+	switch profile.Mode {
+	case config.AK:
+		accessKeyId = profile.AccessKeyId
+		accessKeySecret = profile.AccessKeySecret
+	case config.StsToken:
+		accessKeyId = profile.AccessKeyId
+		accessKeySecret = profile.AccessKeySecret
+		stsToken = profile.StsToken
+	default:
+		credential, err := profile.GetCredential(c.originCtx, nil)
+		if err != nil {
+			return nil, fmt.Errorf("can't get credential: %s", err)
+		}
+		model, err := credential.GetCredential()
+		if err != nil {
+			return nil, fmt.Errorf("can't get credential: %s", err)
+		}
+		accessKeyId = *model.AccessKeyId
+		accessKeySecret = *model.AccessKeySecret
+		if model.SecurityToken != nil {
+			stsToken = *model.SecurityToken
+		}
+	}
+
+	envs := os.Environ()
+	if accessKeyId != "" {
+		envs = append(envs, "ALIBABA_CLOUD_ACCESS_KEY_ID="+accessKeyId)
+	}
+	if accessKeySecret != "" {
+		envs = append(envs, "ALIBABA_CLOUD_ACCESS_KEY_SECRET="+accessKeySecret)
+	}
+	if stsToken != "" {
+		envs = append(envs, "ALIBABA_CLOUD_SECURITY_TOKEN="+stsToken)
+	}
+	if profile.RegionId != "" {
+		envs = append(envs, "ALIBABA_CLOUD_REGION_ID="+profile.RegionId)
+	}
+
+	envs = append(envs, "ALIBABA_CLOUD_FLOW_CLI_COMPAT_MODE=aliyun flow-cli")
+
+	if _, ok := os.LookupEnv("ALIBABA_CLOUD_USER_AGENT"); !ok {
+		configDir := config.GetConfigDir(c.originCtx)
+		if cfg, err := aimode.Load(configDir); err == nil && cfg != nil {
+			if ua := strings.TrimSpace(cfg.UserAgent); ua != "" {
+				envs = append(envs, "ALIBABA_CLOUD_USER_AGENT="+ua)
+			}
+		}
+	}
+	return envs, nil
+}
+
+// ExecuteFlowcli invokes the resolved flow-cli binary with the same stdio
+// wiring as esacli/computenestutil.
+func (c *Context) ExecuteFlowcli(args []string) error {
+	cmd := execCommandFunc(c.execFilePath, args...)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		return err
+	}
+	cmd.Env = envs
+	cmd.Stdout = c.originCtx.Stdout()
+	cmd.Stderr = c.originCtx.Stderr()
+	cmd.Stdin = os.Stdin
+	wd, _ := os.Getwd()
+	cmd.Dir = wd
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute %s %v: %v", c.execFilePath, args, err)
+	}
+	return nil
+}
+
+// --- version cache (24h TTL) ----------------------------------------------
+
+func (c *Context) NeedCheckVersion() bool {
+	if !c.installed {
+		return false
+	}
+	if !fileExists(c.checkVersionCacheFilePath) {
+		return true
+	}
+	data, err := os.ReadFile(c.checkVersionCacheFilePath)
+	if err != nil {
+		return true
+	}
+	var lastCheck int64
+	if _, err := fmt.Sscanf(string(data), "%d", &lastCheck); err != nil {
+		return true
+	}
+	return timeNowFunc().Unix()-lastCheck > int64(VersionCheckTTL)
+}
+
+func (c *Context) UpdateCheckCacheTime() error {
+	now := timeNowFunc().Unix()
+	return os.WriteFile(c.checkVersionCacheFilePath, []byte(fmt.Sprintf("%d", now)), 0o644)
+}
+
+// --- helpers --------------------------------------------------------------
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+var getNodeMajorFunc = getNodeMajor
+
+func getNodeMajor(nodeBin string) (int, error) {
+	cmd := execCommandFunc(nodeBin, "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return 0, err
+	}
+	// "v20.18.0\n" → "20"
+	s := strings.TrimSpace(out.String())
+	s = strings.TrimPrefix(s, "v")
+	dot := strings.Index(s, ".")
+	if dot < 0 {
+		return 0, fmt.Errorf("unexpected node --version output: %q", out.String())
+	}
+	return strconv.Atoi(s[:dot])
+}

--- a/cliext/flowcli/flowcli_test.go
+++ b/cliext/flowcli/flowcli_test.go
@@ -232,6 +232,87 @@ func TestEnsureNpmAvailablePrefersNextToNode(t *testing.T) {
 	}
 }
 
+func TestEnsurePrefixAndPackage_ExecPathOverrideMissing(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	missing := filepath.Join(tmp, "nope", "flow-cli")
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", missing)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo: %v", err)
+	}
+	err := c.EnsurePrefixAndPackage()
+	if err == nil {
+		t.Fatalf("expected error for missing exec path override")
+	}
+	if !strings.Contains(err.Error(), "ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH") || !strings.Contains(err.Error(), missing) {
+		t.Errorf("error should name the env var and path: %v", err)
+	}
+}
+
+func TestEnsurePrefixAndPackage_ExecPathOverrideExists(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	fake := filepath.Join(tmp, "flow-cli")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", fake)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo: %v", err)
+	}
+	if err := c.EnsurePrefixAndPackage(); err != nil {
+		t.Fatalf("existing override should not error: %v", err)
+	}
+}
+
+func TestUsingExecPathOverride(t *testing.T) {
+	c := &Context{}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", "")
+	if c.usingExecPathOverride() {
+		t.Errorf("empty env should not count as override")
+	}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", "  /some/path  ")
+	if !c.usingExecPathOverride() {
+		t.Errorf("non-empty env should count as override")
+	}
+}
+
+func TestApplyMainCliFlagsFromArgs_Shorthand(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	ctx.Flags().Add(&cli.Flag{Name: "profile", Shorthand: 'p', AssignedMode: cli.AssignedOnce, Category: "config"})
+	ctx.Flags().Add(&cli.Flag{Name: "endpoint", Shorthand: 'e', AssignedMode: cli.AssignedOnce, Category: "config"})
+
+	c := NewContext(ctx)
+	c.applyMainCliFlagsFromArgs([]string{"step", "list", "-p", "prod", "-e=https://x", "--name", "n"})
+
+	pf := ctx.Flags().Get("profile")
+	if pf == nil || !pf.IsAssigned() {
+		t.Fatalf("profile flag should be assigned via -p")
+	}
+	if v, _ := pf.GetValue(); v != "prod" {
+		t.Errorf("profile value: want prod got %q", v)
+	}
+	ef := ctx.Flags().Get("endpoint")
+	if ef == nil || !ef.IsAssigned() {
+		t.Fatalf("endpoint flag should be assigned via -e=")
+	}
+	if v, _ := ef.GetValue(); v != "https://x" {
+		t.Errorf("endpoint value: want https://x got %q", v)
+	}
+}
+
 func TestRemoveFlagsForMainCli(t *testing.T) {
 	ctx, _, _ := newOriginCtx()
 	addConfigFlag(ctx, "region", "cn-hangzhou")

--- a/cliext/flowcli/flowcli_test.go
+++ b/cliext/flowcli/flowcli_test.go
@@ -429,6 +429,68 @@ func TestFileExists(t *testing.T) {
 	}
 }
 
+// --- ExitError ---
+
+func TestExitError(t *testing.T) {
+	e := &ExitError{Code: 42}
+	if e.Error() != "subprocess exited with code 42" {
+		t.Errorf("Error() mismatch: %s", e.Error())
+	}
+	if e.ExitCode() != 42 {
+		t.Errorf("ExitCode() mismatch: %d", e.ExitCode())
+	}
+}
+
+func TestExecuteFlowcli_ExitCode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	prepareConfig(t, home)
+
+	origExec := execCommandFunc
+	defer func() { execCommandFunc = origExec }()
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 42")
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.execFilePath = "/any/path"
+
+	err := c.ExecuteFlowcli([]string{"version"})
+	if err == nil {
+		t.Fatalf("expected error for non-zero exit")
+	}
+	exitErr, ok := err.(*ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != 42 {
+		t.Errorf("exit code: got %d, want 42", exitErr.Code)
+	}
+}
+
+func TestExecuteFlowcli_Success(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	prepareConfig(t, home)
+
+	origExec := execCommandFunc
+	defer func() { execCommandFunc = origExec }()
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 0")
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.execFilePath = "/any/path"
+
+	if err := c.ExecuteFlowcli([]string{"version"}); err != nil {
+		t.Fatalf("ExecuteFlowcli: %v", err)
+	}
+}
+
 // --- helpers ---
 
 func envContains(envs []string, needle string) bool {

--- a/cliext/flowcli/flowcli_test.go
+++ b/cliext/flowcli/flowcli_test.go
@@ -1,0 +1,451 @@
+package flowcli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+)
+
+func newOriginCtx() (*cli.Context, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	ctx := cli.NewCommandContext(out, errOut)
+	return ctx, out, errOut
+}
+
+func addConfigFlag(ctx *cli.Context, name string, value string) {
+	f := &cli.Flag{Name: name, AssignedMode: cli.AssignedOnce, Category: "config"}
+	f.SetAssigned(true)
+	f.SetValue(value)
+	ctx.Flags().Add(f)
+}
+
+func prepareConfig(t *testing.T, home string) {
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	configJSON := `{"current":"default","profiles":[{"name":"default","mode":"AK","access_key_id":"ak","access_key_secret":"sk","region_id":"cn-hangzhou","language":"en"}]}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(configJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestNewContext(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if c == nil {
+		t.Fatalf("NewContext returned nil")
+	}
+	if c.originCtx != ctx {
+		t.Errorf("originCtx mismatch")
+	}
+}
+
+func TestInitBasicInfoUnix(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	oldGOOS := runtimeGOOSFunc
+	runtimeGOOSFunc = func() string { return "linux" }
+	defer func() { runtimeGOOSFunc = oldGOOS }()
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo failed: %v", err)
+	}
+
+	wantPrefix := filepath.Join(tmp, prefixDirName)
+	if c.prefixPath != wantPrefix {
+		t.Errorf("prefixPath: want %s got %s", wantPrefix, c.prefixPath)
+	}
+	wantExec := filepath.Join(wantPrefix, "bin", binName)
+	if c.execFilePath != wantExec {
+		t.Errorf("execFilePath: want %s got %s", wantExec, c.execFilePath)
+	}
+	if c.installed {
+		t.Errorf("should not be installed initially")
+	}
+}
+
+func TestInitBasicInfoWindows(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	oldGOOS := runtimeGOOSFunc
+	runtimeGOOSFunc = func() string { return "windows" }
+	defer func() { runtimeGOOSFunc = oldGOOS }()
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	_ = c.InitBasicInfo()
+
+	want := filepath.Join(tmp, prefixDirName, binName+".cmd")
+	if c.execFilePath != want {
+		t.Errorf("execFilePath: want %s got %s", want, c.execFilePath)
+	}
+}
+
+func TestInitBasicInfoExecPathOverride(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	fake := filepath.Join(tmp, "custom-flow-cli")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", fake)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	_ = c.InitBasicInfo()
+	if c.execFilePath != fake {
+		t.Errorf("execFilePath override: want %s got %s", fake, c.execFilePath)
+	}
+	if !c.installed {
+		t.Errorf("should be installed via override")
+	}
+}
+
+func TestEnsureNodeAvailableEnvOverride(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH", "/tmp/fake-node")
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.EnsureNodeAvailable(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if c.nodePath != "/tmp/fake-node" {
+		t.Errorf("nodePath: %s", c.nodePath)
+	}
+}
+
+func TestEnsureNodeAvailableMissingHints(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH", "")
+	oldLook := lookPathFunc
+	lookPathFunc = func(string) (string, error) { return "", exec.ErrNotFound }
+	defer func() { lookPathFunc = oldLook }()
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	err := c.EnsureNodeAvailable()
+	if err == nil {
+		t.Fatalf("expected error when node missing")
+	}
+	msg := err.Error()
+	for _, want := range []string{"node >= 18", "brew install node@18", "nodejs.org", "ALIBABA_CLOUD_FLOW_CLI_NODE_PATH"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error msg missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestEnsureNodeAvailableTooOld(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH", "")
+	oldLook := lookPathFunc
+	lookPathFunc = func(string) (string, error) { return "/usr/bin/node", nil }
+	defer func() { lookPathFunc = oldLook }()
+	oldMaj := getNodeMajorFunc
+	getNodeMajorFunc = func(string) (int, error) { return 16, nil }
+	defer func() { getNodeMajorFunc = oldMaj }()
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	err := c.EnsureNodeAvailable()
+	if err == nil {
+		t.Fatalf("expected error for old node")
+	}
+	if !strings.Contains(err.Error(), "node version too old") {
+		t.Errorf("error: %s", err.Error())
+	}
+}
+
+func TestEnsureNodeAvailableOK(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH", "")
+	oldLook := lookPathFunc
+	lookPathFunc = func(string) (string, error) { return "/usr/local/bin/node", nil }
+	defer func() { lookPathFunc = oldLook }()
+	oldMaj := getNodeMajorFunc
+	getNodeMajorFunc = func(string) (int, error) { return 20, nil }
+	defer func() { getNodeMajorFunc = oldMaj }()
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.EnsureNodeAvailable(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if c.nodePath != "/usr/local/bin/node" {
+		t.Errorf("nodePath: %s", c.nodePath)
+	}
+}
+
+func TestEnsureNpmAvailableEnvOverride(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NPM_PATH", "/tmp/fake-npm")
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.EnsureNpmAvailable(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if c.npmPath != "/tmp/fake-npm" {
+		t.Errorf("npmPath: %s", c.npmPath)
+	}
+}
+
+func TestEnsureNpmAvailablePrefersNextToNode(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NPM_PATH", "")
+	tmp := t.TempDir()
+	nodeBin := filepath.Join(tmp, "node")
+	npmBin := filepath.Join(tmp, "npm")
+	if err := os.WriteFile(nodeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write node: %v", err)
+	}
+	if err := os.WriteFile(npmBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write npm: %v", err)
+	}
+
+	oldGOOS := runtimeGOOSFunc
+	runtimeGOOSFunc = func() string { return "linux" }
+	defer func() { runtimeGOOSFunc = oldGOOS }()
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.osType = "linux"
+	c.nodePath = nodeBin
+	if err := c.EnsureNpmAvailable(); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if c.npmPath != npmBin {
+		t.Errorf("expected npm next to node, got %s", c.npmPath)
+	}
+}
+
+func TestRemoveFlagsForMainCli(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	addConfigFlag(ctx, "region", "cn-hangzhou")
+	addConfigFlag(ctx, "profile", "test")
+
+	c := NewContext(ctx)
+	args := []string{"step", "list", "--region", "cn-hangzhou", "--profile", "test", "--name", "my-step"}
+	out, err := c.RemoveFlagsForMainCli(args)
+	if err != nil {
+		t.Fatalf("RemoveFlagsForMainCli: %v", err)
+	}
+	for _, a := range out {
+		if a == "--region" || a == "--profile" || a == "cn-hangzhou" || a == "test" {
+			t.Errorf("config flag should be stripped: %s — got %v", a, out)
+		}
+	}
+	hasName := false
+	hasValue := false
+	for i, a := range out {
+		if a == "--name" {
+			hasName = true
+			if i+1 < len(out) && out[i+1] == "my-step" {
+				hasValue = true
+			}
+		}
+	}
+	if !hasName || !hasValue {
+		t.Errorf("--name should be preserved: %v", out)
+	}
+}
+
+func TestRemoveFlagsForMainCli_InlineValue(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	addConfigFlag(ctx, "region", "cn-hangzhou")
+	c := NewContext(ctx)
+	args := []string{"step", "list", "--region=cn-hangzhou", "--name=x"}
+	out, err := c.RemoveFlagsForMainCli(args)
+	if err != nil {
+		t.Fatalf("RemoveFlagsForMainCli: %v", err)
+	}
+	for _, a := range out {
+		if strings.HasPrefix(a, "--region") {
+			t.Errorf("--region=... should be stripped: got %v", out)
+		}
+	}
+	if len(out) != 3 || out[2] != "--name=x" {
+		t.Errorf("--name=x should be preserved: got %v", out)
+	}
+}
+
+func TestPrepareEnv_AKMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	prepareConfig(t, home)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv: %v", err)
+	}
+	want := map[string]string{
+		"ALIBABA_CLOUD_ACCESS_KEY_ID":        "ak",
+		"ALIBABA_CLOUD_ACCESS_KEY_SECRET":    "sk",
+		"ALIBABA_CLOUD_REGION_ID":            "cn-hangzhou",
+		"ALIBABA_CLOUD_FLOW_CLI_COMPAT_MODE": "aliyun flow-cli",
+	}
+	for k, v := range want {
+		needle := k + "=" + v
+		if !envContains(envs, needle) {
+			t.Errorf("env %q missing — got %v", needle, filterAliEnv(envs))
+		}
+	}
+}
+
+func TestPrepareEnv_AIModeUserAgentInjected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	os.Unsetenv("ALIBABA_CLOUD_USER_AGENT")
+	prepareConfig(t, home)
+
+	cfgDir := filepath.Join(home, ".aliyun")
+	aiJSON := `{"enabled":false,"user_agent":"AlibabaCloud-Agent-Skills/flow-cli-test"}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "ai-mode.json"), []byte(aiJSON), 0o600); err != nil {
+		t.Fatalf("write ai-mode: %v", err)
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv: %v", err)
+	}
+	want := "ALIBABA_CLOUD_USER_AGENT=AlibabaCloud-Agent-Skills/flow-cli-test"
+	if !envContains(envs, want) {
+		t.Errorf("UA env missing: %v", filterAliEnv(envs))
+	}
+}
+
+func TestPrepareEnv_AIModeUserAgentDoesNotOverrideExported(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("ALIBABA_CLOUD_USER_AGENT", "UserExported/1")
+	prepareConfig(t, home)
+
+	cfgDir := filepath.Join(home, ".aliyun")
+	aiJSON := `{"enabled":true,"user_agent":"FromAiMode/2"}`
+	if err := os.WriteFile(filepath.Join(cfgDir, "ai-mode.json"), []byte(aiJSON), 0o600); err != nil {
+		t.Fatalf("write ai-mode: %v", err)
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	envs, err := c.PrepareEnv()
+	if err != nil {
+		t.Fatalf("PrepareEnv: %v", err)
+	}
+	if envContains(envs, "ALIBABA_CLOUD_USER_AGENT=FromAiMode/2") {
+		t.Errorf("ai-mode UA should NOT override user-exported: %v", filterAliEnv(envs))
+	}
+}
+
+func TestNeedCheckVersion(t *testing.T) {
+	tmp := t.TempDir()
+	cache := filepath.Join(tmp, "cache")
+
+	cases := []struct {
+		name        string
+		installed   bool
+		cacheExists bool
+		content     string
+		now         int64
+		want        bool
+	}{
+		{"not installed", false, false, "", 0, false},
+		{"no cache", true, false, "", 0, true},
+		{"invalid cache", true, true, "garbage", 0, true},
+		{"expired", true, true, "1000000", 2000000, true},
+		{"fresh", true, true, fmt.Sprintf("%d", time.Now().Unix()), time.Now().Unix(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := cache + "-" + tc.name
+			c := &Context{installed: tc.installed, checkVersionCacheFilePath: f}
+			if tc.cacheExists {
+				if err := os.WriteFile(f, []byte(tc.content), 0o644); err != nil {
+					t.Fatalf("write cache: %v", err)
+				}
+			}
+			if tc.now > 0 {
+				old := timeNowFunc
+				timeNowFunc = func() time.Time { return time.Unix(tc.now, 0) }
+				defer func() { timeNowFunc = old }()
+			}
+			if got := c.NeedCheckVersion(); got != tc.want {
+				t.Errorf("want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestEffectiveBaseURL(t *testing.T) {
+	c := &Context{}
+	if got := c.effectiveBaseURL(); got != downloadBaseURL {
+		t.Errorf("default base: %s", got)
+	}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_DOWNLOAD_BASE_URL", "https://example.com/m")
+	if got := c.effectiveBaseURL(); got != "https://example.com/m" {
+		t.Errorf("override base: %s", got)
+	}
+}
+
+func TestEffectiveRegistry(t *testing.T) {
+	c := &Context{}
+	if got := c.effectiveRegistry(); got != defaultRegistry {
+		t.Errorf("default registry: %s", got)
+	}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NPM_REGISTRY", "https://registry.npmjs.org")
+	if got := c.effectiveRegistry(); got != "https://registry.npmjs.org" {
+		t.Errorf("override registry: %s", got)
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "x.txt")
+	if fileExists(p) {
+		t.Errorf("should not exist")
+	}
+	_ = os.WriteFile(p, []byte("x"), 0o644)
+	if !fileExists(p) {
+		t.Errorf("should exist")
+	}
+}
+
+// --- helpers ---
+
+func envContains(envs []string, needle string) bool {
+	for _, e := range envs {
+		if e == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func filterAliEnv(envs []string) []string {
+	out := []string{}
+	for _, e := range envs {
+		if strings.HasPrefix(e, "ALIBABA_CLOUD_") {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/cliext/flowcli/main.go
+++ b/cliext/flowcli/main.go
@@ -26,7 +26,18 @@ func NewFlowcliCommand() *cli.Command {
 					args = append(args, "--help")
 				}
 			}
-			return NewContext(ctx).Run(args)
+			if err := NewContext(ctx).Run(args); err != nil {
+				if exitErr, ok := err.(*ExitError); ok {
+					// Subprocess already wrote its own output to the connected
+					// stdout/stderr. Propagate the exit code directly instead
+					// of returning an error (which would print "ERROR: ..."
+					// and force exit code 1).
+					cli.Exit(exitErr.Code)
+					return nil
+				}
+				return err
+			}
+			return nil
 		},
 		EnableUnknownFlag: true,
 		KeepArgs:          true,

--- a/cliext/flowcli/main.go
+++ b/cliext/flowcli/main.go
@@ -1,0 +1,40 @@
+package flowcli
+
+import (
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+)
+
+func NewFlowcliCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name:   "flow-cli",
+		Short:  i18n.T("Alibaba Cloud DevOps Flow CLI for custom pipeline steps", "云效流水线 Flow-CLI，用于自定义开发步骤"),
+		Usage:  "aliyun flow-cli <command> [args...]",
+		Hidden: false,
+		Run: func(ctx *cli.Context, args []string) error {
+			// flow-cli uses commander; help is conventionally triggered by --help / -h
+			if ctx.IsHelp() {
+				hasHelp := false
+				for _, a := range args {
+					if a == "--help" || a == "-h" {
+						hasHelp = true
+						break
+					}
+				}
+				if !hasHelp {
+					args = append(args, "--help")
+				}
+			}
+			return NewContext(ctx).Run(args)
+		},
+		EnableUnknownFlag: true,
+		KeepArgs:          true,
+		SkipDefaultHelp:   true,
+	}
+	// register aliyun config flags (e.g. --access-key-id / --region) so
+	// they survive into ctx.Flags() for LoadProfileWithContext and so
+	// RemoveFlagsForMainCli can strip them from the args we forward.
+	config.AddFlags(cmd.Flags())
+	return cmd
+}

--- a/cliext/flowcli/main_test.go
+++ b/cliext/flowcli/main_test.go
@@ -1,0 +1,63 @@
+package flowcli
+
+import (
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+)
+
+func TestNewFlowcliCommand(t *testing.T) {
+	cmd := NewFlowcliCommand()
+	if cmd == nil {
+		t.Fatalf("NewFlowcliCommand returned nil")
+	}
+	if cmd.Name != "flow-cli" {
+		t.Errorf("Name expected 'flow-cli', got %s", cmd.Name)
+	}
+	if cmd.Short == nil {
+		t.Fatalf("Short i18n text nil")
+	}
+	if en := cmd.Short.Get("en"); en != "Alibaba Cloud DevOps Flow CLI for custom pipeline steps" {
+		t.Errorf("Short en unexpected: %s", en)
+	}
+	if zh := cmd.Short.Get("zh"); zh != "云效流水线 Flow-CLI，用于自定义开发步骤" {
+		t.Errorf("Short zh unexpected: %s", zh)
+	}
+	if cmd.Usage != "aliyun flow-cli <command> [args...]" {
+		t.Errorf("Usage unexpected: %s", cmd.Usage)
+	}
+	if cmd.Hidden {
+		t.Errorf("Hidden expected false")
+	}
+	if !cmd.EnableUnknownFlag {
+		t.Errorf("EnableUnknownFlag expected true")
+	}
+	if !cmd.KeepArgs {
+		t.Errorf("KeepArgs expected true")
+	}
+	if !cmd.SkipDefaultHelp {
+		t.Errorf("SkipDefaultHelp expected true")
+	}
+	if cmd.Run == nil {
+		t.Errorf("Run function should not be nil")
+	}
+}
+
+func TestNewFlowcliCommandMetadata(t *testing.T) {
+	cmd := NewFlowcliCommand()
+	metaMap := map[string]*cli.Metadata{}
+	cmd.GetMetadata(metaMap)
+	m, ok := metaMap[cmd.Name]
+	if !ok {
+		t.Fatalf("metadata for %s not found", cmd.Name)
+	}
+	if m.Name != "flow-cli" {
+		t.Errorf("metadata name expected flow-cli, got %s", m.Name)
+	}
+	if m.Usage != cmd.Usage {
+		t.Errorf("metadata usage mismatch")
+	}
+	if m.Hidden != cmd.Hidden {
+		t.Errorf("metadata hidden mismatch")
+	}
+}

--- a/cliext/flowcli/main_test.go
+++ b/cliext/flowcli/main_test.go
@@ -1,6 +1,7 @@
 package flowcli
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -59,5 +60,37 @@ func TestNewFlowcliCommandMetadata(t *testing.T) {
 	}
 	if m.Hidden != cmd.Hidden {
 		t.Errorf("metadata hidden mismatch")
+	}
+}
+
+func TestNewFlowcliCommand_RunSuppressesExitError(t *testing.T) {
+	cli.DisableExitCode()
+	defer cli.EnableExitCode()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	prepareConfig(t, home)
+
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", "/fake/flow-cli")
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH", "/fake/node")
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NPM_PATH", "/fake/npm")
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NO_UPDATE_CHECK", "1")
+
+	origExec := execCommandFunc
+	defer func() { execCommandFunc = origExec }()
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 7")
+	}
+
+	ctx, stdout, _ := newOriginCtx()
+	cmd := NewFlowcliCommand()
+	err := cmd.Run(ctx, []string{"version"})
+
+	if err != nil {
+		t.Fatalf("Run should return nil for ExitError (not propagate to framework), got: %v", err)
+	}
+	if stdout.Len() > 0 {
+		t.Errorf("no ANSI error text should appear on stdout, got: %q", stdout.String())
 	}
 }

--- a/cliext/flowcli/main_test.go
+++ b/cliext/flowcli/main_test.go
@@ -1,7 +1,9 @@
 package flowcli
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -72,9 +74,12 @@ func TestNewFlowcliCommand_RunSuppressesExitError(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 	prepareConfig(t, home)
 
-	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", "/fake/flow-cli")
+	fakeExec := filepath.Join(t.TempDir(), "flow-cli")
+	if err := os.WriteFile(fakeExec, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake exec: %v", err)
+	}
+	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_EXEC_PATH", fakeExec)
 	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NODE_PATH", "/fake/node")
-	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NPM_PATH", "/fake/npm")
 	t.Setenv("ALIBABA_CLOUD_FLOW_CLI_NO_UPDATE_CHECK", "1")
 
 	origExec := execCommandFunc

--- a/main/main.go
+++ b/main/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/cliext/codeup"
 	"github.com/aliyun/aliyun-cli/v3/cliext/computenestutil"
 	"github.com/aliyun/aliyun-cli/v3/cliext/esacli"
+	"github.com/aliyun/aliyun-cli/v3/cliext/flowcli"
 	"github.com/aliyun/aliyun-cli/v3/cliext/iact3"
 	"github.com/aliyun/aliyun-cli/v3/cliext/maxc"
 	"github.com/aliyun/aliyun-cli/v3/cliext/ossutil"
@@ -156,6 +157,8 @@ func newRootCommand(profile config.Profile, stdout io.Writer) *cli.Command {
 	rootCmd.AddSubCommand(computenestutil.NewComputenestCommand())
 	// esa-cli command
 	rootCmd.AddSubCommand(esacli.NewEsacliCommand())
+	// flow-cli command (云效 Flow)
+	rootCmd.AddSubCommand(flowcli.NewFlowcliCommand())
 	// cms2 command
 	rootCmd.AddSubCommand(cms2.NewCms2Command())
 	// maxc command


### PR DESCRIPTION
## Summary

- Add `aliyun flow-cli` root command that installs and proxies `@flow-step/flow-cli` (same pattern as esa-cli)
- Auto-install via npm into `~/.aliyun/flow-cli-prefix` with npmmirror as default registry; forward profile credentials/region
- Propagate subprocess ExitError via `cli.Exit` so child exit codes and output are not overwritten by the CLI framework