### PR TITLE
feat: add mseutil command to aliyun CLI

### DIFF
--- a/cliext/mseutil/main.go
+++ b/cliext/mseutil/main.go
@@ -1,0 +1,34 @@
+package mseutil
+
+import (
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+)
+
+func NewMseutilCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "mseutil",
+		Short:  i18n.T("Alibaba Cloud MSE utility for diagnosing Nacos/ZooKeeper instances", "阿里云 MSE 诊断工具（Nacos/ZooKeeper）"),
+		Usage:  "aliyun mseutil <command> [args...]",
+		Hidden: false,
+		Run: func(ctx *cli.Context, args []string) error {
+			// mseutil is cobra-based; help is --help / -h
+			if ctx.IsHelp() {
+				hasHelp := false
+				for _, a := range args {
+					if a == "--help" || a == "-h" {
+						hasHelp = true
+						break
+					}
+				}
+				if !hasHelp {
+					args = append(args, "--help")
+				}
+			}
+			return NewContext(ctx).Run(args)
+		},
+		EnableUnknownFlag: true,
+		KeepArgs:          true,
+		SkipDefaultHelp:   true,
+	}
+}

--- a/cliext/mseutil/main.go
+++ b/cliext/mseutil/main.go
@@ -25,7 +25,17 @@ func NewMseutilCommand() *cli.Command {
 					args = append(args, "--help")
 				}
 			}
-			return NewContext(ctx).Run(args)
+			if err := NewContext(ctx).Run(args); err != nil {
+				if exitErr, ok := err.(*ExitError); ok {
+					// Subprocess already wrote its own output to stdout/stderr.
+					// Propagate the exit code directly instead of returning an
+					// error (which would print an ANSI "ERROR: ..." line).
+					cli.Exit(exitErr.Code)
+					return nil
+				}
+				return err
+			}
+			return nil
 		},
 		EnableUnknownFlag: true,
 		KeepArgs:          true,

--- a/cliext/mseutil/main_test.go
+++ b/cliext/mseutil/main_test.go
@@ -1,0 +1,109 @@
+package mseutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+)
+
+func TestNewMseutilCommand(t *testing.T) {
+	cmd := NewMseutilCommand()
+	if cmd == nil {
+		t.Fatalf("NewMseutilCommand returned nil")
+	}
+	if cmd.Name != "mseutil" {
+		t.Errorf("Name expected 'mseutil', got %s", cmd.Name)
+	}
+	if cmd.Short == nil {
+		t.Fatalf("Short i18n text nil")
+	}
+	if en := cmd.Short.Get("en"); en != "Alibaba Cloud MSE utility for diagnosing Nacos/ZooKeeper instances" {
+		t.Errorf("Short en mismatch: %s", en)
+	}
+	if zh := cmd.Short.Get("zh"); zh != "阿里云 MSE 诊断工具（Nacos/ZooKeeper）" {
+		t.Errorf("Short zh mismatch: %s", zh)
+	}
+	if cmd.Usage != "aliyun mseutil <command> [args...]" {
+		t.Errorf("Usage mismatch: %s", cmd.Usage)
+	}
+	if cmd.Hidden {
+		t.Errorf("Hidden expected false")
+	}
+	if !cmd.EnableUnknownFlag {
+		t.Errorf("EnableUnknownFlag expected true")
+	}
+	if !cmd.KeepArgs {
+		t.Errorf("KeepArgs expected true")
+	}
+	if !cmd.SkipDefaultHelp {
+		t.Errorf("SkipDefaultHelp expected true")
+	}
+	if cmd.Run == nil {
+		t.Errorf("Run function should not be nil")
+	}
+}
+
+func TestNewMseutilCommandMetadata(t *testing.T) {
+	cmd := NewMseutilCommand()
+	metaMap := map[string]*cli.Metadata{}
+	cmd.GetMetadata(metaMap)
+	m, ok := metaMap[cmd.Name]
+	if !ok {
+		t.Fatalf("metadata for %s not found", cmd.Name)
+	}
+	if m.Name != "mseutil" {
+		t.Errorf("metadata name expected mseutil, got %s", m.Name)
+	}
+	if m.Usage != cmd.Usage {
+		t.Errorf("metadata usage mismatch")
+	}
+}
+
+func TestMseutilCommandRunInstalledSkipNetwork(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldGet := getConfigurePathFunc
+	oldGetVersion := getRemoteBinaryVersionFunc
+	getConfigurePathFunc = func() string { return tmpDir }
+	getRemoteBinaryVersionFunc = func(url string) (string, error) { return "etag-v1", nil }
+	defer func() {
+		getConfigurePathFunc = oldGet
+		getRemoteBinaryVersionFunc = oldGetVersion
+	}()
+
+	execPath := filepath.Join(tmpDir, "mseutil")
+	if runtime.GOOS == "windows" {
+		execPath += ".exe"
+	}
+	if err := os.WriteFile(execPath, []byte("dummy"), 0755); err != nil {
+		t.Fatalf("write fake exec: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".mseutil_version_check"), []byte("0"), 0644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".mseutil_version"), []byte("etag-v1"), 0644); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+
+	os.Setenv("ALIBABA_CLOUD_IGNORE_PROFILE", "TRUE")
+	defer os.Unsetenv("ALIBABA_CLOUD_IGNORE_PROFILE")
+
+	cmd := NewMseutilCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ctx := cli.NewCommandContext(stdout, stderr)
+
+	err := cmd.Run(ctx, []string{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	errStr := err.Error()
+	if !bytes.Contains([]byte(errStr), []byte("profile default is not configure yet")) &&
+		!bytes.Contains([]byte(errStr), []byte("can't get credential")) &&
+		!bytes.Contains([]byte(errStr), []byte("config failed")) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/cliext/mseutil/main_test.go
+++ b/cliext/mseutil/main_test.go
@@ -2,12 +2,16 @@ package mseutil
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
 )
 
 func TestNewMseutilCommand(t *testing.T) {
@@ -105,5 +109,69 @@ func TestMseutilCommandRunInstalledSkipNetwork(t *testing.T) {
 		!bytes.Contains([]byte(errStr), []byte("can't get credential")) &&
 		!bytes.Contains([]byte(errStr), []byte("config failed")) {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewMseutilCommand_RunSuppressesExitError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash exit helper not used on windows")
+	}
+	cli.DisableExitCode()
+	defer cli.EnableExitCode()
+
+	tmpDir := t.TempDir()
+	oldGet := getConfigurePathFunc
+	oldExec := execCommandFunc
+	oldGOOS := runtimeGOOSFunc
+	oldGOARCH := runtimeGOARCHFunc
+	getConfigurePathFunc = func() string { return tmpDir }
+	runtimeGOOSFunc = func() string { return "linux" }
+	runtimeGOARCHFunc = func() string { return "amd64" }
+	defer func() {
+		getConfigurePathFunc = oldGet
+		execCommandFunc = oldExec
+		runtimeGOOSFunc = oldGOOS
+		runtimeGOARCHFunc = oldGOARCH
+	}()
+
+	execPath := filepath.Join(tmpDir, "mseutil")
+	if err := os.WriteFile(execPath, []byte("dummy"), 0755); err != nil {
+		t.Fatalf("write fake exec: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".mseutil_version_check"),
+		[]byte(fmt.Sprintf("%d", time.Now().Unix())), 0644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".mseutil_version"), []byte("etag-v1"), 0644); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+		"current":"default",
+		"profiles":[{"name":"default","mode":"AK","access_key_id":"ak","access_key_secret":"sk","region_id":"cn-hangzhou"}]
+	}`), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 1")
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ctx := cli.NewCommandContext(stdout, stderr)
+	config.AddFlags(ctx.Flags())
+	cpFlag := ctx.Flags().Get(config.ConfigurePathFlagName)
+	cpFlag.SetAssigned(true)
+	cpFlag.SetValue(configPath)
+
+	cmd := NewMseutilCommand()
+	err := cmd.Run(ctx, []string{"version"})
+	if err != nil {
+		t.Fatalf("Run should return nil for ExitError (not propagate to framework), got: %v", err)
+	}
+	if stdout.Len() > 0 {
+		t.Errorf("no ANSI error text should appear on stdout, got: %q", stdout.String())
 	}
 }

--- a/cliext/mseutil/mseutil.go
+++ b/cliext/mseutil/mseutil.go
@@ -56,6 +56,20 @@ const defaultDownloadBase = "https://msetools.oss-cn-hangzhou.aliyuncs.com/mseut
 
 var VersionCheckTTL = 86400 // 1 day, in seconds
 
+// ExitError carries the exit code from the child process so the caller
+// can propagate it without calling os.Exit directly (which skips defers).
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("subprocess exited with code %d", e.Code)
+}
+
+func (e *ExitError) ExitCode() int {
+	return e.Code
+}
+
 // platformPaths maps goos-goarch to OSS path segments used by mseutil releases.
 // Official URLs use x86_64 (not amd64).
 var platformPaths = map[string][2]string{
@@ -357,6 +371,9 @@ func (c *Context) ExecuteMseutil(args []string) error {
 	cmd.Stdin = os.Stdin
 
 	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return &ExitError{Code: exitErr.ExitCode()}
+		}
 		return fmt.Errorf("failed to execute %s %v: %v", c.execFilePath, args, err)
 	}
 	return nil

--- a/cliext/mseutil/mseutil.go
+++ b/cliext/mseutil/mseutil.go
@@ -1,0 +1,432 @@
+package mseutil
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/util"
+)
+
+type Context struct {
+	originCtx                 *cli.Context
+	configPath                string
+	checkVersionCacheFilePath string
+	versionFilePath           string
+	execFilePath              string
+	installed                 bool
+	versionLocal              string
+	versionRemote             string
+	osType                    string
+	osArch                    string
+	osSupport                 bool
+	platformOS                string // OSS path segment: linux/darwin/windows
+	platformArch              string // OSS path segment: x86_64/arm64
+	envMap                    map[string]string
+	useExternalBinary         bool
+}
+
+var getConfigurePathFunc = func() string {
+	return config.GetConfigPath()
+}
+
+var (
+	downloadBinaryFunc         = downloadBinary
+	execCommandFunc            = exec.Command
+	timeNowFunc                = time.Now
+	runtimeGOOSFunc            = func() string { return runtime.GOOS }
+	runtimeGOARCHFunc          = func() string { return runtime.GOARCH }
+	getRemoteBinaryVersionFunc = GetRemoteBinaryVersion
+	httpDoFunc                 = func(req *http.Request) (*http.Response, error) {
+		client := &http.Client{Timeout: 30 * time.Second}
+		return client.Do(req)
+	}
+)
+
+// Official mseutil distribution (see help.aliyun.com mseutil docs).
+const defaultDownloadBase = "https://msetools.oss-cn-hangzhou.aliyuncs.com/mseutil"
+
+var VersionCheckTTL = 86400 // 1 day, in seconds
+
+// platformPaths maps goos-goarch to OSS path segments used by mseutil releases.
+// Official URLs use x86_64 (not amd64).
+var platformPaths = map[string][2]string{
+	"linux-amd64":   {"linux", "x86_64"},
+	"linux-arm64":   {"linux", "arm64"},
+	"darwin-amd64":  {"darwin", "x86_64"},
+	"darwin-arm64":  {"darwin", "arm64"},
+	"windows-amd64": {"windows", "x86_64"},
+	"windows-arm64": {"windows", "arm64"},
+}
+
+func NewContext(originContext *cli.Context) *Context {
+	return &Context{
+		originCtx: originContext,
+	}
+}
+
+func (c *Context) Run(args []string) error {
+	if err := c.InitializeAndValidatePlatform(); err != nil {
+		return err
+	}
+	if err := c.EnsureInstalledAndUpdated(); err != nil {
+		return err
+	}
+	if err := c.PrepareEnv(); err != nil {
+		return err
+	}
+	newArgs, err := c.RemoveFlagsForMainCli(args)
+	if err != nil {
+		return err
+	}
+	return c.ExecuteMseutil(newArgs)
+}
+
+func (c *Context) InitializeAndValidatePlatform() error {
+	c.InitBasicInfo()
+	c.CheckOsTypeAndArch()
+	if !c.osSupport && !c.useExternalBinary {
+		return fmt.Errorf("your os type %s and arch %s is not supported now", c.osType, c.osArch)
+	}
+	return nil
+}
+
+func (c *Context) CheckOsTypeAndArch() {
+	c.osType = runtimeGOOSFunc()
+	c.osArch = runtimeGOARCHFunc()
+	key := c.osType + "-" + c.osArch
+	if parts, ok := platformPaths[key]; ok {
+		c.osSupport = true
+		c.platformOS = parts[0]
+		c.platformArch = parts[1]
+	} else {
+		c.osSupport = false
+		c.platformOS = ""
+		c.platformArch = ""
+	}
+}
+
+func (c *Context) InitBasicInfo() {
+	c.configPath = getConfigurePathFunc()
+	c.checkVersionCacheFilePath = filepath.Join(c.configPath, ".mseutil_version_check")
+	c.versionFilePath = filepath.Join(c.configPath, ".mseutil_version")
+	c.execFilePath = filepath.Join(c.configPath, "mseutil")
+	if runtimeGOOSFunc() == "windows" {
+		c.execFilePath += ".exe"
+	}
+
+	if envPath := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_MSEUTIL_EXEC_PATH")); envPath != "" {
+		c.execFilePath = envPath
+		c.useExternalBinary = true
+	}
+	c.installed = fileExists(c.execFilePath)
+}
+
+func (c *Context) effectiveBaseURL() string {
+	if u := strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_MSEUTIL_DOWNLOAD_BASE_URL")); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return defaultDownloadBase
+}
+
+func (c *Context) downloadURL() string {
+	return fmt.Sprintf("%s/%s/%s/mseutil", c.effectiveBaseURL(), c.platformOS, c.platformArch)
+}
+
+// GetRemoteBinaryVersion returns a fingerprint for the remote binary via HEAD ETag
+// (mseutil OSS has no version.txt channel).
+func GetRemoteBinaryVersion(downloadURL string) (string, error) {
+	req, err := http.NewRequest(http.MethodHead, downloadURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request for %s: %v", downloadURL, err)
+	}
+	req.Header.Set("User-Agent", "aliyun-cli/"+cli.Version)
+
+	resp, err := httpDoFunc(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch headers from %s: %v", downloadURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("HTTP request failed with status code %d from %s", resp.StatusCode, downloadURL)
+	}
+
+	etag := strings.Trim(resp.Header.Get("ETag"), `"`)
+	if etag == "" {
+		etag = strings.TrimSpace(resp.Header.Get("Content-MD5"))
+	}
+	if etag == "" {
+		etag = strings.TrimSpace(resp.Header.Get("Last-Modified"))
+	}
+	if etag == "" {
+		return "", fmt.Errorf("no ETag/Content-MD5/Last-Modified on %s", downloadURL)
+	}
+	return etag, nil
+}
+
+func (c *Context) EnsureInstalledAndUpdated() error {
+	if c.useExternalBinary {
+		if !c.installed {
+			return fmt.Errorf("mseutil binary not found at ALIBABA_CLOUD_MSEUTIL_EXEC_PATH=%s", c.execFilePath)
+		}
+		return nil
+	}
+
+	if !c.installed {
+		version, err := getRemoteBinaryVersionFunc(c.downloadURL())
+		if err != nil {
+			return fmt.Errorf("mseutil is not installed and auto-download failed: %v", err)
+		}
+		c.versionRemote = version
+		if err := c.Install(); err != nil {
+			return err
+		}
+		_ = c.UpdateCheckCacheTime()
+		return nil
+	}
+
+	if os.Getenv("ALIBABA_CLOUD_MSEUTIL_NO_UPDATE_CHECK") == "1" {
+		return nil
+	}
+	if !c.NeedCheckVersion() {
+		return nil
+	}
+
+	version, err := getRemoteBinaryVersionFunc(c.downloadURL())
+	if err != nil {
+		// upgrade is best-effort when already installed
+		return nil
+	}
+	c.versionRemote = version
+
+	if err := c.GetLocalVersion(); err != nil {
+		// missing local fingerprint → treat as need update
+		c.versionLocal = ""
+	}
+	if c.versionLocal != c.versionRemote {
+		if err := c.Install(); err != nil {
+			return nil
+		}
+	}
+	_ = c.UpdateCheckCacheTime()
+	return nil
+}
+
+func (c *Context) Install() error {
+	url := c.downloadURL()
+	if c.originCtx != nil {
+		fmt.Fprintf(c.originCtx.Stderr(), "Installing mseutil from %s ...\n", url)
+	}
+
+	tmpFile := c.execFilePath + ".tmp"
+	if err := downloadBinaryFunc(url, tmpFile); err != nil {
+		_ = os.Remove(tmpFile)
+		return fmt.Errorf("failed to download mseutil from %s: %v", url, err)
+	}
+
+	if runtimeGOOSFunc() != "windows" {
+		if err := os.Chmod(tmpFile, 0755); err != nil {
+			_ = os.Remove(tmpFile)
+			return fmt.Errorf("failed to set exec permission: %v", err)
+		}
+	}
+
+	if runtimeGOOSFunc() == "windows" && fileExists(c.execFilePath) {
+		_ = os.Remove(c.execFilePath)
+	}
+	if err := os.Rename(tmpFile, c.execFilePath); err != nil {
+		if copyErr := util.CopyFileAndRemoveSource(tmpFile, c.execFilePath); copyErr != nil {
+			return fmt.Errorf("failed to install mseutil binary: %v", copyErr)
+		}
+	}
+
+	c.versionLocal = c.versionRemote
+	c.installed = true
+	return c.SaveLocalVersion()
+}
+
+func downloadBinary(url string, destFile string) error {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for %s: %v", url, err)
+	}
+	req.Header.Set("User-Agent", "aliyun-cli/"+cli.Version)
+
+	resp, err := httpDoFunc(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: status code %d", url, resp.StatusCode)
+	}
+	out, err := os.Create(destFile)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %v", destFile, err)
+	}
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		_ = out.Close()
+		return fmt.Errorf("failed to write to file %s: %v", destFile, err)
+	}
+	if err = out.Close(); err != nil {
+		return fmt.Errorf("failed to close file %s: %v", destFile, err)
+	}
+	return nil
+}
+
+func (c *Context) PrepareEnv() error {
+	profile, err := config.LoadProfileWithContext(c.originCtx)
+	if err != nil {
+		return fmt.Errorf("config failed: %s", err.Error())
+	}
+
+	envMap, err := profile.GetRuntimeEnv(c.originCtx)
+	if err != nil {
+		return fmt.Errorf("failed to get runtime env: %s", err.Error())
+	}
+
+	if profile.RegionId != "" {
+		envMap["REGION_ID"] = profile.RegionId
+	}
+	envMap["ALIBABA_CLOUD_MSEUTIL_COMPAT_MODE"] = "aliyun mseutil"
+
+	c.envMap = envMap
+	return nil
+}
+
+func (c *Context) RemoveFlagsForMainCli(args []string) ([]string, error) {
+	if c.originCtx.Flags() == nil || c.originCtx.Flags().Flags() == nil {
+		return append([]string(nil), args...), nil
+	}
+	longNeedsValue := make(map[string]bool)
+	shortNeedsValue := make(map[string]bool)
+	for _, f := range c.originCtx.Flags().Flags() {
+		if !f.IsAssigned() || f.Category != "config" {
+			continue
+		}
+		needsValue := f.AssignedMode != cli.AssignedNone
+		if f.Name != "" {
+			longNeedsValue["--"+f.Name] = needsValue
+		}
+		if f.Shorthand != 0 {
+			shortNeedsValue["-"+string(f.Shorthand)] = needsValue
+		}
+	}
+
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if needs, ok := longNeedsValue[a]; ok {
+			if needs && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		if needs, ok := shortNeedsValue[a]; ok {
+			if needs && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func (c *Context) ExecuteMseutil(args []string) error {
+	http.DefaultClient.CloseIdleConnections()
+
+	cmd := execCommandFunc(c.execFilePath, args...)
+	envs := filterEnv(os.Environ(), c.envMap)
+	for k, v := range c.envMap {
+		envs = append(envs, k+"="+v)
+	}
+	cmd.Env = envs
+	cmd.Stdout = c.originCtx.Stdout()
+	cmd.Stderr = c.originCtx.Stderr()
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute %s %v: %v", c.execFilePath, args, err)
+	}
+	return nil
+}
+
+func (c *Context) NeedCheckVersion() bool {
+	if !c.installed {
+		return false
+	}
+	if !fileExists(c.checkVersionCacheFilePath) {
+		return true
+	}
+	data, err := os.ReadFile(c.checkVersionCacheFilePath)
+	if err != nil {
+		return true
+	}
+	var lastCheckTime int64
+	if _, err := fmt.Sscanf(string(data), "%d", &lastCheckTime); err != nil {
+		return true
+	}
+	return timeNowFunc().Unix()-lastCheckTime > int64(VersionCheckTTL)
+}
+
+func (c *Context) GetLocalVersion() error {
+	if !c.installed {
+		c.versionLocal = ""
+		return fmt.Errorf("mseutil not installed")
+	}
+	if fileExists(c.versionFilePath) {
+		data, err := os.ReadFile(c.versionFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to read version file %s: %v", c.versionFilePath, err)
+		}
+		c.versionLocal = strings.TrimSpace(string(data))
+		if c.versionLocal == "" {
+			return fmt.Errorf("version file %s is empty", c.versionFilePath)
+		}
+		return nil
+	}
+	return fmt.Errorf("version file %s not found", c.versionFilePath)
+}
+
+func (c *Context) SaveLocalVersion() error {
+	if err := os.WriteFile(c.versionFilePath, []byte(c.versionLocal), 0644); err != nil {
+		return fmt.Errorf("failed to write version file %s: %v", c.versionFilePath, err)
+	}
+	return nil
+}
+
+func (c *Context) UpdateCheckCacheTime() error {
+	data := fmt.Sprintf("%d", timeNowFunc().Unix())
+	if err := os.WriteFile(c.checkVersionCacheFilePath, []byte(data), 0644); err != nil {
+		return fmt.Errorf("failed to write cache file %s: %v", c.checkVersionCacheFilePath, err)
+	}
+	return nil
+}
+
+func filterEnv(base []string, overrides map[string]string) []string {
+	result := make([]string, 0, len(base))
+	for _, item := range base {
+		key, _, _ := strings.Cut(item, "=")
+		if _, conflict := overrides[key]; conflict {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cliext/mseutil/mseutil_test.go
+++ b/cliext/mseutil/mseutil_test.go
@@ -655,3 +655,63 @@ func TestUnsupportedPlatform(t *testing.T) {
 		t.Fatalf("expected unsupported platform error, got %v", err)
 	}
 }
+
+// --- ExitError ---
+
+func TestExitError(t *testing.T) {
+	e := &ExitError{Code: 42}
+	if e.Error() != "subprocess exited with code 42" {
+		t.Errorf("Error() mismatch: %s", e.Error())
+	}
+	if e.ExitCode() != 42 {
+		t.Errorf("ExitCode() mismatch: %d", e.ExitCode())
+	}
+}
+
+func TestExecuteMseutil_ExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash exit helper not used on windows")
+	}
+	origExec := execCommandFunc
+	defer func() { execCommandFunc = origExec }()
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 42")
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.execFilePath = "/any/path"
+	c.envMap = map[string]string{}
+
+	err := c.ExecuteMseutil([]string{"version"})
+	if err == nil {
+		t.Fatalf("expected error for non-zero exit")
+	}
+	exitErr, ok := err.(*ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != 42 {
+		t.Errorf("exit code: got %d, want 42", exitErr.Code)
+	}
+}
+
+func TestExecuteMseutil_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash exit helper not used on windows")
+	}
+	origExec := execCommandFunc
+	defer func() { execCommandFunc = origExec }()
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("bash", "-c", "exit 0")
+	}
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.execFilePath = "/any/path"
+	c.envMap = map[string]string{"ALIBABA_CLOUD_MSEUTIL_COMPAT_MODE": "aliyun mseutil"}
+
+	if err := c.ExecuteMseutil([]string{"version"}); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}

--- a/cliext/mseutil/mseutil_test.go
+++ b/cliext/mseutil/mseutil_test.go
@@ -1,0 +1,657 @@
+package mseutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+)
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Exit(0)
+}
+
+func setupTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
+	origHomeDrive := os.Getenv("HOMEDRIVE")
+	origHomePath := os.Getenv("HOMEPATH")
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("USERPROFILE", origUserProfile)
+		os.Setenv("HOMEDRIVE", origHomeDrive)
+		os.Setenv("HOMEPATH", origHomePath)
+	})
+	os.Setenv("HOME", home)
+	os.Setenv("USERPROFILE", home)
+	os.Setenv("HOMEDRIVE", "")
+	os.Setenv("HOMEPATH", "")
+	return home
+}
+
+func prepareConfig(t *testing.T, home string, language string) {
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	configJSON := fmt.Sprintf(`{"current":"default","profiles":[{"name":"default","mode":"AK","access_key_id":"ak","access_key_secret":"sk","region_id":"cn-hangzhou","language":"%s"}]}`, language)
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func prepareConfigWithMode(t *testing.T, home string, mode string, extraFields map[string]string) {
+	cfgDir := filepath.Join(home, ".aliyun")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	profile := map[string]interface{}{
+		"name":              "default",
+		"mode":              mode,
+		"access_key_id":     "ak",
+		"access_key_secret": "sk",
+		"region_id":         "cn-hangzhou",
+		"language":          "en",
+	}
+	for k, v := range extraFields {
+		switch k {
+		case "retry_timeout", "connect_timeout", "retry_count":
+			if intVal, err := strconv.Atoi(v); err == nil {
+				profile[k] = intVal
+			} else {
+				profile[k] = v
+			}
+		default:
+			profile[k] = v
+		}
+	}
+	configMap := map[string]interface{}{
+		"current":  "default",
+		"profiles": []interface{}{profile},
+	}
+	configJSON, err := json.Marshal(configMap)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), configJSON, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func newOriginCtx() (*cli.Context, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	ctx := cli.NewCommandContext(out, errOut)
+	return ctx, out, errOut
+}
+
+func addConfigFlag(ctx *cli.Context, name string, value string) {
+	f := &cli.Flag{Name: name, AssignedMode: cli.AssignedOnce, Category: "config"}
+	f.SetAssigned(true)
+	f.SetValue(value)
+	ctx.Flags().Add(f)
+}
+
+func writeExecutable(t *testing.T, path string, content string) {
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write exec failed: %v", err)
+	}
+}
+
+func mockExecCommand() *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+func TestRun_NotInstalled_FreshInstallAndExecute(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfig(t, home, "zh")
+
+	origDownload := downloadBinaryFunc
+	origExec := execCommandFunc
+	origTimeNow := timeNowFunc
+	origGetVersion := getRemoteBinaryVersionFunc
+	downloadCount := 0
+	downloadBinaryFunc = func(url, dest string) error {
+		downloadCount++
+		writeExecutable(t, dest, "dummy")
+		return nil
+	}
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		return mockExecCommand()
+	}
+	getRemoteBinaryVersionFunc = func(url string) (string, error) { return "etag-fresh", nil }
+	fixedNow := time.Unix(1700000000, 0)
+	timeNowFunc = func() time.Time { return fixedNow }
+	t.Cleanup(func() {
+		downloadBinaryFunc = origDownload
+		execCommandFunc = origExec
+		timeNowFunc = origTimeNow
+		getRemoteBinaryVersionFunc = origGetVersion
+	})
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+
+	if err := c.Run([]string{"zookeeper", "--serverAddr", "mse-x.aliyuncs.com", "inspect"}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if downloadCount != 1 {
+		t.Fatalf("expected download once, got %d", downloadCount)
+	}
+	data, err := os.ReadFile(filepath.Join(config.GetConfigPath(), ".mseutil_version_check"))
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != fmt.Sprintf("%d", fixedNow.Unix()) {
+		t.Fatalf("cache timestamp mismatch: %s", string(data))
+	}
+}
+
+func TestRun_Installed_NoVersionCheckWithinTTL(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfig(t, home, "en")
+
+	execPath := filepath.Join(config.GetConfigPath(), "mseutil")
+	if runtime.GOOS == "windows" {
+		execPath += ".exe"
+	}
+	writeExecutable(t, execPath, "dummy")
+	_ = os.WriteFile(filepath.Join(config.GetConfigPath(), ".mseutil_version_check"), []byte(fmt.Sprintf("%d", time.Now().Unix())), 0644)
+
+	origDownload := downloadBinaryFunc
+	origExec := execCommandFunc
+	downloadCount := 0
+	downloadBinaryFunc = func(url, dest string) error { downloadCount++; return nil }
+	execCommandFunc = func(name string, args ...string) *exec.Cmd { return mockExecCommand() }
+	t.Cleanup(func() {
+		downloadBinaryFunc = origDownload
+		execCommandFunc = origExec
+	})
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.Run([]string{"nacos", "inspect"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if downloadCount != 0 {
+		t.Fatalf("expected no download, got %d", downloadCount)
+	}
+}
+
+func TestRun_Installed_UpdateWhenExpired(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfig(t, home, "en")
+
+	execPath := filepath.Join(config.GetConfigPath(), "mseutil")
+	if runtime.GOOS == "windows" {
+		execPath += ".exe"
+	}
+	writeExecutable(t, execPath, "dummy")
+
+	old := time.Now().Unix() - int64(VersionCheckTTL) - 10
+	_ = os.WriteFile(filepath.Join(config.GetConfigPath(), ".mseutil_version_check"), []byte(fmt.Sprintf("%d", old)), 0644)
+	_ = os.WriteFile(filepath.Join(config.GetConfigPath(), ".mseutil_version"), []byte("etag-old"), 0644)
+
+	origDownload := downloadBinaryFunc
+	origExec := execCommandFunc
+	origGetVersion := getRemoteBinaryVersionFunc
+	downloadCount := 0
+	downloadBinaryFunc = func(url, dest string) error {
+		downloadCount++
+		writeExecutable(t, dest, "dummy")
+		return nil
+	}
+	execCommandFunc = func(name string, args ...string) *exec.Cmd { return mockExecCommand() }
+	getRemoteBinaryVersionFunc = func(url string) (string, error) { return "etag-new", nil }
+	t.Cleanup(func() {
+		downloadBinaryFunc = origDownload
+		execCommandFunc = origExec
+		getRemoteBinaryVersionFunc = origGetVersion
+	})
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.Run([]string{"net", "help"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if downloadCount == 0 {
+		t.Fatalf("expected download triggered")
+	}
+}
+
+func TestRun_ExternalExecPath(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfig(t, home, "en")
+
+	external := filepath.Join(t.TempDir(), "custom-mseutil")
+	writeExecutable(t, external, "dummy")
+	t.Setenv("ALIBABA_CLOUD_MSEUTIL_EXEC_PATH", external)
+
+	origDownload := downloadBinaryFunc
+	origExec := execCommandFunc
+	downloadCount := 0
+	downloadBinaryFunc = func(url, dest string) error { downloadCount++; return nil }
+	var gotName string
+	execCommandFunc = func(name string, args ...string) *exec.Cmd {
+		gotName = name
+		return mockExecCommand()
+	}
+	t.Cleanup(func() {
+		downloadBinaryFunc = origDownload
+		execCommandFunc = origExec
+	})
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.Run([]string{"-h"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if downloadCount != 0 {
+		t.Fatalf("external path should skip download")
+	}
+	if gotName != external {
+		t.Fatalf("expected exec %s, got %s", external, gotName)
+	}
+}
+
+func TestNeedCheckVersionVariants(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfig(t, home, "zh")
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	if c.NeedCheckVersion() {
+		t.Fatalf("not installed should return false")
+	}
+
+	execPath := filepath.Join(config.GetConfigPath(), "mseutil")
+	if runtime.GOOS == "windows" {
+		execPath += ".exe"
+	}
+	writeExecutable(t, execPath, "dummy")
+	c.InitBasicInfo()
+	if !c.NeedCheckVersion() {
+		t.Fatalf("installed no cache => true")
+	}
+
+	_ = os.WriteFile(filepath.Join(config.GetConfigPath(), ".mseutil_version_check"), []byte("abc"), 0644)
+	c.InitBasicInfo()
+	if !c.NeedCheckVersion() {
+		t.Fatalf("invalid content => true")
+	}
+
+	_ = os.WriteFile(filepath.Join(config.GetConfigPath(), ".mseutil_version_check"), []byte(fmt.Sprintf("%d", time.Now().Unix())), 0644)
+	c.InitBasicInfo()
+	if c.NeedCheckVersion() {
+		t.Fatalf("fresh cache => false")
+	}
+
+	_ = os.WriteFile(filepath.Join(config.GetConfigPath(), ".mseutil_version_check"), []byte(fmt.Sprintf("%d", time.Now().Unix()-int64(VersionCheckTTL)-5)), 0644)
+	c.InitBasicInfo()
+	if !c.NeedCheckVersion() {
+		t.Fatalf("expired => true")
+	}
+}
+
+func TestRemoveFlagsForMainCli(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	addConfigFlag(ctx, "region", "cn-hangzhou")
+	c := NewContext(ctx)
+	args, err := c.RemoveFlagsForMainCli([]string{"zookeeper", "inspect", "--region", "cn-hangzhou"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--region") {
+		t.Fatalf("region flag should be removed: %s", joined)
+	}
+	if !strings.Contains(joined, "inspect") {
+		t.Fatalf("inspect should remain: %s", joined)
+	}
+}
+
+func TestRemoveFlagsForMainCli_NilFlags(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	args, err := c.RemoveFlagsForMainCli([]string{"nacos", "ls"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(args) != 2 || args[0] != "nacos" || args[1] != "ls" {
+		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
+func TestGetLocalVersion_NotInstalled(t *testing.T) {
+	setupTestHome(t)
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	c.installed = false
+	err := c.GetLocalVersion()
+	if err == nil {
+		t.Fatalf("expected error when not installed")
+	}
+	if c.versionLocal != "" {
+		t.Fatalf("versionLocal should be empty")
+	}
+}
+
+func TestGetLocalVersion_Success(t *testing.T) {
+	setupTestHome(t)
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	c.installed = true
+	_ = os.WriteFile(c.versionFilePath, []byte("etag-abc\n"), 0644)
+	if err := c.GetLocalVersion(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if c.versionLocal != "etag-abc" {
+		t.Fatalf("versionLocal mismatch %s", c.versionLocal)
+	}
+}
+
+func TestInstallUrlAndInvocation(t *testing.T) {
+	setupTestHome(t)
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	c.CheckOsTypeAndArch()
+	c.versionRemote = "etag-install"
+
+	called := false
+	origDownload := downloadBinaryFunc
+	downloadBinaryFunc = func(url, dest string) error {
+		called = true
+		expectedURL := c.downloadURL()
+		if url != expectedURL {
+			t.Fatalf("url mismatch: %s vs %s", url, expectedURL)
+		}
+		writeExecutable(t, dest, "dummy")
+		return nil
+	}
+	defer func() { downloadBinaryFunc = origDownload }()
+
+	if err := c.Install(); err != nil {
+		t.Fatalf("Install err: %v", err)
+	}
+	if !called {
+		t.Fatalf("download not called")
+	}
+	if c.versionLocal != "etag-install" {
+		t.Fatalf("versionLocal should be etag-install, got %s", c.versionLocal)
+	}
+	if !c.installed {
+		t.Fatalf("installed should be true")
+	}
+}
+
+func TestUpdateCheckCacheTime(t *testing.T) {
+	setupTestHome(t)
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	origNow := timeNowFunc
+	fixed := time.Unix(1800000000, 0)
+	timeNowFunc = func() time.Time { return fixed }
+	defer func() { timeNowFunc = origNow }()
+
+	if err := c.UpdateCheckCacheTime(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b, _ := os.ReadFile(c.checkVersionCacheFilePath)
+	if strings.TrimSpace(string(b)) != fmt.Sprintf("%d", fixed.Unix()) {
+		t.Fatalf("cache mismatch %s", string(b))
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.txt")
+	if fileExists(f) {
+		t.Fatalf("should false before create")
+	}
+	_ = os.WriteFile(f, []byte("1"), 0644)
+	if !fileExists(f) {
+		t.Fatalf("should true after create")
+	}
+}
+
+func TestPrepareEnv(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfig(t, home, "en")
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	if err := c.PrepareEnv(); err != nil {
+		t.Fatalf("PrepareEnv err: %v", err)
+	}
+	if c.envMap["ALIBABA_CLOUD_MSEUTIL_COMPAT_MODE"] != "aliyun mseutil" {
+		t.Fatalf("COMPAT_MODE missing")
+	}
+	if c.envMap["REGION_ID"] != "cn-hangzhou" {
+		t.Fatalf("REGION_ID mismatch: %v", c.envMap["REGION_ID"])
+	}
+	if c.envMap["ALIBABA_CLOUD_ACCESS_KEY_ID"] != "ak" {
+		t.Fatalf("ak mismatch: %v", c.envMap["ALIBABA_CLOUD_ACCESS_KEY_ID"])
+	}
+	if c.envMap["ALIBABA_CLOUD_ACCESS_KEY_SECRET"] != "sk" {
+		t.Fatalf("sk mismatch: %v", c.envMap["ALIBABA_CLOUD_ACCESS_KEY_SECRET"])
+	}
+}
+
+func TestPrepareEnv_StsToken(t *testing.T) {
+	home := setupTestHome(t)
+	prepareConfigWithMode(t, home, "StsToken", map[string]string{
+		"sts_token": "sts123",
+	})
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	if err := c.PrepareEnv(); err != nil {
+		t.Fatalf("PrepareEnv err: %v", err)
+	}
+	if c.envMap["ALIBABA_CLOUD_SECURITY_TOKEN"] != "sts123" {
+		t.Fatalf("security token mismatch: %v", c.envMap["ALIBABA_CLOUD_SECURITY_TOKEN"])
+	}
+}
+
+func TestPrepareEnv_ConfigLoadError(t *testing.T) {
+	setupTestHome(t)
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.InitBasicInfo()
+	err := c.PrepareEnv()
+	if err == nil {
+		t.Fatalf("expected config load error")
+	}
+	if !strings.Contains(err.Error(), "config failed") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestCheckOsTypeAndArchVariants(t *testing.T) {
+	origGOOS := runtimeGOOSFunc
+	origGOARCH := runtimeGOARCHFunc
+	defer func() { runtimeGOOSFunc = origGOOS; runtimeGOARCHFunc = origGOARCH }()
+
+	tests := []struct {
+		os, arch string
+		support  bool
+		platOS   string
+		platArch string
+	}{
+		{"linux", "amd64", true, "linux", "x86_64"},
+		{"linux", "arm64", true, "linux", "arm64"},
+		{"darwin", "amd64", true, "darwin", "x86_64"},
+		{"darwin", "arm64", true, "darwin", "arm64"},
+		{"windows", "amd64", true, "windows", "x86_64"},
+		{"windows", "arm64", true, "windows", "arm64"},
+		{"linux", "s390x", false, "", ""},
+		{"unknown", "amd64", false, "", ""},
+	}
+	for _, tc := range tests {
+		runtimeGOOSFunc = func(val string) func() string { return func() string { return val } }(tc.os)
+		runtimeGOARCHFunc = func(val string) func() string { return func() string { return val } }(tc.arch)
+		ctx, _, _ := newOriginCtx()
+		c := NewContext(ctx)
+		c.CheckOsTypeAndArch()
+		if c.osSupport != tc.support {
+			t.Fatalf("expect support=%v for %s/%s got %v", tc.support, tc.os, tc.arch, c.osSupport)
+		}
+		if c.platformOS != tc.platOS || c.platformArch != tc.platArch {
+			t.Fatalf("platform mismatch for %s/%s: got %s/%s want %s/%s",
+				tc.os, tc.arch, c.platformOS, c.platformArch, tc.platOS, tc.platArch)
+		}
+	}
+}
+
+func TestDownloadURLUsesOfficialLayout(t *testing.T) {
+	origGOOS := runtimeGOOSFunc
+	origGOARCH := runtimeGOARCHFunc
+	defer func() { runtimeGOOSFunc = origGOOS; runtimeGOARCHFunc = origGOARCH }()
+
+	runtimeGOOSFunc = func() string { return "darwin" }
+	runtimeGOARCHFunc = func() string { return "arm64" }
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	c.CheckOsTypeAndArch()
+	want := defaultDownloadBase + "/darwin/arm64/mseutil"
+	if got := c.downloadURL(); got != want {
+		t.Fatalf("downloadURL=%s want %s", got, want)
+	}
+}
+
+func TestDownloadBinary_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("binary content"))
+	}))
+	defer srv.Close()
+
+	origHTTPDo := httpDoFunc
+	defer func() { httpDoFunc = origHTTPDo }()
+	httpDoFunc = func(req *http.Request) (*http.Response, error) {
+		return http.DefaultClient.Do(req)
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "test.bin")
+	err := downloadBinary(srv.URL+"/binary", tmpFile)
+	if err != nil {
+		t.Fatalf("downloadBinary err: %v", err)
+	}
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("read file err: %v", err)
+	}
+	if string(data) != "binary content" {
+		t.Fatalf("content mismatch: %s", string(data))
+	}
+}
+
+func TestDownloadBinary_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	origHTTPDo := httpDoFunc
+	defer func() { httpDoFunc = origHTTPDo }()
+	httpDoFunc = func(req *http.Request) (*http.Response, error) {
+		return http.DefaultClient.Do(req)
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "test.bin")
+	err := downloadBinary(srv.URL+"/binary", tmpFile)
+	if err == nil || !strings.Contains(err.Error(), "status code") {
+		t.Fatalf("expected status code error, got %v", err)
+	}
+}
+
+func TestGetRemoteBinaryVersion_Success(t *testing.T) {
+	origHTTPDo := httpDoFunc
+	defer func() { httpDoFunc = origHTTPDo }()
+	httpDoFunc = func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodHead {
+			t.Fatalf("expected HEAD, got %s", req.Method)
+		}
+		if req.Header.Get("User-Agent") == "" {
+			t.Fatalf("User-Agent should be set")
+		}
+		header := make(http.Header)
+		header.Set("ETag", `"D3C873DEE520C93C652500F24494DAE8"`)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+
+	ver, err := GetRemoteBinaryVersion("https://example.com/mseutil")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ver != "D3C873DEE520C93C652500F24494DAE8" {
+		t.Errorf("version mismatch: got %s", ver)
+	}
+}
+
+func TestGetRemoteBinaryVersion_NetworkError(t *testing.T) {
+	origHTTPDo := httpDoFunc
+	defer func() { httpDoFunc = origHTTPDo }()
+	httpDoFunc = func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("network down")
+	}
+
+	_, err := GetRemoteBinaryVersion("https://example.com/mseutil")
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("expected network error, got %v", err)
+	}
+}
+
+func TestGetRemoteBinaryVersion_Non200(t *testing.T) {
+	origHTTPDo := httpDoFunc
+	defer func() { httpDoFunc = origHTTPDo }()
+	httpDoFunc = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 404, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}
+
+	_, err := GetRemoteBinaryVersion("https://example.com/mseutil")
+	if err == nil || !strings.Contains(err.Error(), "status code 404") {
+		t.Fatalf("expected 404 error, got %v", err)
+	}
+}
+
+func TestUnsupportedPlatform(t *testing.T) {
+	origGOOS := runtimeGOOSFunc
+	origGOARCH := runtimeGOARCHFunc
+	defer func() { runtimeGOOSFunc = origGOOS; runtimeGOARCHFunc = origGOARCH }()
+	runtimeGOOSFunc = func() string { return "plan9" }
+	runtimeGOARCHFunc = func() string { return "amd64" }
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	err := c.InitializeAndValidatePlatform()
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("expected unsupported platform error, got %v", err)
+	}
+}

--- a/main/main.go
+++ b/main/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aliyun/aliyun-cli/v3/cliext/kmscli"
 	"github.com/aliyun/aliyun-cli/v3/cliext/lindormcli"
+	"github.com/aliyun/aliyun-cli/v3/cliext/mseutil"
 
 	aliyunopenapimeta "github.com/aliyun/aliyun-cli/v3/aliyun-openapi-meta"
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -144,6 +145,8 @@ func newRootCommand(profile config.Profile, stdout io.Writer) *cli.Command {
 	rootCmd.AddSubCommand(kmscli.NewKmscliCommand())
 	// lindorm command
 	rootCmd.AddSubCommand(lindormcli.NewLindormCliCommand())
+	// mseutil command
+	rootCmd.AddSubCommand(mseutil.NewMseutilCommand())
 	// acr command
 	rootCmd.AddSubCommand(acrutil.NewAcrutilCommand())
 	// codeup command


### PR DESCRIPTION
## Summary
- Add `aliyun mseutil` wrapper under `cliext/mseutil` that auto-downloads the official binary from msetools OSS and forwards args
- Map CLI profile credentials/region into the subprocess env; strip aliyun config flags before passthrough
- Propagate subprocess exit code via `ExitError` + `cli.Exit` (no extra CLI ERROR line)