### PR TITLE
fix: ignore empty --mode so env credentials still apply

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -267,7 +267,13 @@ func (cp *Profile) GetParent() *Configuration {
 }
 
 func (cp *Profile) OverwriteWithFlags(ctx *cli.Context) {
-	cp.Mode = NormalizeMode(ModeFlag(ctx.Flags()).GetStringOrDefault(string(cp.Mode)))
+	modeFlag := ModeFlag(ctx.Flags())
+	if modeFlag != nil && modeFlag.IsAssigned() {
+		// Empty --mode is ignored so profile Mode is preserved.
+		if mode := strings.TrimSpace(modeFlag.GetStringOrDefault("")); mode != "" {
+			cp.Mode = NormalizeMode(mode)
+		}
+	}
 	cp.AccessKeyId = AccessKeyIdFlag(ctx.Flags()).GetStringOrDefault(cp.AccessKeyId)
 	cp.AccessKeySecret = AccessKeySecretFlag(ctx.Flags()).GetStringOrDefault(cp.AccessKeySecret)
 	cp.StsToken = StsTokenFlag(ctx.Flags()).GetStringOrDefault(cp.StsToken)

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -327,6 +327,27 @@ func TestOverwriteWithFlags(t *testing.T) {
 	assert.Equal(t, exp, actual)
 }
 
+func TestOverwriteWithFlagsIgnoresEmptyMode(t *testing.T) {
+	buf := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(buf, stderr)
+	AddFlags(ctx.Flags())
+	resetEnv()
+
+	actual := newProfile()
+	actual.Mode = AK
+	actual.AccessKeyId = ""
+
+	ModeFlag(ctx.Flags()).SetAssigned(true)
+	ModeFlag(ctx.Flags()).SetValue("")
+	os.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "from-env")
+	defer os.Unsetenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
+
+	actual.OverwriteWithFlags(ctx)
+	assert.Equal(t, AK, actual.Mode, "empty --mode should not overwrite profile Mode")
+	assert.Equal(t, "from-env", actual.AccessKeyId, "env credentials should still apply")
+}
+
 func TestOverwriteWithFlagsWithRegionIDEnv(t *testing.T) {
 	buf := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -92,7 +92,9 @@ func (c *Commando) InitWithCommand(cmd *cli.Command) {
 
 func DetectInConfigureMode(flags *cli.FlagSet) bool {
 	mode, modeExist := flags.GetValue(config.ModeFlagName)
-	if !modeExist || config.Anonymous == config.NormalizeMode(mode) {
+	// Empty --mode is treated as unset so OverwriteWithFlags still runs
+	// (env credentials / timeout / retry flags remain effective).
+	if !modeExist || strings.TrimSpace(mode) == "" || config.Anonymous == config.NormalizeMode(mode) {
 		return true
 	}
 	// if mode exist, check if other flags exist

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -654,13 +654,32 @@ func TestDetectInConfigureMode(t *testing.T) {
 	result := DetectInConfigureMode(flags)
 	assert.True(t, result, "Expected true when no flags are set")
 
-	// Test case 2: Mode flag set
+	// Test case 2: Mode flag assigned but empty — treat as unset
+	flags = cli.NewFlagSet()
+	emptyModeFlag := &cli.Flag{Name: config.ModeFlagName}
+	emptyModeFlag.SetAssigned(true)
+	emptyModeFlag.SetValue("")
+	flags.Add(emptyModeFlag)
+	result = DetectInConfigureMode(flags)
+	assert.True(t, result, "Expected true when mode flag is empty")
+
+	// Test case 2b: Mode flag assigned with whitespace only — treat as unset
+	flags = cli.NewFlagSet()
+	wsModeFlag := &cli.Flag{Name: config.ModeFlagName}
+	wsModeFlag.SetAssigned(true)
+	wsModeFlag.SetValue("   ")
+	flags.Add(wsModeFlag)
+	result = DetectInConfigureMode(flags)
+	assert.True(t, result, "Expected true when mode flag is whitespace-only")
+
+	// Test case 2c: Mode flag set to a non-empty value without credential flags
 	flags = cli.NewFlagSet()
 	modeFlag := &cli.Flag{Name: config.ModeFlagName}
 	modeFlag.SetAssigned(true)
+	modeFlag.SetValue("AK")
 	flags.Add(modeFlag)
 	result = DetectInConfigureMode(flags)
-	assert.False(t, result, "Expected false when mode flag is set")
+	assert.False(t, result, "Expected false when mode flag has a non-empty value without credential flags")
 
 	// Test case 3: AccessKeyId flag set
 	flags = cli.NewFlagSet()


### PR DESCRIPTION
## Summary

- Treat empty/whitespace-only `--mode` as unset in `DetectInConfigureMode`, so `OverwriteWithFlags` still runs
- Ignore empty `--mode` in `OverwriteWithFlags` to preserve profile Mode while applying env credentials and timeout/retry flags
- Add unit coverage for empty/whitespace `--mode` and env credential merge