### PR TITLE
fix(oss): honor profile endpoint and endpoint-type vpc

### DIFF
--- a/oss/lib/cli_bridge.go
+++ b/oss/lib/cli_bridge.go
@@ -170,6 +170,13 @@ func ParseAndGetEndpoint(ctx *cli.Context, args []string) (string, error) {
 	} else if r, ok := ctx.Flags().GetValue("region"); ok && r != "" {
 		region = r
 	}
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return "", fmt.Errorf("missing region for oss endpoint, use --region <regionId>")
+	}
+	if !config.IsRegion(region) {
+		return "", fmt.Errorf("invalid region %s", region)
+	}
 
 	return buildOssEndpoint(region, profile.EndpointType), nil
 }

--- a/oss/lib/cli_bridge.go
+++ b/oss/lib/cli_bridge.go
@@ -119,38 +119,59 @@ func NewCommandBridge(cmd Command) *cli.Command {
 	return result
 }
 
-// ParseAndGetEndpoint get oss endpoint from cli context
+// buildOssEndpoint builds the regional OSS endpoint.
+// When endpointType is "vpc", use the internal endpoint (oss-{region}-internal.aliyuncs.com).
+func buildOssEndpoint(region, endpointType string) string {
+	if strings.EqualFold(strings.TrimSpace(endpointType), "vpc") {
+		return "oss-" + region + "-internal.aliyuncs.com"
+	}
+	return "oss-" + region + ".aliyuncs.com"
+}
+
+func getArgValue(args []string, name string) (string, bool) {
+	for i, arg := range args {
+		if arg == name && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+// ParseAndGetEndpoint get oss endpoint from cli context.
+// Priority (aligned with OpenAPI): explicit --endpoint (args/flag) >
+// profile.Endpoint > construct from region + endpoint-type.
 func ParseAndGetEndpoint(ctx *cli.Context, args []string) (string, error) {
 	profile, err := config.LoadProfileWithContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("config failed: %s", err.Error())
 	}
-	// try fetch endpoint from args
-	if len(args) > 0 {
-		for i, arg := range args {
-			if arg == "--endpoint" {
-				if i+1 < len(args) {
-					return args[i+1], nil
-				}
-			}
-		}
-	}
-	// try fetch region from args
-	if len(args) > 0 {
-		for i, arg := range args {
-			if arg == "--region" {
-				if i+1 < len(args) {
-					return "oss-" + args[i+1] + ".aliyuncs.com", nil
-				}
-			}
-		}
-	}
-	// check endpoint from flags
-	if ep, ok := ctx.Flags().GetValue("endpoint"); !ok {
-		return "oss-" + profile.RegionId + ".aliyuncs.com", nil
-	} else {
+	// Ensure flag/env overlays for endpoint fields even when not in configure mode.
+	profile.OverwriteWithFlags(ctx)
+
+	// 1. Explicit --endpoint in remaining args
+	if ep, ok := getArgValue(args, "--endpoint"); ok {
 		return ep, nil
 	}
+
+	// 2. Explicit --endpoint flag
+	if ep, ok := ctx.Flags().GetValue("endpoint"); ok && ep != "" {
+		return ep, nil
+	}
+
+	// 3. profile.Endpoint (config / env / flag via OverwriteWithFlags)
+	if profile.Endpoint != "" {
+		return profile.Endpoint, nil
+	}
+
+	// 4. Resolve region then build public or VPC/internal endpoint
+	region := profile.RegionId
+	if r, ok := getArgValue(args, "--region"); ok {
+		region = r
+	} else if r, ok := ctx.Flags().GetValue("region"); ok && r != "" {
+		region = r
+	}
+
+	return buildOssEndpoint(region, profile.EndpointType), nil
 }
 
 func ParseAndRunCommandFromCli(ctx *cli.Context, args []string) error {

--- a/oss/lib/cli_bridge_test.go
+++ b/oss/lib/cli_bridge_test.go
@@ -4,72 +4,142 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCliBridge(t *testing.T) {
 	NewCommandBridge(configCommand.command)
 }
 
-func TestParseAndGetEndpoint(t *testing.T) {
-	type args struct {
-		ctx  *cli.Context
-		args []string
-	}
+func TestBuildOssEndpoint(t *testing.T) {
+	assert.Equal(t, "oss-cn-hangzhou.aliyuncs.com", buildOssEndpoint("cn-hangzhou", ""))
+	assert.Equal(t, "oss-cn-hangzhou-internal.aliyuncs.com", buildOssEndpoint("cn-hangzhou", "vpc"))
+	assert.Equal(t, "oss-cn-beijing-internal.aliyuncs.com", buildOssEndpoint("cn-beijing", "VPC"))
+}
+
+func newEndpointTestContext(t *testing.T) *cli.Context {
+	t.Helper()
 	w := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	context := cli.NewCommandContext(w, stderr)
-	flag := cli.Flag{
-		Name: "endpoint",
-	}
-	flag.SetValue("oss-cn-hangzhou.aliyuncs.com")
-	context.Flags().Add(&flag)
+	ctx := cli.NewCommandContext(w, stderr)
+	config.AddFlags(ctx.Flags())
+	ctx.SetInConfigureMode(true)
+	return ctx
+}
 
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr assert.ErrorAssertionFunc
-	}{
-		{
-			name: "Valid endpoint from args",
-			args: args{
-				ctx:  new(cli.Context),
-				args: []string{"--endpoint", "oss-cn-shenzhen.aliyuncs.com"},
-			},
-			want:    "oss-cn-shenzhen.aliyuncs.com",
-			wantErr: assert.NoError,
-		},
-		{
-			name: "Valid region from args",
-			args: args{
-				ctx:  new(cli.Context),
-				args: []string{"--region", "cn-shenzhen"},
-			},
-			want:    "oss-cn-shenzhen.aliyuncs.com",
-			wantErr: assert.NoError,
-		},
-		{
-			name: "Fetch endpoint flag from context",
-			args: args{
-				ctx: context,
-			},
-			want:    "oss-cn-hangzhou.aliyuncs.com",
-			wantErr: assert.NoError,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseAndGetEndpoint(tt.args.ctx, tt.args.args)
-			if !tt.wantErr(t, err, fmt.Sprintf("ParseAndGetEndpoint(%v, %v)", tt.args.ctx, tt.args.args)) {
-				return
-			}
-			assert.Equalf(t, tt.want, got, "ParseAndGetEndpoint(%v, %v)", tt.args.ctx, tt.args.args)
-		})
-	}
+func writeEndpointTestConfig(t *testing.T, endpoint, endpointType, region string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := fmt.Sprintf(`{
+  "current": "default",
+  "profiles": [{
+    "name": "default",
+    "mode": "AK",
+    "access_key_id": "test-ak",
+    "access_key_secret": "test-sk",
+    "region_id": %q,
+    "endpoint": %q,
+    "endpoint_type": %q,
+    "output_format": "json",
+    "language": "en"
+  }]
+}`, region, endpoint, endpointType)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+func TestParseAndGetEndpoint(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_IGNORE_PROFILE", "")
+	t.Setenv("ALIBABA_CLOUD_ENDPOINT", "")
+	t.Setenv("ALIBABA_CLOUD_ENDPOINT_TYPE", "")
+
+	t.Run("endpoint from args wins", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "oss-cn-hangzhou.aliyuncs.com", "vpc", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		got, err := ParseAndGetEndpoint(ctx, []string{"--endpoint", "oss-cn-shenzhen.aliyuncs.com"})
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-shenzhen.aliyuncs.com", got)
+	})
+
+	t.Run("endpoint from flag wins over profile", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "oss-cn-hangzhou.aliyuncs.com", "", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+		config.EndpointFlag(ctx.Flags()).SetAssigned(true)
+		config.EndpointFlag(ctx.Flags()).SetValue("oss-cn-beijing.aliyuncs.com")
+
+		got, err := ParseAndGetEndpoint(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-beijing.aliyuncs.com", got)
+	})
+
+	t.Run("profile endpoint used when no explicit endpoint", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "oss-cn-shanghai.aliyuncs.com", "vpc", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		got, err := ParseAndGetEndpoint(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-shanghai.aliyuncs.com", got)
+	})
+
+	t.Run("endpoint-type vpc builds internal endpoint", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "", "vpc", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		got, err := ParseAndGetEndpoint(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-hangzhou-internal.aliyuncs.com", got)
+	})
+
+	t.Run("region from args with vpc endpoint-type", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "", "vpc", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		got, err := ParseAndGetEndpoint(ctx, []string{"--region", "cn-shenzhen"})
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-shenzhen-internal.aliyuncs.com", got)
+	})
+
+	t.Run("region from args without vpc is public", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "", "", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		got, err := ParseAndGetEndpoint(ctx, []string{"--region", "cn-shenzhen"})
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-shenzhen.aliyuncs.com", got)
+	})
+
+	t.Run("endpoint-type flag vpc builds internal endpoint", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "", "", "cn-beijing")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+		config.EndpointTypeFlag(ctx.Flags()).SetAssigned(true)
+		config.EndpointTypeFlag(ctx.Flags()).SetValue("vpc")
+
+		got, err := ParseAndGetEndpoint(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "oss-cn-beijing-internal.aliyuncs.com", got)
+	})
 }
 
 func TestParseAndRunCommandFromCli(t *testing.T) {

--- a/oss/lib/cli_bridge_test.go
+++ b/oss/lib/cli_bridge_test.go
@@ -33,6 +33,32 @@ func newEndpointTestContext(t *testing.T) *cli.Context {
 	return ctx
 }
 
+func clearEndpointTestEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"ALIBABA_CLOUD_IGNORE_PROFILE",
+		"ALIBABACLOUD_IGNORE_PROFILE",
+		"ALIBABA_CLOUD_PROFILE",
+		"ALIBABACLOUD_PROFILE",
+		"ALICLOUD_PROFILE",
+		"ALIBABA_CLOUD_REGION_ID",
+		"ALIBABACLOUD_REGION_ID",
+		"ALICLOUD_REGION_ID",
+		"REGION_ID",
+		"REGION",
+		"ALIBABA_CLOUD_ENDPOINT",
+		"ALIBABACLOUD_ENDPOINT",
+		"ALICLOUD_ENDPOINT",
+		"ENDPOINT",
+		"ALIBABA_CLOUD_ENDPOINT_TYPE",
+		"ALIBABACLOUD_ENDPOINT_TYPE",
+		"ALICLOUD_ENDPOINT_TYPE",
+		"ENDPOINT_TYPE",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func writeEndpointTestConfig(t *testing.T, endpoint, endpointType, region string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -56,9 +82,7 @@ func writeEndpointTestConfig(t *testing.T, endpoint, endpointType, region string
 }
 
 func TestParseAndGetEndpoint(t *testing.T) {
-	t.Setenv("ALIBABA_CLOUD_IGNORE_PROFILE", "")
-	t.Setenv("ALIBABA_CLOUD_ENDPOINT", "")
-	t.Setenv("ALIBABA_CLOUD_ENDPOINT_TYPE", "")
+	clearEndpointTestEnv(t)
 
 	t.Run("endpoint from args wins", func(t *testing.T) {
 		ctx := newEndpointTestContext(t)
@@ -139,6 +163,28 @@ func TestParseAndGetEndpoint(t *testing.T) {
 		got, err := ParseAndGetEndpoint(ctx, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "oss-cn-beijing-internal.aliyuncs.com", got)
+	})
+
+	t.Run("whitespace region from args returns error", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "", "", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		_, err := ParseAndGetEndpoint(ctx, []string{"--region", "  "})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing region")
+	})
+
+	t.Run("invalid region from args returns error", func(t *testing.T) {
+		ctx := newEndpointTestContext(t)
+		path := writeEndpointTestConfig(t, "", "", "cn-hangzhou")
+		config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+		config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+		_, err := ParseAndGetEndpoint(ctx, []string{"--region", "bad region!"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid region")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Make `aliyun oss` resolve endpoints like OpenAPI: explicit `--endpoint` wins, then `profile.endpoint`, then region-derived host
- When `endpoint-type=vpc` (profile/flag/env) and no explicit endpoint, use `oss-{region}-internal.aliyuncs.com` instead of the public host
- Add unit tests covering profile endpoint, vpc internal construction, and precedence