### PR TITLE
fix: POSIX line-continuation in External process_command splitting

### DIFF
--- a/config/command_split.go
+++ b/config/command_split.go
@@ -26,8 +26,9 @@ import (
 // single argument so Windows paths like "C:\Program Files\tool.exe" work.
 //
 // On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
-// next rune; inside double quotes, '\' only escapes '"', '\', '$', '`' and
-// newline; inside single quotes, all characters are literal.
+// next rune; inside double quotes, '\' only escapes '"', '\', '$' and '`';
+// backslash-newline is a line continuation (both removed) outside single
+// quotes; inside single quotes, all characters are literal.
 //
 // On Windows, '\' is a path separator and is treated as a literal (except
 // '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
@@ -84,7 +85,11 @@ func splitProcessCommandForOS(command, goos string) ([]string, error) {
 						i++
 						continue
 					}
-				} else if next == '"' || next == '\\' || next == '$' || next == '`' || next == '\n' {
+				} else if next == '\n' {
+					// Backslash-newline is a line continuation: both removed.
+					i++
+					continue
+				} else if next == '"' || next == '\\' || next == '$' || next == '`' {
 					current.WriteRune(next)
 					i++
 					continue
@@ -103,6 +108,11 @@ func splitProcessCommandForOS(command, goos string) ([]string, error) {
 			}
 			if i+1 >= len(runes) {
 				return nil, fmt.Errorf("invalid process_command: trailing backslash")
+			}
+			if runes[i+1] == '\n' {
+				// Backslash-newline is a line continuation: both removed.
+				i++
+				continue
 			}
 			hasToken = true
 			current.WriteRune(runes[i+1])

--- a/config/command_split_test.go
+++ b/config/command_split_test.go
@@ -82,6 +82,18 @@ func TestSplitProcessCommand(t *testing.T) {
 			want:  []string{"tool", "a bc d"},
 		},
 		{
+			name:          "backslash-newline outside quotes is line continuation",
+			input:         "tool arg1 \\\n arg2",
+			want:          []string{"tool", "arg1", "arg2"},
+			skipOnWindows: true,
+		},
+		{
+			name:          "backslash-newline inside double quotes is line continuation",
+			input:         "tool \"a\\\nb\"",
+			want:          []string{"tool", "ab"},
+			skipOnWindows: true,
+		},
+		{
 			name:    "empty",
 			input:   "   ",
 			wantErr: "process_command is empty",

--- a/config/profile.go
+++ b/config/profile.go
@@ -594,7 +594,7 @@ func (cp *Profile) GetCredential(ctx *cli.Context, proxyHost *string) (cred cred
 
 		args, err := splitProcessCommand(cp.ProcessCommand)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("profile %s: %s", cp.Name, err.Error())
 		}
 		cmd := exec.Command(args[0], args[1:]...)
 

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -1363,6 +1363,25 @@ echo 'This is not a valid JSON'
 	}
 }
 
+func TestProfile_GetCredential_ExternalInvalidProcessCommand(t *testing.T) {
+	profile := Profile{
+		Name:           "badquote",
+		Mode:           External,
+		ProcessCommand: `"C:\Program Files\tool.exe`,
+	}
+	config := &Configuration{
+		CurrentProfile: profile.Name,
+		Profiles:       []Profile{profile},
+	}
+	profile.parent = config
+
+	ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+	_, err := profile.GetCredential(ctx, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "profile badquote")
+	assert.Contains(t, err.Error(), "unclosed quote")
+}
+
 func TestProfile_GetCredential_ExternalProcessDisabled(t *testing.T) {
 	orig := os.Getenv(EnvDisableExternalProcess)
 	os.Setenv(EnvDisableExternalProcess, "1")


### PR DESCRIPTION
## Summary
- Treat backslash-newline as POSIX line continuation (both removed) in `splitProcessCommand`, outside quotes and inside double quotes, matching shlex semantics (follow-up to #1391 review).
- Wrap split errors with the profile name for easier troubleshooting.
- Add test cases for both continuation positions and the wrapped error.