### PR TITLE
Improve invalid flag error with did-you-mean hints

### DIFF
--- a/cli/context_test.go
+++ b/cli/context_test.go
@@ -118,6 +118,19 @@ func TestDetectFlag(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestDetectFlag_InvalidNamesSuggestsName(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(w, stderr)
+	cmd := &Command{Name: "uninstall", flags: NewFlagSet()}
+	cmd.Flags().Add(&Flag{Name: "name", AssignedMode: AssignedOnce})
+	ctx.EnterCommand(cmd)
+
+	f, err := ctx.detectFlag("names")
+	assert.Nil(t, f)
+	assert.EqualError(t, err, "invalid flag --names, did you mean --name?")
+}
+
 func TestDetectFlagByShorthand(t *testing.T) {
 	w := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -13,7 +13,10 @@
 // limitations under the License.
 package cli
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // If command.Execute return Noticeable error, print i18n Notice under error information
 type ErrorWithTip interface {
@@ -77,11 +80,43 @@ func NewInvalidFlagError(name string, ctx *Context) error {
 	}
 }
 
+func (e *InvalidFlagError) flagDisplay() string {
+	if strings.HasPrefix(e.Flag, "-") {
+		return e.Flag
+	}
+	return "--" + e.Flag
+}
+
 func (e *InvalidFlagError) Error() string {
-	return fmt.Sprintf("invalid flag %s", e.Flag)
+	display := e.flagDisplay()
+	suggestions := e.closeSuggestions()
+	if len(suggestions) > 0 {
+		return fmt.Sprintf("invalid flag %s, did you mean %s?", display, strings.Join(suggestions, " or "))
+	}
+	available := e.availableFlags()
+	if len(available) > 0 {
+		return fmt.Sprintf("invalid flag %s; available flags: %s", display, strings.Join(available, ", "))
+	}
+	return fmt.Sprintf("invalid flag %s", display)
+}
+
+func (e *InvalidFlagError) closeSuggestions() []string {
+	if e.ctx == nil || e.ctx.command == nil || e.ctx.Flags() == nil {
+		return nil
+	}
+	distance := e.ctx.command.GetSuggestDistance()
+	return e.ctx.Flags().GetSuggestions(e.Flag, distance)
+}
+
+func (e *InvalidFlagError) availableFlags() []string {
+	if e.ctx == nil || e.ctx.Flags() == nil {
+		return nil
+	}
+	return e.ctx.Flags().AvailableFlagNames()
 }
 
 func (e *InvalidFlagError) GetSuggestions() []string {
-	distance := e.ctx.command.GetSuggestDistance()
-	return e.ctx.Flags().GetSuggestions(e.Flag, distance)
+	// Suggestions are already embedded in Error() to keep the hint on stderr
+	// (PrintSuggestions writes to stdout and is easy to miss).
+	return nil
 }

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -87,11 +87,26 @@ func TestInvalidFlagError_DidYouMeanOr(t *testing.T) {
 
 	err := NewInvalidFlagError("fo", ctx)
 	e := err.(*InvalidFlagError)
+	// Suggestions are sorted so the joined message is stable across runs
+	assert.Equal(t, "invalid flag --fo, did you mean --foo or --fox?", e.Error())
+}
+
+func TestInvalidFlagError_AvailableIncludesAliasAndShort(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(w, stderr)
+	cmd := &Command{Name: "cmd", flags: NewFlagSet()}
+	cmd.Flags().Add(&Flag{Name: "log-level", Aliases: []string{"log_level"}, Shorthand: 'L'})
+	ctx.EnterCommand(cmd)
+
+	err := NewInvalidFlagError("zzzzz", ctx)
+	e := err.(*InvalidFlagError)
 	msg := e.Error()
-	assert.Contains(t, msg, "invalid flag --fo, did you mean")
-	assert.Contains(t, msg, "--foo")
-	assert.Contains(t, msg, "--fox")
-	assert.Contains(t, msg, " or ")
+	assert.Contains(t, msg, "invalid flag --zzzzz; available flags:")
+	assert.Contains(t, msg, "--log-level")
+	assert.Contains(t, msg, "--log_level")
+	assert.Contains(t, msg, "-L")
+	assert.Contains(t, msg, "--help")
 }
 
 func TestInvalidFlagError_AlreadyPrefixed(t *testing.T) {

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -50,9 +50,62 @@ func TestInvalidFlagError(t *testing.T) {
 	err := NewInvalidFlagError("MrX", ctx)
 	e, ok := err.(*InvalidFlagError)
 	assert.True(t, ok)
-	assert.Equal(t, "invalid flag MrX", e.Error())
+	assert.Equal(t, "invalid flag --MrX", e.Error())
+	assert.Nil(t, e.GetSuggestions())
 
 	e.ctx.EnterCommand(&Command{Name: "oss", flags: NewFlagSet()})
-	assert.NotNil(t, e.GetSuggestions())
-	assert.Len(t, e.GetSuggestions(), 0)
+	// help flag is always added; no close match for MrX → list available flags
+	assert.Contains(t, e.Error(), "invalid flag --MrX; available flags:")
+	assert.Contains(t, e.Error(), "--help")
+	assert.Nil(t, e.GetSuggestions())
+}
+
+func TestInvalidFlagError_DidYouMean(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(w, stderr)
+	cmd := &Command{Name: "uninstall", flags: NewFlagSet()}
+	cmd.Flags().Add(&Flag{Name: "name", AssignedMode: AssignedOnce})
+	ctx.EnterCommand(cmd)
+
+	err := NewInvalidFlagError("names", ctx)
+	e, ok := err.(*InvalidFlagError)
+	assert.True(t, ok)
+	// "names" vs "--name" should suggest via UnifyApply
+	assert.Equal(t, "invalid flag --names, did you mean --name?", e.Error())
+	assert.Nil(t, e.GetSuggestions())
+}
+
+func TestInvalidFlagError_DidYouMeanOr(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(w, stderr)
+	cmd := &Command{Name: "cmd", flags: NewFlagSet()}
+	cmd.Flags().Add(&Flag{Name: "foo", AssignedMode: AssignedOnce})
+	cmd.Flags().Add(&Flag{Name: "fox", AssignedMode: AssignedOnce})
+	ctx.EnterCommand(cmd)
+
+	err := NewInvalidFlagError("fo", ctx)
+	e := err.(*InvalidFlagError)
+	msg := e.Error()
+	assert.Contains(t, msg, "invalid flag --fo, did you mean")
+	assert.Contains(t, msg, "--foo")
+	assert.Contains(t, msg, "--fox")
+	assert.Contains(t, msg, " or ")
+}
+
+func TestInvalidFlagError_AlreadyPrefixed(t *testing.T) {
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(w, stderr)
+	err := NewInvalidFlagError("--MrX", ctx)
+	e := err.(*InvalidFlagError)
+	assert.Equal(t, "invalid flag --MrX", e.Error())
+}
+
+func TestInvalidFlagError_NilContext(t *testing.T) {
+	e := &InvalidFlagError{Flag: "x", ctx: nil}
+	assert.Equal(t, "invalid flag --x", e.Error())
+	assert.Nil(t, e.closeSuggestions())
+	assert.Nil(t, e.availableFlags())
 }

--- a/cli/flag_set.go
+++ b/cli/flag_set.go
@@ -15,6 +15,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -85,6 +86,7 @@ func (fs *FlagSet) GetByShorthand(c rune) *Flag {
 
 // get suggestions for an unknown flag name.
 // Uses UnifyApply so comparing "names" against "--name" works (dashes ignored).
+// Results are sorted for stable error messages (index is a map).
 func (fs *FlagSet) GetSuggestions(name string, distance int) []string {
 	sr := NewSuggester(name, distance)
 	for k := range fs.index {
@@ -92,11 +94,13 @@ func (fs *FlagSet) GetSuggestions(name string, distance int) []string {
 	}
 	ss := make([]string, 0)
 	ss = append(ss, sr.GetResults()...)
-
+	sort.Strings(ss)
 	return ss
 }
 
-// AvailableFlagNames returns long-form flag names (e.g. "--name") for non-hidden flags.
+// AvailableFlagNames returns accepted forms for non-hidden flags (primary,
+// aliases, and shorthand), e.g. "--name", "--log_level", "-p". Sorted for
+// stable error messages.
 func (fs *FlagSet) AvailableFlagNames() []string {
 	if fs == nil {
 		return nil
@@ -106,8 +110,9 @@ func (fs *FlagSet) AvailableFlagNames() []string {
 		if f.Hidden {
 			continue
 		}
-		ss = append(ss, "--"+f.Name)
+		ss = append(ss, f.GetFormations()...)
 	}
+	sort.Strings(ss)
 	return ss
 }
 

--- a/cli/flag_set.go
+++ b/cli/flag_set.go
@@ -83,15 +83,31 @@ func (fs *FlagSet) GetByShorthand(c rune) *Flag {
 	return nil
 }
 
-// get suggestions
+// get suggestions for an unknown flag name.
+// Uses UnifyApply so comparing "names" against "--name" works (dashes ignored).
 func (fs *FlagSet) GetSuggestions(name string, distance int) []string {
 	sr := NewSuggester(name, distance)
 	for k := range fs.index {
-		sr.Apply(k)
+		sr.UnifyApply(k)
 	}
 	ss := make([]string, 0)
 	ss = append(ss, sr.GetResults()...)
 
+	return ss
+}
+
+// AvailableFlagNames returns long-form flag names (e.g. "--name") for non-hidden flags.
+func (fs *FlagSet) AvailableFlagNames() []string {
+	if fs == nil {
+		return nil
+	}
+	ss := make([]string, 0, len(fs.flags))
+	for _, f := range fs.flags {
+		if f.Hidden {
+			continue
+		}
+		ss = append(ss, "--"+f.Name)
+	}
 	return ss
 }
 

--- a/cli/flag_set_test.go
+++ b/cli/flag_set_test.go
@@ -97,6 +97,12 @@ func TestGetSuggestions(t *testing.T) {
 	// No close match
 	ss = fs.GetSuggestions("zzzzz", DefaultSuggestDistance)
 	assert.Empty(t, ss)
+
+	// Multiple matches are sorted for stable error messages
+	fs.Add(&Flag{Name: "foo", AssignedMode: AssignedOnce})
+	fs.Add(&Flag{Name: "fox", AssignedMode: AssignedOnce})
+	ss = fs.GetSuggestions("fo", DefaultSuggestDistance)
+	assert.Equal(t, []string{"--foo", "--fox"}, ss)
 }
 
 func TestAvailableFlagNames(t *testing.T) {
@@ -106,11 +112,11 @@ func TestAvailableFlagNames(t *testing.T) {
 	fs.Add(&Flag{Name: "name"})
 	fs.Add(&Flag{Name: "hidden", Hidden: true})
 	fs.Add(&Flag{Name: "profile", Shorthand: 'p'})
+	fs.Add(&Flag{Name: "log-level", Aliases: []string{"log_level"}})
 
 	names := fs.AvailableFlagNames()
-	assert.Equal(t, []string{"--name", "--profile"}, names)
+	assert.Equal(t, []string{"--log-level", "--log_level", "--name", "--profile", "-p"}, names)
 	assert.NotContains(t, names, "--hidden")
-	assert.NotContains(t, names, "-p")
 }
 
 func TestGetValue(t *testing.T) {

--- a/cli/flag_set_test.go
+++ b/cli/flag_set_test.go
@@ -82,7 +82,35 @@ func TestGetByShorthand(t *testing.T) {
 }
 
 func TestGetSuggestions(t *testing.T) {
-	//TODO after prefected cli/suggestion.go testcase
+	fs := NewFlagSet()
+	fs.Add(&Flag{Name: "name", AssignedMode: AssignedOnce})
+	fs.Add(&Flag{Name: "profile", Shorthand: 'p', AssignedMode: AssignedOnce})
+
+	// Typo "names" should suggest "--name" (UnifyApply ignores leading dashes)
+	ss := fs.GetSuggestions("names", DefaultSuggestDistance)
+	assert.Equal(t, []string{"--name"}, ss)
+
+	// Exact-ish match on long form
+	ss = fs.GetSuggestions("profil", DefaultSuggestDistance)
+	assert.Equal(t, []string{"--profile"}, ss)
+
+	// No close match
+	ss = fs.GetSuggestions("zzzzz", DefaultSuggestDistance)
+	assert.Empty(t, ss)
+}
+
+func TestAvailableFlagNames(t *testing.T) {
+	assert.Nil(t, (*FlagSet)(nil).AvailableFlagNames())
+
+	fs := NewFlagSet()
+	fs.Add(&Flag{Name: "name"})
+	fs.Add(&Flag{Name: "hidden", Hidden: true})
+	fs.Add(&Flag{Name: "profile", Shorthand: 'p'})
+
+	names := fs.AvailableFlagNames()
+	assert.Equal(t, []string{"--name", "--profile"}, names)
+	assert.NotContains(t, names, "--hidden")
+	assert.NotContains(t, names, "-p")
 }
 
 func TestGetValue(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix flag suggestion matching so typos like `--names` suggest `--name` (UnifyApply ignores dashes)
- Embed closest-match or available-flag list in the invalid-flag error message on stderr
- Add unit tests covering suggestion, fallback listing, and detectFlag path