### PR TITLE
fix: persist configure read-timeout as read_timeout

### DIFF
--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -189,7 +189,7 @@ func TestNewConfigFromBytes(t *testing.T) {
 				"output_format": "json",
 				"language": "en",
 				"site": "",
-				"retry_timeout": 0,
+				"read_timeout": 0,
 				"retry_count": 0
 			}
 		],

--- a/config/profile.go
+++ b/config/profile.go
@@ -111,7 +111,7 @@ type Profile struct {
 	OutputFormat               string           `json:"output_format,omitempty"`
 	Language                   string           `json:"language,omitempty"`
 	Site                       string           `json:"site,omitempty"`
-	ReadTimeout                int              `json:"retry_timeout,omitempty"`
+	ReadTimeout                int              `json:"read_timeout,omitempty"`
 	ConnectTimeout             int              `json:"connect_timeout,omitempty"`
 	RetryCount                 int              `json:"retry_count,omitempty"`
 	ProcessCommand             string           `json:"process_command,omitempty"`
@@ -146,6 +146,25 @@ func NewProfile(name string) Profile {
 		OutputFormat: "json",
 		Language:     i18n.GetLanguage(),
 	}
+}
+
+// UnmarshalJSON accepts both read_timeout (current) and legacy retry_timeout.
+// configure set --read-timeout historically persisted as retry_timeout; keep loading those configs.
+func (cp *Profile) UnmarshalJSON(data []byte) error {
+	type profileAlias Profile
+	aux := &struct {
+		*profileAlias
+		RetryTimeout *int `json:"retry_timeout"`
+	}{
+		profileAlias: (*profileAlias)(cp),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if cp.ReadTimeout == 0 && aux.RetryTimeout != nil {
+		cp.ReadTimeout = *aux.RetryTimeout
+	}
+	return nil
 }
 
 func (cp *Profile) Validate() error {

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1944,4 +1945,73 @@ func TestErrBearerTokenRequiresPlugin(t *testing.T) {
 
 	err = ErrBearerTokenRequiresPlugin("")
 	assert.Contains(t, err.Error(), "product plugin")
+}
+
+func TestProfileReadTimeoutJSONKey(t *testing.T) {
+	p := Profile{Name: "default", ReadTimeout: 30}
+	raw, err := json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Contains(t, string(raw), `"read_timeout":30`)
+	assert.NotContains(t, string(raw), `retry_timeout`)
+
+	var fromNew Profile
+	assert.NoError(t, json.Unmarshal([]byte(`{"name":"default","read_timeout":45}`), &fromNew))
+	assert.Equal(t, 45, fromNew.ReadTimeout)
+
+	var fromLegacy Profile
+	assert.NoError(t, json.Unmarshal([]byte(`{"name":"default","retry_timeout":60}`), &fromLegacy))
+	assert.Equal(t, 60, fromLegacy.ReadTimeout)
+
+	var preferNew Profile
+	assert.NoError(t, json.Unmarshal([]byte(`{"name":"default","read_timeout":10,"retry_timeout":99}`), &preferNew))
+	assert.Equal(t, 10, preferNew.ReadTimeout)
+}
+
+func TestConfigureSetPersistsReadTimeoutJSONKey(t *testing.T) {
+	var saved *Configuration
+	origLoad := hookLoadOrCreateConfiguration
+	origSave := hookSaveConfigurationWithContext
+	defer func() {
+		hookLoadOrCreateConfiguration = origLoad
+		hookSaveConfigurationWithContext = origSave
+	}()
+
+	hookLoadOrCreateConfiguration = func(fn func(path string) (*Configuration, error)) func(path string) (*Configuration, error) {
+		return func(path string) (*Configuration, error) {
+			return &Configuration{
+				CurrentProfile: "default",
+				Profiles: []Profile{
+					{Name: "default", Mode: AK, AccessKeyId: "ak", AccessKeySecret: "sk", RegionId: "cn-hangzhou", OutputFormat: "json"},
+				},
+			}, nil
+		}
+	}
+	hookSaveConfigurationWithContext = func(fn func(ctx *cli.Context, config *Configuration) error) func(ctx *cli.Context, config *Configuration) error {
+		return func(ctx *cli.Context, config *Configuration) error {
+			saved = config
+			return nil
+		}
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	AddFlags(ctx.Flags())
+	ReadTimeoutFlag(ctx.Flags()).SetAssigned(true)
+	ReadTimeoutFlag(ctx.Flags()).SetValue("30")
+
+	assert.NoError(t, doConfigureSet(ctx))
+	assert.NotNil(t, saved)
+	p, ok := saved.GetProfile("default")
+	assert.True(t, ok)
+	assert.Equal(t, 30, p.ReadTimeout)
+
+	raw, err := json.Marshal(p)
+	assert.NoError(t, err)
+	assert.Contains(t, string(raw), `"read_timeout":30`)
+	assert.NotContains(t, string(raw), `retry_timeout`)
+
+	envs, err := p.GetRuntimeEnv(newCtx())
+	assert.NoError(t, err)
+	assert.Equal(t, "30", envs["ALIBABA_CLOUD_READ_TIMEOUT"])
 }


### PR DESCRIPTION
## Summary

- `configure set --read-timeout` now writes `read_timeout` in config.json (was `retry_timeout`), matching the CLI flag and runtime field name
- Profile JSON unmarshal still accepts legacy `retry_timeout` so existing configs keep working
- Plugin path continues to forward the value via `ALIBABA_CLOUD_READ_TIMEOUT`