### PR TITLE
fix: flatten Array params for RPC APIs like ALB Servers

### DIFF
--- a/meta/api.go
+++ b/meta/api.go
@@ -65,11 +65,18 @@ func (a *Api) ForeachParameters(f func(s string, p Parameter)) {
 	foreachParameters(a.Parameters, "", f)
 }
 
+// IsListParameterType reports whether the parameter is a list that may be
+// assigned via flat dotted flags (Name.1 / Name.1.Field), including both the
+// classic RepeatList style and the newer Array type used by products such as ALB.
+func IsListParameterType(t string) bool {
+	return t == "RepeatList" || t == "Array"
+}
+
 func foreachParameters(params []Parameter, prefix string, f func(s string, p Parameter)) {
 	for _, p := range params {
 		if len(p.SubParameters) > 0 {
 			foreachParameters(p.SubParameters, prefix+p.Name+".1.", f)
-		} else if p.Type == "RepeatList" {
+		} else if IsListParameterType(p.Type) {
 			f(prefix+p.Name+".1", p)
 		} else {
 			f(prefix+p.Name, p)
@@ -93,8 +100,8 @@ func findParameterInner(params []Parameter, name string) *Parameter {
 			return nil
 		}
 
-		if p.Type == "RepeatList" && strings.HasPrefix(name, p.Name) {
-			// XXX.1
+		if IsListParameterType(p.Type) && strings.HasPrefix(name, p.Name) {
+			// XXX.1 or XXX.1.YYY
 			s := name[len(p.Name):]
 			if len(s) >= 2 && s[0] == '.' {
 				return &((params)[i])
@@ -110,7 +117,9 @@ func (a *Api) CheckRequiredParameters(checker func(string) bool) error {
 	for _, p := range a.Parameters {
 		if p.Required {
 			name := p.Name
-			if p.Type != "RepeatList" {
+			// List params may be supplied as --Name.1 / --Name.1.Field; skip the
+			// top-level presence check (same historical behavior as RepeatList).
+			if !IsListParameterType(p.Type) {
 				if !checker(name) {
 					missing = true
 					s = s + "\n  --" + p.Name

--- a/meta/api_test.go
+++ b/meta/api_test.go
@@ -143,6 +143,45 @@ func TestApi_FindParameter(t *testing.T) {
 	assert.NotNil(t, parameter)
 }
 
+func TestApi_FindParameter_ArrayFlatFlags(t *testing.T) {
+	api := &Api{
+		Parameters: []Parameter{
+			{Name: "Servers", Type: "Array", Position: "Body", Required: true},
+			{Name: "ServerGroupId", Type: "String", Position: "Query", Required: true},
+		},
+	}
+
+	assert.NotNil(t, api.FindParameter("Servers"))
+	assert.NotNil(t, api.FindParameter("Servers.1.ServerId"))
+	assert.NotNil(t, api.FindParameter("Servers.1.ServerType"))
+	assert.NotNil(t, api.FindParameter("Servers.10.Port"))
+	assert.Equal(t, "Servers", api.FindParameter("Servers.1.Weight").Name)
+	assert.Nil(t, api.FindParameter("ServersX.1.ServerId"))
+	assert.Nil(t, api.FindParameter("ServerGroupId.1.X"))
+}
+
+func TestIsListParameterType(t *testing.T) {
+	assert.True(t, IsListParameterType("RepeatList"))
+	assert.True(t, IsListParameterType("Array"))
+	assert.False(t, IsListParameterType("String"))
+	assert.False(t, IsListParameterType(""))
+}
+
+func TestApi_CheckRequiredParameters_ArraySkippedLikeRepeatList(t *testing.T) {
+	api := &Api{
+		Parameters: []Parameter{
+			{Name: "Servers", Type: "Array", Required: true},
+			{Name: "ServerGroupId", Type: "String", Required: true},
+		},
+	}
+	err := api.CheckRequiredParameters(func(s string) bool {
+		return false
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--ServerGroupId")
+	assert.NotContains(t, err.Error(), "--Servers")
+}
+
 func TestApi_ForeachParameters(t *testing.T) {
 	api := &Api{}
 	f := func(s string, p Parameter) {

--- a/openapi/array_flatten.go
+++ b/openapi/array_flatten.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// expandJSONArrayParameter tries to parse value as a JSON array/object and
+// flatten it into RPC flat-form keys (e.g. Servers.1.ServerId). Returns ok=false
+// when value is not JSON structured data, so callers keep the original string.
+func expandJSONArrayParameter(name, value string) (map[string]string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, false
+	}
+	if trimmed[0] != '[' && trimmed[0] != '{' {
+		return nil, false
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader([]byte(trimmed)))
+	decoder.UseNumber()
+	var parsed interface{}
+	if err := decoder.Decode(&parsed); err != nil {
+		return nil, false
+	}
+
+	out := make(map[string]string)
+	flattenRPCValue(name, parsed, out)
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func flattenRPCValue(prefix string, v interface{}, out map[string]string) {
+	switch val := v.(type) {
+	case []interface{}:
+		for i, item := range val {
+			flattenRPCValue(fmt.Sprintf("%s.%d", prefix, i+1), item, out)
+		}
+	case map[string]interface{}:
+		for k, item := range val {
+			flattenRPCValue(fmt.Sprintf("%s.%s", prefix, k), item, out)
+		}
+	case nil:
+		return
+	case json.Number:
+		out[prefix] = val.String()
+	case string:
+		out[prefix] = val
+	case bool:
+		out[prefix] = fmt.Sprintf("%t", val)
+	default:
+		out[prefix] = fmt.Sprintf("%v", val)
+	}
+}

--- a/openapi/array_flatten_test.go
+++ b/openapi/array_flatten_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandJSONArrayParameter_ObjectArray(t *testing.T) {
+	flat, ok := expandJSONArrayParameter("Servers", `[{"ServerId":"i-xxx","ServerType":"Ecs","Port":8081,"Weight":100}]`)
+	assert.True(t, ok)
+	assert.Equal(t, "i-xxx", flat["Servers.1.ServerId"])
+	assert.Equal(t, "Ecs", flat["Servers.1.ServerType"])
+	assert.Equal(t, "8081", flat["Servers.1.Port"])
+	assert.Equal(t, "100", flat["Servers.1.Weight"])
+}
+
+func TestExpandJSONArrayParameter_MultipleItems(t *testing.T) {
+	flat, ok := expandJSONArrayParameter("Servers", `[{"ServerId":"i-1","Port":80},{"ServerId":"i-2","Port":443}]`)
+	assert.True(t, ok)
+	assert.Equal(t, "i-1", flat["Servers.1.ServerId"])
+	assert.Equal(t, "80", flat["Servers.1.Port"])
+	assert.Equal(t, "i-2", flat["Servers.2.ServerId"])
+	assert.Equal(t, "443", flat["Servers.2.Port"])
+}
+
+func TestExpandJSONArrayParameter_PrimitiveArray(t *testing.T) {
+	flat, ok := expandJSONArrayParameter("Ids", `["a","b"]`)
+	assert.True(t, ok)
+	assert.Equal(t, "a", flat["Ids.1"])
+	assert.Equal(t, "b", flat["Ids.2"])
+}
+
+func TestExpandJSONArrayParameter_SingleObject(t *testing.T) {
+	flat, ok := expandJSONArrayParameter("Server", `{"ServerId":"i-xxx","Port":8081}`)
+	assert.True(t, ok)
+	assert.Equal(t, "i-xxx", flat["Server.ServerId"])
+	assert.Equal(t, "8081", flat["Server.Port"])
+}
+
+func TestExpandJSONArrayParameter_NestedArray(t *testing.T) {
+	flat, ok := expandJSONArrayParameter("Rule", `[{"Actions":[{"Type":"Forward","Order":1}]}]`)
+	assert.True(t, ok)
+	assert.Equal(t, "Forward", flat["Rule.1.Actions.1.Type"])
+	assert.Equal(t, "1", flat["Rule.1.Actions.1.Order"])
+}
+
+func TestExpandJSONArrayParameter_BoolAndNull(t *testing.T) {
+	flat, ok := expandJSONArrayParameter("Items", `[{"Enabled":true,"Note":null}]`)
+	assert.True(t, ok)
+	assert.Equal(t, "true", flat["Items.1.Enabled"])
+	_, hasNote := flat["Items.1.Note"]
+	assert.False(t, hasNote)
+}
+
+func TestExpandJSONArrayParameter_RejectsNonJSON(t *testing.T) {
+	_, ok := expandJSONArrayParameter("Servers", "not-json")
+	assert.False(t, ok)
+
+	_, ok = expandJSONArrayParameter("Servers", "")
+	assert.False(t, ok)
+
+	_, ok = expandJSONArrayParameter("Servers", "   ")
+	assert.False(t, ok)
+
+	_, ok = expandJSONArrayParameter("Servers", `{broken`)
+	assert.False(t, ok)
+
+	_, ok = expandJSONArrayParameter("Servers", `[]`)
+	assert.False(t, ok)
+}
+
+func TestFlattenRPCValue_DefaultKind(t *testing.T) {
+	out := make(map[string]string)
+	flattenRPCValue("N", float64(1.5), out)
+	assert.Equal(t, "1.5", out["N"])
+}

--- a/openapi/library.go
+++ b/openapi/library.go
@@ -181,7 +181,7 @@ func printParameters(w io.Writer, params []meta.Parameter, prefix string, detail
 			continue
 		}
 
-		if param.Type == "RepeatList" {
+		if meta.IsListParameterType(param.Type) {
 			if len(param.SubParameters) > 0 {
 				printParameters(w, param.SubParameters, prefix+param.Name+".n.", detail)
 			} else {

--- a/openapi/library_test.go
+++ b/openapi/library_test.go
@@ -113,6 +113,19 @@ func Test_printParameters(t *testing.T) {
 	assert.Contains(t, w.String(), cli.Colorized(cli.Cyan, "Values")+".n")
 }
 
+func TestPrintParameters_ArrayShowsFlatHint(t *testing.T) {
+	w := new(bytes.Buffer)
+	params := []meta.Parameter{
+		{Name: "Servers", Type: "Array", Required: true},
+		{Name: "ServerGroupId", Type: "String", Required: true},
+	}
+	printParameters(w, params, "", &newmeta.APIDetail{})
+	assert.Contains(t, w.String(), cli.Colorized(cli.Cyan, "Servers")+".n")
+	assert.Contains(t, w.String(), "Array")
+	assert.Contains(t, w.String(), "Required")
+	assert.Contains(t, w.String(), cli.Colorized(cli.Cyan, "ServerGroupId"))
+}
+
 func getRepository() *meta.Repository {
 	repository := meta.LoadRepository()
 	return repository

--- a/openapi/rpc.go
+++ b/openapi/rpc.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/meta"
@@ -68,11 +69,21 @@ func (a *RpcInvoker) Prepare(ctx *cli.Context) error {
 			return &InvalidParameterError{Name: f.Name, api: api, flags: ctx.Flags()}
 		}
 
+		value, _ := f.GetValue()
+		// Array params often require RPC flat serialization (Servers.1.ServerId).
+		// When the user passes a JSON array/object via --Servers '[...]', expand it.
+		if param.Type == "Array" && f.Name == param.Name {
+			if flat, ok := expandJSONArrayParameter(param.Name, value); ok {
+				assignRPCParams(request, param.Position, flat)
+				continue
+			}
+		}
+
 		if param.Position == "Query" {
-			request.QueryParams[f.Name], _ = f.GetValue()
+			request.QueryParams[f.Name] = value
 		} else if param.Position == "Body" || param.Position == "FormData" {
 			// new add FormData
-			request.FormParams[f.Name], _ = f.GetValue()
+			request.FormParams[f.Name] = value
 		} else if param.Position == "Domain" {
 			continue
 		} else {
@@ -122,4 +133,14 @@ func replaceValueWithFile(f *cli.Flag) {
 		panic(err)
 	}
 	f.SetValue(string(data))
+}
+
+func assignRPCParams(request *requests.CommonRequest, position string, params map[string]string) {
+	for k, v := range params {
+		if position == "Query" {
+			request.QueryParams[k] = v
+		} else if position == "Body" || position == "FormData" {
+			request.FormParams[k] = v
+		}
+	}
 }

--- a/openapi/rpc_test.go
+++ b/openapi/rpc_test.go
@@ -126,6 +126,124 @@ func TestRpcInvoker_Prepare(t *testing.T) {
 
 }
 
+func TestRpcInvoker_Prepare_ArrayJSONFlattensToFormParams(t *testing.T) {
+	a := &RpcInvoker{
+		BasicInvoker: &BasicInvoker{
+			request: requests.NewCommonRequest(),
+		},
+		api: &meta.Api{
+			Product: &meta.Product{Code: "alb"},
+			Name:    "AddServersToServerGroup",
+			Method:  "POST",
+			Parameters: []meta.Parameter{
+				{Name: "ServerGroupId", Position: "Query", Type: "String", Required: true},
+				{Name: "Servers", Position: "Body", Type: "Array", Required: true},
+			},
+		},
+	}
+	w := new(bufio.Writer)
+	stderr := new(bufio.Writer)
+	ctx := cli.NewCommandContext(w, stderr)
+	ctx.Flags().Add(NewSecureFlag())
+	ctx.Flags().Add(NewInsecureFlag())
+	ctx.Flags().Add(NewMethodFlag())
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	ctx.UnknownFlags().AddByName("ServerGroupId")
+	ctx.UnknownFlags().Get("ServerGroupId").SetAssigned(true)
+	ctx.UnknownFlags().Get("ServerGroupId").SetValue("sgp-xxx")
+	ctx.UnknownFlags().AddByName("Servers")
+	ctx.UnknownFlags().Get("Servers").SetAssigned(true)
+	ctx.UnknownFlags().Get("Servers").SetValue(`[{"ServerId":"i-xxx","ServerType":"Ecs","Port":8081,"Weight":100}]`)
+
+	err := a.Prepare(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "sgp-xxx", a.request.QueryParams["ServerGroupId"])
+	assert.Equal(t, "i-xxx", a.request.FormParams["Servers.1.ServerId"])
+	assert.Equal(t, "Ecs", a.request.FormParams["Servers.1.ServerType"])
+	assert.Equal(t, "8081", a.request.FormParams["Servers.1.Port"])
+	assert.Equal(t, "100", a.request.FormParams["Servers.1.Weight"])
+	_, hasRaw := a.request.FormParams["Servers"]
+	assert.False(t, hasRaw, "raw JSON Servers key must not remain after flatten")
+}
+
+func TestRpcInvoker_Prepare_ArrayFlatFlagsAccepted(t *testing.T) {
+	a := &RpcInvoker{
+		BasicInvoker: &BasicInvoker{
+			request: requests.NewCommonRequest(),
+		},
+		api: &meta.Api{
+			Product: &meta.Product{Code: "alb"},
+			Name:    "AddServersToServerGroup",
+			Method:  "POST",
+			Parameters: []meta.Parameter{
+				{Name: "ServerGroupId", Position: "Query", Type: "String", Required: true},
+				{Name: "Servers", Position: "Body", Type: "Array", Required: true},
+			},
+		},
+	}
+	w := new(bufio.Writer)
+	stderr := new(bufio.Writer)
+	ctx := cli.NewCommandContext(w, stderr)
+	ctx.Flags().Add(NewSecureFlag())
+	ctx.Flags().Add(NewInsecureFlag())
+	ctx.Flags().Add(NewMethodFlag())
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	ctx.UnknownFlags().AddByName("ServerGroupId")
+	ctx.UnknownFlags().Get("ServerGroupId").SetAssigned(true)
+	ctx.UnknownFlags().Get("ServerGroupId").SetValue("sgp-xxx")
+	for _, kv := range [][2]string{
+		{"Servers.1.ServerId", "i-xxx"},
+		{"Servers.1.ServerType", "Ecs"},
+		{"Servers.1.Port", "8081"},
+		{"Servers.1.Weight", "100"},
+	} {
+		ctx.UnknownFlags().AddByName(kv[0])
+		ctx.UnknownFlags().Get(kv[0]).SetAssigned(true)
+		ctx.UnknownFlags().Get(kv[0]).SetValue(kv[1])
+	}
+
+	err := a.Prepare(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "i-xxx", a.request.FormParams["Servers.1.ServerId"])
+	assert.Equal(t, "Ecs", a.request.FormParams["Servers.1.ServerType"])
+	assert.Equal(t, "8081", a.request.FormParams["Servers.1.Port"])
+	assert.Equal(t, "100", a.request.FormParams["Servers.1.Weight"])
+}
+
+func TestRpcInvoker_Prepare_ArrayJSONFlattensToQueryParams(t *testing.T) {
+	a := &RpcInvoker{
+		BasicInvoker: &BasicInvoker{
+			request: requests.NewCommonRequest(),
+		},
+		api: &meta.Api{
+			Product: &meta.Product{Code: "demo"},
+			Name:    "Demo",
+			Method:  "POST",
+			Parameters: []meta.Parameter{
+				{Name: "Tags", Position: "Query", Type: "Array", Required: true},
+			},
+		},
+	}
+	w := new(bufio.Writer)
+	stderr := new(bufio.Writer)
+	ctx := cli.NewCommandContext(w, stderr)
+	ctx.Flags().Add(NewSecureFlag())
+	ctx.Flags().Add(NewInsecureFlag())
+	ctx.Flags().Add(NewMethodFlag())
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	ctx.UnknownFlags().AddByName("Tags")
+	ctx.UnknownFlags().Get("Tags").SetAssigned(true)
+	ctx.UnknownFlags().Get("Tags").SetValue(`[{"Key":"env","Value":"prod"}]`)
+
+	err := a.Prepare(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "env", a.request.QueryParams["Tags.1.Key"])
+	assert.Equal(t, "prod", a.request.QueryParams["Tags.1.Value"])
+}
+
 func TestRpcInvoker_Call(t *testing.T) {
 	client, err := sdk.NewClientWithAccessKey("regionid", "accesskeyid", "accesskeysecret")
 	assert.Nil(t, err)


### PR DESCRIPTION
## Summary

- Accept Array-typed RPC parameters via flat flags (`--Servers.1.Field`), same as RepeatList.
- Expand `--Servers '[{...}]'` JSON arrays into flat form (`Servers.1.Field`) before sending.
- Help text shows `--Servers.n` for Array parameters.