### PR TITLE
fix: detect throttling by x-acs-retry-after header

### DIFF
--- a/openapi/http_context.go
+++ b/openapi/http_context.go
@@ -138,9 +138,6 @@ func openapiThrottlingRetryDelay(err error, cfg *throttlingretry.Config) (int64,
 	if !errors.As(err, &throttlingErr) {
 		return 0, false
 	}
-	if !strings.Contains(tea.StringValue(throttlingErr.GetCode()), "Throttling") {
-		return 0, false
-	}
 
 	retryAfter := throttlingErr.GetRetryAfter()
 	if retryAfter == nil || *retryAfter < 0 {

--- a/openapi/http_context_throttling_test.go
+++ b/openapi/http_context_throttling_test.go
@@ -59,8 +59,10 @@ func TestOpenapiThrottlingRetryDelay(t *testing.T) {
 	_, ok = openapiThrottlingRetryDelay(errors.New("plain"), cfg)
 	assert.False(t, ok)
 
-	_, ok = openapiThrottlingRetryDelay(newOpenAPThrottlingError("InternalError", 100), cfg)
-	assert.False(t, ok)
+	// Non-Throttling code with retryAfter still counts as throttling.
+	delay, ok = openapiThrottlingRetryDelay(newOpenAPThrottlingError("ServiceUnavailable", 100), cfg)
+	assert.True(t, ok)
+	assert.Equal(t, int64(100), delay)
 
 	err := newOpenAPThrottlingError("Throttling", 100)
 	throttlingErr := err.(*openapiClient.ThrottlingError)

--- a/openapi/throttling_retry.go
+++ b/openapi/throttling_retry.go
@@ -70,9 +70,6 @@ func (a *BasicInvoker) throttlingRetryDelay(err error) (int64, bool) {
 	if !errors.As(err, &serverErr) {
 		return 0, false
 	}
-	if !strings.Contains(serverErr.ErrorCode(), "Throttling") {
-		return 0, false
-	}
 
 	delayMS, ok := retryAfterFromHeaders(serverErr.RespHeaders)
 	if !ok {

--- a/openapi/throttling_retry_test.go
+++ b/openapi/throttling_retry_test.go
@@ -199,15 +199,16 @@ func TestCallWithThrottlingRetryStopsWhenDisabled(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
-func TestThrottlingRetryDelayRequiresThrottlingCodeAndRetryAfter(t *testing.T) {
+func TestThrottlingRetryDelayRequiresRetryAfterHeader(t *testing.T) {
 	invoker := &BasicInvoker{}
 
 	delay, ok := invoker.throttlingRetryDelay(newThrottlingServerError("Throttling.Api", "123"))
 	assert.True(t, ok)
 	assert.Equal(t, int64(123), delay)
 
-	_, ok = invoker.throttlingRetryDelay(newThrottlingServerError("InternalError", "123"))
-	assert.False(t, ok)
+	delay, ok = invoker.throttlingRetryDelay(newThrottlingServerError("InternalError", "123"))
+	assert.True(t, ok)
+	assert.Equal(t, int64(123), delay)
 
 	_, ok = invoker.throttlingRetryDelay(newThrottlingServerError("Throttling.Api", "not-number"))
 	assert.False(t, ok)


### PR DESCRIPTION
## Summary
- Classic OpenAPI and V2 client throttling retry now key off `x-acs-retry-after` / RetryAfter.
- Stop requiring error Code to contain `Throttling`.
- Update unit tests for non-Throttling codes that still carry retry-after.