### PR TITLE
fix(esacli): harden exec override and shorthand flags

### DIFF
--- a/cliext/esacli/esacli.go
+++ b/cliext/esacli/esacli.go
@@ -171,12 +171,9 @@ func (c *Context) EnsureNpmAvailable() error {
 func (c *Context) EnsurePrefixAndPackage() error {
 	if c.usingExecPathOverride() {
 		// The user opted out of the managed install; make sure the override
-		// actually resolves so we fail fast with an actionable message
+		// is a usable executable so we fail fast with an actionable message
 		// instead of a cryptic exec error later.
-		if !c.installed {
-			return fmt.Errorf("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH=%s does not point to an existing file", c.execFilePath)
-		}
-		return nil
+		return c.validateExecPathOverride()
 	}
 
 	if err := os.MkdirAll(c.prefixPath, 0o755); err != nil {
@@ -518,6 +515,27 @@ func fileExists(p string) bool {
 // npm install/upgrade path (and the npm requirement) is bypassed.
 func (c *Context) usingExecPathOverride() bool {
 	return strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH")) != ""
+}
+
+// validateExecPathOverride ensures ALIBABA_CLOUD_ESA_CLI_EXEC_PATH points at a
+// regular, executable file (existence alone is not enough — a directory or a
+// non-executable file would otherwise surface as a cryptic exec failure).
+func (c *Context) validateExecPathOverride() error {
+	info, err := os.Stat(c.execFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH=%q does not point to an existing file", c.execFilePath)
+		}
+		return fmt.Errorf("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH=%q: %v", c.execFilePath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH=%q is not a regular file", c.execFilePath)
+	}
+	// Windows does not use Unix permission bits for executability.
+	if c.osType != "windows" && info.Mode()&0o111 == 0 {
+		return fmt.Errorf("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH=%q is not executable", c.execFilePath)
+	}
+	return nil
 }
 
 var getNodeMajorFunc = getNodeMajor

--- a/cliext/esacli/esacli.go
+++ b/cliext/esacli/esacli.go
@@ -44,11 +44,11 @@ var (
 )
 
 const (
-	npmPackageName    = "esa-cli"
-	prefixDirName     = "esa-cli-prefix"
-	minNodeMajor      = 20
-	versionCacheFile  = ".esa_cli_version_check"
-	downloadBaseURL   = "https://aliyun-cli-pub.oss-cn-hangzhou.aliyuncs.com/cli-ext/esa-cli/downloads"
+	npmPackageName   = "esa-cli"
+	prefixDirName    = "esa-cli-prefix"
+	minNodeMajor     = 20
+	versionCacheFile = ".esa_cli_version_check"
+	downloadBaseURL  = "https://aliyun-cli-pub.oss-cn-hangzhou.aliyuncs.com/cli-ext/esa-cli/downloads"
 )
 
 var VersionCheckTTL = 86400
@@ -64,8 +64,13 @@ func (c *Context) Run(args []string) error {
 	if err := c.EnsureNodeAvailable(); err != nil {
 		return err
 	}
-	if err := c.EnsureNpmAvailable(); err != nil {
-		return err
+	// npm is only needed to install/upgrade the managed copy. When the user
+	// points ALIBABA_CLOUD_ESA_CLI_EXEC_PATH at an existing binary, honour
+	// that escape hatch even on machines without npm.
+	if !c.usingExecPathOverride() {
+		if err := c.EnsureNpmAvailable(); err != nil {
+			return err
+		}
 	}
 	if err := c.EnsurePrefixAndPackage(); err != nil {
 		return err
@@ -164,7 +169,13 @@ func (c *Context) EnsureNpmAvailable() error {
 }
 
 func (c *Context) EnsurePrefixAndPackage() error {
-	if os.Getenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH") != "" {
+	if c.usingExecPathOverride() {
+		// The user opted out of the managed install; make sure the override
+		// actually resolves so we fail fast with an actionable message
+		// instead of a cryptic exec error later.
+		if !c.installed {
+			return fmt.Errorf("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH=%s does not point to an existing file", c.execFilePath)
+		}
 		return nil
 	}
 
@@ -275,19 +286,31 @@ func (c *Context) applyMainCliFlagsFromArgs(args []string) {
 	flags := c.originCtx.Flags()
 	for i := 0; i < len(args); i++ {
 		a := args[i]
-		if !strings.HasPrefix(a, "--") {
+
+		var f *cli.Flag
+		var value string
+		var hasValue bool
+
+		switch {
+		case strings.HasPrefix(a, "--"):
+			name := a[2:]
+			if idx := strings.Index(a, "="); idx > 0 {
+				name = a[2:idx]
+				value = a[idx+1:]
+				hasValue = true
+			}
+			f = flags.Get(name)
+		case strings.HasPrefix(a, "-") && len(a) > 1:
+			// shorthand form: -p / -p=value / -pvalue (e.g. profile, endpoint)
+			f = flags.GetByShorthand(rune(a[1]))
+			if rest := a[2:]; rest != "" {
+				value = strings.TrimPrefix(rest, "=")
+				hasValue = true
+			}
+		default:
 			continue
 		}
-		var name, value string
-		var hasValue bool
-		if idx := strings.Index(a, "="); idx > 0 {
-			name = a[2:idx]
-			value = a[idx+1:]
-			hasValue = true
-		} else {
-			name = a[2:]
-		}
-		f := flags.Get(name)
+
 		if f == nil || f.Category != "config" {
 			continue
 		}
@@ -488,6 +511,13 @@ func (c *Context) UpdateCheckCacheTime() error {
 func fileExists(p string) bool {
 	_, err := os.Stat(p)
 	return err == nil
+}
+
+// usingExecPathOverride reports whether the user pinned an existing esa-cli
+// binary via ALIBABA_CLOUD_ESA_CLI_EXEC_PATH, in which case the managed
+// npm install/upgrade path (and the npm requirement) is bypassed.
+func (c *Context) usingExecPathOverride() bool {
+	return strings.TrimSpace(os.Getenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH")) != ""
 }
 
 var getNodeMajorFunc = getNodeMajor

--- a/cliext/esacli/esacli_test.go
+++ b/cliext/esacli/esacli_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -308,6 +309,57 @@ func TestEnsurePrefixAndPackage_ExecPathOverrideMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ALIBABA_CLOUD_ESA_CLI_EXEC_PATH") || !strings.Contains(err.Error(), missing) {
 		t.Errorf("error should name the env var and path: %v", err)
+	}
+}
+
+func TestEnsurePrefixAndPackage_ExecPathOverrideDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", tmp)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo: %v", err)
+	}
+	err := c.EnsurePrefixAndPackage()
+	if err == nil {
+		t.Fatalf("expected error when override points at a directory")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error should say not a regular file: %v", err)
+	}
+}
+
+func TestEnsurePrefixAndPackage_ExecPathOverrideNotExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit is not enforced on Windows")
+	}
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	fake := filepath.Join(tmp, "esa-cli")
+	if err := os.WriteFile(fake, []byte("fake"), 0o644); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", fake)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo: %v", err)
+	}
+	err := c.EnsurePrefixAndPackage()
+	if err == nil {
+		t.Fatalf("expected error when override is not executable")
+	}
+	if !strings.Contains(err.Error(), "not executable") {
+		t.Errorf("error should say not executable: %v", err)
 	}
 }
 

--- a/cliext/esacli/esacli_test.go
+++ b/cliext/esacli/esacli_test.go
@@ -265,6 +265,27 @@ func TestRunExecPathOverrideSkipsNpm(t *testing.T) {
 	}
 }
 
+func TestRunWithoutExecPathOverrideRequiresNpm(t *testing.T) {
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", "")
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_NODE_PATH", "/fake/node")
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_NPM_PATH", "")
+
+	oldLook := lookPathFunc
+	lookPathFunc = func(name string) (string, error) {
+		if name != "npm" {
+			t.Fatalf("unexpected lookup: %s", name)
+		}
+		return "", exec.ErrNotFound
+	}
+	defer func() { lookPathFunc = oldLook }()
+
+	ctx, _, _ := newOriginCtx()
+	err := NewContext(ctx).Run(nil)
+	if err == nil || !strings.Contains(err.Error(), "npm not found") {
+		t.Fatalf("Run without npm: got %v", err)
+	}
+}
+
 func TestEsacliHelperProcess(t *testing.T) {}
 
 func TestEnsurePrefixAndPackage_ExecPathOverrideMissing(t *testing.T) {
@@ -359,6 +380,25 @@ func TestApplyMainCliFlagsFromArgs_Shorthand(t *testing.T) {
 				t.Errorf("profile value: want %q got %q", tt.want, got)
 			}
 		})
+	}
+}
+
+func TestApplyMainCliFlagsFromArgs_LongInlineValue(t *testing.T) {
+	ctx, _, _ := newOriginCtx()
+	ctx.Flags().Add(&cli.Flag{
+		Name:         "profile",
+		AssignedMode: cli.AssignedOnce,
+		Category:     "config",
+	})
+
+	NewContext(ctx).applyMainCliFlagsFromArgs([]string{"deploy", "--profile=prod"})
+
+	f := ctx.Flags().Get("profile")
+	if f == nil || !f.IsAssigned() {
+		t.Fatalf("profile flag should be assigned")
+	}
+	if got, _ := f.GetValue(); got != "prod" {
+		t.Errorf("profile value: want %q got %q", "prod", got)
 	}
 }
 

--- a/cliext/esacli/esacli_test.go
+++ b/cliext/esacli/esacli_test.go
@@ -232,6 +232,136 @@ func TestEnsureNpmAvailablePrefersNextToNode(t *testing.T) {
 	}
 }
 
+func TestRunExecPathOverrideSkipsNpm(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	prepareConfig(t, home)
+
+	fakeExec := filepath.Join(t.TempDir(), "esa-cli")
+	if err := os.WriteFile(fakeExec, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("write fake exec: %v", err)
+	}
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", fakeExec)
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_NODE_PATH", "/fake/node")
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_NPM_PATH", "")
+
+	oldLook := lookPathFunc
+	lookPathFunc = func(name string) (string, error) {
+		t.Fatalf("lookPathFunc(%q) should not be called with EXEC_PATH override", name)
+		return "", exec.ErrNotFound
+	}
+	defer func() { lookPathFunc = oldLook }()
+
+	oldExec := execCommandFunc
+	execCommandFunc = func(string, ...string) *exec.Cmd {
+		return exec.Command(os.Args[0], "-test.run=^TestEsacliHelperProcess$")
+	}
+	defer func() { execCommandFunc = oldExec }()
+
+	ctx, _, _ := newOriginCtx()
+	if err := NewContext(ctx).Run([]string{"--help"}); err != nil {
+		t.Fatalf("Run with EXEC_PATH override: %v", err)
+	}
+}
+
+func TestEsacliHelperProcess(t *testing.T) {}
+
+func TestEnsurePrefixAndPackage_ExecPathOverrideMissing(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	missing := filepath.Join(tmp, "nope", "esa-cli")
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", missing)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo: %v", err)
+	}
+	err := c.EnsurePrefixAndPackage()
+	if err == nil {
+		t.Fatalf("expected error for missing exec path override")
+	}
+	if !strings.Contains(err.Error(), "ALIBABA_CLOUD_ESA_CLI_EXEC_PATH") || !strings.Contains(err.Error(), missing) {
+		t.Errorf("error should name the env var and path: %v", err)
+	}
+}
+
+func TestEnsurePrefixAndPackage_ExecPathOverrideExists(t *testing.T) {
+	tmp := t.TempDir()
+	oldGet := getConfigurePathFunc
+	getConfigurePathFunc = func() string { return tmp }
+	defer func() { getConfigurePathFunc = oldGet }()
+
+	fake := filepath.Join(tmp, "esa-cli")
+	if err := os.WriteFile(fake, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", fake)
+
+	ctx, _, _ := newOriginCtx()
+	c := NewContext(ctx)
+	if err := c.InitBasicInfo(); err != nil {
+		t.Fatalf("InitBasicInfo: %v", err)
+	}
+	if err := c.EnsurePrefixAndPackage(); err != nil {
+		t.Fatalf("existing override should not error: %v", err)
+	}
+}
+
+func TestUsingExecPathOverride(t *testing.T) {
+	c := &Context{}
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", "")
+	if c.usingExecPathOverride() {
+		t.Errorf("empty env should not count as override")
+	}
+	t.Setenv("ALIBABA_CLOUD_ESA_CLI_EXEC_PATH", "  /some/path  ")
+	if !c.usingExecPathOverride() {
+		t.Errorf("non-empty env should count as override")
+	}
+}
+
+func TestApplyMainCliFlagsFromArgs_Shorthand(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "separate value", arg: "-p", want: "prod"},
+		{name: "equals value", arg: "-p=prod", want: "prod"},
+		{name: "joined value", arg: "-pprod", want: "prod"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _, _ := newOriginCtx()
+			ctx.Flags().Add(&cli.Flag{
+				Name:         "profile",
+				Shorthand:    'p',
+				AssignedMode: cli.AssignedOnce,
+				Category:     "config",
+			})
+
+			args := []string{"deploy", tt.arg}
+			if tt.arg == "-p" {
+				args = append(args, tt.want)
+			}
+			NewContext(ctx).applyMainCliFlagsFromArgs(args)
+
+			f := ctx.Flags().Get("profile")
+			if f == nil || !f.IsAssigned() {
+				t.Fatalf("profile flag should be assigned via %s", tt.arg)
+			}
+			if got, _ := f.GetValue(); got != tt.want {
+				t.Errorf("profile value: want %q got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestRemoveFlagsForMainCli(t *testing.T) {
 	ctx, _, _ := newOriginCtx()
 	addConfigFlag(ctx, "region", "cn-hangzhou")
@@ -295,9 +425,9 @@ func TestPrepareEnv_AKMode(t *testing.T) {
 		t.Fatalf("PrepareEnv: %v", err)
 	}
 	want := map[string]string{
-		"ALIBABA_CLOUD_ACCESS_KEY_ID":      "ak",
-		"ALIBABA_CLOUD_ACCESS_KEY_SECRET":  "sk",
-		"ALIBABA_CLOUD_REGION_ID":          "cn-hangzhou",
+		"ALIBABA_CLOUD_ACCESS_KEY_ID":       "ak",
+		"ALIBABA_CLOUD_ACCESS_KEY_SECRET":   "sk",
+		"ALIBABA_CLOUD_REGION_ID":           "cn-hangzhou",
 		"ALIBABA_CLOUD_ESA_CLI_COMPAT_MODE": "aliyun esa-cli",
 	}
 	for k, v := range want {


### PR DESCRIPTION
## Summary

- Skip npm checks for local esa-cli executable overrides and validate missing override paths early.
- Fold config shorthand forms into the parent CLI flags so child credentials and endpoint settings stay consistent.
- Add regression coverage for override and shorthand behavior.