### PR TITLE
fix: correct waiter timeout/interval range validation

### DIFF
--- a/openapi/waiter.go
+++ b/openapi/waiter.go
@@ -67,7 +67,7 @@ func (a *Waiter) CallWith(invoker Invoker) (string, error) {
 	timeout := time.Duration(time.Second * 180)
 	if s, ok := WaiterFlag.GetFieldValue("timeout"); ok {
 		if n, err := strconv.Atoi(s); err == nil {
-			if n <= 0 && n > 600 {
+			if n <= 0 || n > 600 {
 				return "", fmt.Errorf("--waiter timeout=%s must between 1-600 (seconds)", s)
 			}
 			timeout = time.Duration(time.Second * time.Duration(n))
@@ -80,7 +80,7 @@ func (a *Waiter) CallWith(invoker Invoker) (string, error) {
 	interval := time.Duration(time.Second * 5)
 	if s, ok := WaiterFlag.GetFieldValue("interval"); ok {
 		if n, err := strconv.Atoi(s); err == nil {
-			if n <= 1 && n > 10 {
+			if n <= 1 || n > 10 {
 				return "", fmt.Errorf("--waiter interval=%s must between 2-10 (seconds)", s)
 			}
 			interval = time.Duration(time.Second * time.Duration(n))

--- a/openapi/waiter_test.go
+++ b/openapi/waiter_test.go
@@ -59,3 +59,63 @@ func TestWaiter_CallWith(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "[SDK.CanNotResolveEndpoint] Can not resolve endpoint")
 }
+
+func TestWaiter_CallWith_TimeoutRange(t *testing.T) {
+	originWaiterFlag := WaiterFlag
+	defer func() { WaiterFlag = originWaiterFlag }()
+
+	WaiterFlag.SetAssigned(true)
+	waiter := GetWaiter()
+	assert.NotNil(t, waiter)
+
+	client, err := sdk.NewClientWithAccessKey("regionid", "accesskeyid", "accesskeysecret")
+	assert.Nil(t, err)
+	invoker := &RpcInvoker{
+		BasicInvoker: &BasicInvoker{
+			client:  client,
+			request: requests.NewCommonRequest(),
+		},
+	}
+
+	WaiterFlag.Fields[2].SetAssigned(true)
+	WaiterFlag.Fields[3].SetAssigned(true)
+	WaiterFlag.Fields[3].SetValue("5")
+
+	for _, timeout := range []string{"0", "-1", "601"} {
+		WaiterFlag.Fields[2].SetValue(timeout)
+		str, err := waiter.CallWith(invoker)
+		assert.Equal(t, "", str)
+		assert.NotNil(t, err)
+		assert.Equal(t, "--waiter timeout="+timeout+" must between 1-600 (seconds)", err.Error())
+	}
+}
+
+func TestWaiter_CallWith_IntervalRange(t *testing.T) {
+	originWaiterFlag := WaiterFlag
+	defer func() { WaiterFlag = originWaiterFlag }()
+
+	WaiterFlag.SetAssigned(true)
+	waiter := GetWaiter()
+	assert.NotNil(t, waiter)
+
+	client, err := sdk.NewClientWithAccessKey("regionid", "accesskeyid", "accesskeysecret")
+	assert.Nil(t, err)
+	invoker := &RpcInvoker{
+		BasicInvoker: &BasicInvoker{
+			client:  client,
+			request: requests.NewCommonRequest(),
+		},
+	}
+
+	WaiterFlag.Fields[2].SetAssigned(true)
+	WaiterFlag.Fields[3].SetAssigned(true)
+	WaiterFlag.Fields[2].SetValue("180")
+
+	for _, interval := range []string{"1", "0", "11"} {
+		WaiterFlag.Fields[3].SetValue(interval)
+		str, err := waiter.CallWith(invoker)
+		assert.Equal(t, "", str)
+		assert.NotNil(t, err)
+		assert.Equal(t, "--waiter interval="+interval+" must between 2-10 (seconds)", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- Fix unreachable range checks in `--waiter timeout` / `interval` (`&&` → `||`) so values outside 1–600s / 2–10s are rejected
- Same logic bug existed on both timeout and interval validators
- Add unit tests covering out-of-range timeout and interval inputs