### PR TITLE
fix: quote-aware External process_command parsing

### DIFF
--- a/config/command_split.go
+++ b/config/command_split.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// splitProcessCommand splits process_command into argv with quote support.
+// Whitespace outside quotes separates arguments. Double/single quotes group a
+// single argument so Windows paths like "C:\Program Files\tool.exe" work.
+// Escape rules follow POSIX shlex: outside quotes, '\' escapes the next rune;
+// inside double quotes, '\' only escapes '"', '\', '$', '`' and newline;
+// inside single quotes, all characters are literal.
+func splitProcessCommand(command string) ([]string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, fmt.Errorf("process_command is empty")
+	}
+
+	var args []string
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+
+	flush := func() {
+		if current.Len() > 0 {
+			args = append(args, current.String())
+			current.Reset()
+		}
+	}
+
+	runes := []rune(command)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if inSingle {
+			if r == '\'' {
+				inSingle = false
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		}
+		if inDouble {
+			if r == '"' {
+				inDouble = false
+				continue
+			}
+			if r == '\\' && i+1 < len(runes) {
+				next := runes[i+1]
+				if next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n' {
+					current.WriteRune(next)
+					i++
+					continue
+				}
+			}
+			current.WriteRune(r)
+			continue
+		}
+		if r == '\\' {
+			if i+1 >= len(runes) {
+				return nil, fmt.Errorf("invalid process_command: trailing backslash")
+			}
+			current.WriteRune(runes[i+1])
+			i++
+			continue
+		}
+		if r == '\'' {
+			inSingle = true
+			continue
+		}
+		if r == '"' {
+			inDouble = true
+			continue
+		}
+		if unicode.IsSpace(r) {
+			flush()
+			continue
+		}
+		current.WriteRune(r)
+	}
+
+	if inSingle || inDouble {
+		return nil, fmt.Errorf("invalid process_command: unclosed quote")
+	}
+	flush()
+	if len(args) == 0 {
+		return nil, fmt.Errorf("process_command is empty")
+	}
+	return args, nil
+}

--- a/config/command_split.go
+++ b/config/command_split.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"unicode"
 )
@@ -23,15 +24,25 @@ import (
 // splitProcessCommand splits process_command into argv with quote support.
 // Whitespace outside quotes separates arguments. Double/single quotes group a
 // single argument so Windows paths like "C:\Program Files\tool.exe" work.
-// Escape rules follow POSIX shlex: outside quotes, '\' escapes the next rune;
-// inside double quotes, '\' only escapes '"', '\', '$', '`' and newline;
-// inside single quotes, all characters are literal.
+//
+// On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
+// next rune; inside double quotes, '\' only escapes '"', '\', '$', '`' and
+// newline; inside single quotes, all characters are literal.
+//
+// On Windows, '\' is a path separator and is treated as a literal (except
+// '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
+// their backslashes.
 func splitProcessCommand(command string) ([]string, error) {
+	return splitProcessCommandForOS(command, runtime.GOOS)
+}
+
+func splitProcessCommandForOS(command, goos string) ([]string, error) {
 	command = strings.TrimSpace(command)
 	if command == "" {
 		return nil, fmt.Errorf("process_command is empty")
 	}
 
+	windows := goos == "windows"
 	var args []string
 	var current strings.Builder
 	inSingle := false
@@ -66,7 +77,14 @@ func splitProcessCommand(command string) ([]string, error) {
 			}
 			if r == '\\' && i+1 < len(runes) {
 				next := runes[i+1]
-				if next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n' {
+				if windows {
+					// On Windows only \" is an escape inside double quotes.
+					if next == '"' {
+						current.WriteRune(next)
+						i++
+						continue
+					}
+				} else if next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n' {
 					current.WriteRune(next)
 					i++
 					continue
@@ -75,7 +93,14 @@ func splitProcessCommand(command string) ([]string, error) {
 			current.WriteRune(r)
 			continue
 		}
+		// unquoted
 		if r == '\\' {
+			if windows {
+				// Path separator — keep literal.
+				hasToken = true
+				current.WriteRune(r)
+				continue
+			}
 			if i+1 >= len(runes) {
 				return nil, fmt.Errorf("invalid process_command: trailing backslash")
 			}

--- a/config/command_split.go
+++ b/config/command_split.go
@@ -36,11 +36,15 @@ func splitProcessCommand(command string) ([]string, error) {
 	var current strings.Builder
 	inSingle := false
 	inDouble := false
+	// hasToken tracks that a token has started even if it is empty, so quoted
+	// empty arguments like `tool "" arg` keep their empty argv element.
+	hasToken := false
 
 	flush := func() {
-		if current.Len() > 0 {
+		if hasToken {
 			args = append(args, current.String())
 			current.Reset()
+			hasToken = false
 		}
 	}
 
@@ -75,22 +79,26 @@ func splitProcessCommand(command string) ([]string, error) {
 			if i+1 >= len(runes) {
 				return nil, fmt.Errorf("invalid process_command: trailing backslash")
 			}
+			hasToken = true
 			current.WriteRune(runes[i+1])
 			i++
 			continue
 		}
 		if r == '\'' {
 			inSingle = true
+			hasToken = true
 			continue
 		}
 		if r == '"' {
 			inDouble = true
+			hasToken = true
 			continue
 		}
 		if unicode.IsSpace(r) {
 			flush()
 			continue
 		}
+		hasToken = true
 		current.WriteRune(r)
 	}
 
@@ -98,7 +106,7 @@ func splitProcessCommand(command string) ([]string, error) {
 		return nil, fmt.Errorf("invalid process_command: unclosed quote")
 	}
 	flush()
-	if len(args) == 0 {
+	if len(args) == 0 || args[0] == "" {
 		return nil, fmt.Errorf("process_command is empty")
 	}
 	return args, nil

--- a/config/command_split_test.go
+++ b/config/command_split_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitProcessCommand(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:  "simple",
+			input: "cmd arg1 arg2",
+			want:  []string{"cmd", "arg1", "arg2"},
+		},
+		{
+			name:  "extra whitespace",
+			input: "  cmd   arg1\targ2  ",
+			want:  []string{"cmd", "arg1", "arg2"},
+		},
+		{
+			name:  "windows path with spaces double quoted",
+			input: `"C:\Program Files\tool\cred.exe" get --profile default`,
+			want:  []string{`C:\Program Files\tool\cred.exe`, "get", "--profile", "default"},
+		},
+		{
+			name:  "unix path with spaces single quoted",
+			input: `'/usr/local/my tools/cred' arg`,
+			want:  []string{"/usr/local/my tools/cred", "arg"},
+		},
+		{
+			name:  "quoted argument with spaces",
+			input: `tool --name "First Last"`,
+			want:  []string{"tool", "--name", "First Last"},
+		},
+		{
+			name:  "escaped space",
+			input: `tool arg\ with\ space`,
+			want:  []string{"tool", "arg with space"},
+		},
+		{
+			name:  "escaped quote inside double quotes",
+			input: `tool "say \"hi\""`,
+			want:  []string{"tool", `say "hi"`},
+		},
+		{
+			name:    "empty",
+			input:   "   ",
+			wantErr: "process_command is empty",
+		},
+		{
+			name:    "unclosed double quote",
+			input:   `"C:\Program Files\tool.exe`,
+			wantErr: "unclosed quote",
+		},
+		{
+			name:    "unclosed single quote",
+			input:   `'/usr/bin/tool`,
+			wantErr: "unclosed quote",
+		},
+		{
+			name:    "trailing backslash",
+			input:   `tool\`,
+			wantErr: "trailing backslash",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := splitProcessCommand(tc.input)
+			if tc.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/config/command_split_test.go
+++ b/config/command_split_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,8 @@ func TestSplitProcessCommand(t *testing.T) {
 		input   string
 		want    []string
 		wantErr string
+		// skipOnWindows: POSIX-only escape semantics
+		skipOnWindows bool
 	}{
 		{
 			name:  "simple",
@@ -53,9 +56,10 @@ func TestSplitProcessCommand(t *testing.T) {
 			want:  []string{"tool", "--name", "First Last"},
 		},
 		{
-			name:  "escaped space",
-			input: `tool arg\ with\ space`,
-			want:  []string{"tool", "arg with space"},
+			name:          "escaped space",
+			input:         `tool arg\ with\ space`,
+			want:          []string{"tool", "arg with space"},
+			skipOnWindows: true,
 		},
 		{
 			name:  "escaped quote inside double quotes",
@@ -98,14 +102,18 @@ func TestSplitProcessCommand(t *testing.T) {
 			wantErr: "unclosed quote",
 		},
 		{
-			name:    "trailing backslash",
-			input:   `tool\`,
-			wantErr: "trailing backslash",
+			name:          "trailing backslash",
+			input:         `tool\`,
+			wantErr:       "trailing backslash",
+			skipOnWindows: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipOnWindows && runtime.GOOS == "windows" {
+				t.Skip("POSIX escape semantics not used on Windows")
+			}
 			got, err := splitProcessCommand(tc.input)
 			if tc.wantErr != "" {
 				assert.Error(t, err)
@@ -116,4 +124,45 @@ func TestSplitProcessCommand(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestSplitProcessCommandForOS_WindowsKeepsBackslashes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "unquoted windows path",
+			input: `C:\tools\cred.exe get`,
+			want:  []string{`C:\tools\cred.exe`, "get"},
+		},
+		{
+			name:  "quoted program files path",
+			input: `"C:\Program Files\tool\cred.exe" get`,
+			want:  []string{`C:\Program Files\tool\cred.exe`, "get"},
+		},
+		{
+			name:  "escaped quote still works",
+			input: `tool "say \"hi\""`,
+			want:  []string{"tool", `say "hi"`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := splitProcessCommandForOS(tc.input, "windows")
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSplitProcessCommandForOS_UnixEscapes(t *testing.T) {
+	got, err := splitProcessCommandForOS(`tool arg\ with\ space`, "linux")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"tool", "arg with space"}, got)
+
+	_, err = splitProcessCommandForOS(`tool\`, "linux")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "trailing backslash")
 }

--- a/config/command_split_test.go
+++ b/config/command_split_test.go
@@ -63,8 +63,28 @@ func TestSplitProcessCommand(t *testing.T) {
 			want:  []string{"tool", `say "hi"`},
 		},
 		{
+			name:  "empty double quoted argument",
+			input: `tool "" arg`,
+			want:  []string{"tool", "", "arg"},
+		},
+		{
+			name:  "empty single quoted argument",
+			input: `tool '' arg`,
+			want:  []string{"tool", "", "arg"},
+		},
+		{
+			name:  "adjacent quoted segments form one argument",
+			input: `tool "a b"'c d'`,
+			want:  []string{"tool", "a bc d"},
+		},
+		{
 			name:    "empty",
 			input:   "   ",
+			wantErr: "process_command is empty",
+		},
+		{
+			name:    "empty quoted command",
+			input:   `""`,
 			wantErr: "process_command is empty",
 		},
 		{

--- a/config/profile.go
+++ b/config/profile.go
@@ -592,7 +592,10 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 			return nil, fmt.Errorf("external credential source is disabled by %s (External mode)", EnvDisableExternalProcess)
 		}
 
-		args := strings.Fields(cp.ProcessCommand)
+		args, err := splitProcessCommand(cp.ProcessCommand)
+		if err != nil {
+			return nil, err
+		}
 		cmd := exec.Command(args[0], args[1:]...)
 
 		// 创建一个buffer来捕获标准输出


### PR DESCRIPTION
## Summary
- External process_command 改为支持引号的 argv 分词（POSIX shlex 语义）
- Windows 带空格路径（如 Program Files）可用双引号包成单个参数
- 补充单测并达到新增代码覆盖率门禁