### PR TITLE
fix: allow --profile with aliyun oss subcommands

### DIFF
--- a/oss/lib/cli_bridge.go
+++ b/oss/lib/cli_bridge.go
@@ -137,6 +137,71 @@ func getArgValue(args []string, name string) (string, bool) {
 	return "", false
 }
 
+// ossKnownOptionNames returns long/short option names understood by OSS goopt (OptionMap).
+func ossKnownOptionNames() map[string]struct{} {
+	m := make(map[string]struct{}, len(OptionMap)*2)
+	for _, opt := range OptionMap {
+		if opt.nameAlias != "" {
+			m[opt.nameAlias] = struct{}{}
+		}
+		if opt.name != "" {
+			m[opt.name] = struct{}{}
+		}
+	}
+	return m
+}
+
+// stripCliOnlyFlagsFromArgs removes aliyun CLI config flags that OSS goopt does not
+// understand (e.g. --profile / -p), while keeping flags shared with OSS
+// (e.g. --endpoint, --region). Keeps KeepArgs forwarding from breaking on
+// trailing global flags. Supports --name value, --name=value, and short forms.
+func stripCliOnlyFlagsFromArgs(args []string) []string {
+	configFS := cli.NewFlagSet()
+	config.AddFlags(configFS)
+	ossKnown := ossKnownOptionNames()
+
+	longNeedsValue := make(map[string]bool)
+	shortNeedsValue := make(map[string]bool)
+
+	for _, f := range configFS.Flags() {
+		long := "--" + f.Name
+		if _, ok := ossKnown[long]; ok {
+			continue
+		}
+		needsValue := f.AssignedMode != cli.AssignedNone
+		longNeedsValue[long] = needsValue
+		if f.Shorthand != 0 {
+			shortNeedsValue["-"+string(f.Shorthand)] = needsValue
+		}
+	}
+
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if strings.HasPrefix(a, "--") {
+			if idx := strings.IndexByte(a, '='); idx > 0 {
+				if _, ok := longNeedsValue[a[:idx]]; ok {
+					continue
+				}
+			}
+		}
+		if needs, ok := longNeedsValue[a]; ok {
+			if needs && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		if needs, ok := shortNeedsValue[a]; ok {
+			if needs && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
 // ParseAndGetEndpoint get oss endpoint from cli context.
 // Priority (aligned with OpenAPI): explicit --endpoint (args/flag) >
 // profile.Endpoint > construct from region + endpoint-type.
@@ -253,6 +318,10 @@ func ParseAndRunCommandFromCli(ctx *cli.Context, args []string) error {
 			}
 		}
 	}
+
+	// Drop CLI-only config flags (e.g. --profile) before forwarding to OSS goopt.
+	// Credentials were already resolved from the selected profile above.
+	args = stripCliOnlyFlagsFromArgs(args)
 
 	a2 := []string{"aliyun", "oss"}
 	a2 = append(a2, ctx.Command().Name)

--- a/oss/lib/cli_bridge.go
+++ b/oss/lib/cli_bridge.go
@@ -186,13 +186,16 @@ func stripCliOnlyFlagsFromArgs(args []string) []string {
 			}
 		}
 		if needs, ok := longNeedsValue[a]; ok {
-			if needs && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			// Consume the value token even when it starts with '-' (e.g. profile
+			// "-myprof" or path "-tmp/cfg"). Only skip when the next token is a
+			// long option (--...), which indicates a missing value.
+			if needs && i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
 				i++
 			}
 			continue
 		}
 		if needs, ok := shortNeedsValue[a]; ok {
-			if needs && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			if needs && i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
 				i++
 			}
 			continue

--- a/oss/lib/cli_bridge_test.go
+++ b/oss/lib/cli_bridge_test.go
@@ -83,6 +83,27 @@ func TestStripCliOnlyFlagsFromArgs(t *testing.T) {
 		assert.Equal(t, []string{"ls", "--force"}, got)
 	})
 
+	t.Run("consumes value that starts with single dash", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"cp", "a", "b", "--profile", "-myprof", "--recursive",
+		})
+		assert.Equal(t, []string{"cp", "a", "b", "--recursive"}, got)
+	})
+
+	t.Run("consumes config-path value that looks like a dash path", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"ls", "oss://b", "--config-path", "-tmp/cfg", "--force",
+		})
+		assert.Equal(t, []string{"ls", "oss://b", "--force"}, got)
+	})
+
+	t.Run("shorthand consumes dash-prefixed profile value", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"src", "dst", "-p", "-myprof", "--force",
+		})
+		assert.Equal(t, []string{"src", "dst", "--force"}, got)
+	})
+
 	t.Run("strips AssignedNone CLI-only flag without consuming next", func(t *testing.T) {
 		got := stripCliOnlyFlagsFromArgs([]string{
 			"ls", "oss://b", "--skip-secure-verify", "--recursive",

--- a/oss/lib/cli_bridge_test.go
+++ b/oss/lib/cli_bridge_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -21,6 +22,88 @@ func TestBuildOssEndpoint(t *testing.T) {
 	assert.Equal(t, "oss-cn-hangzhou.aliyuncs.com", buildOssEndpoint("cn-hangzhou", ""))
 	assert.Equal(t, "oss-cn-hangzhou-internal.aliyuncs.com", buildOssEndpoint("cn-hangzhou", "vpc"))
 	assert.Equal(t, "oss-cn-beijing-internal.aliyuncs.com", buildOssEndpoint("cn-beijing", "VPC"))
+}
+
+func TestStripCliOnlyFlagsFromArgs(t *testing.T) {
+	t.Run("strips profile long and value", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"oss://bucket/obj", "/tmp/out", "--profile", "mac16@oyj",
+		})
+		assert.Equal(t, []string{"oss://bucket/obj", "/tmp/out"}, got)
+	})
+
+	t.Run("strips profile equals form", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"oss://bucket/obj", "--profile=other", "--recursive",
+		})
+		assert.Equal(t, []string{"oss://bucket/obj", "--recursive"}, got)
+	})
+
+	t.Run("strips profile shorthand -p", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"src", "dst", "-p", "myprof", "--force",
+		})
+		assert.Equal(t, []string{"src", "dst", "--force"}, got)
+	})
+
+	t.Run("keeps shared OSS options like region and endpoint", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"ls", "oss://b",
+			"--region", "cn-hangzhou",
+			"--endpoint", "oss-cn-hangzhou.aliyuncs.com",
+			"--profile", "x",
+			"--access-key-id", "ak",
+		})
+		assert.Equal(t, []string{
+			"ls", "oss://b",
+			"--region", "cn-hangzhou",
+			"--endpoint", "oss-cn-hangzhou.aliyuncs.com",
+			"--access-key-id", "ak",
+		}, got)
+	})
+
+	t.Run("strips other CLI-only config flags", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"cp", "a", "b",
+			"--config-path", "/tmp/cfg.json",
+			"--sts-endpoint", "sts.aliyuncs.com",
+			"--source-profile", "base",
+			"--recursive",
+		})
+		assert.Equal(t, []string{"cp", "a", "b", "--recursive"}, got)
+	})
+
+	t.Run("profile without value does not swallow next flag", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{"ls", "--profile", "--recursive"})
+		assert.Equal(t, []string{"ls", "--recursive"}, got)
+	})
+
+	t.Run("shorthand without value does not swallow next flag", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{"ls", "-p", "--force"})
+		assert.Equal(t, []string{"ls", "--force"}, got)
+	})
+
+	t.Run("strips AssignedNone CLI-only flag without consuming next", func(t *testing.T) {
+		got := stripCliOnlyFlagsFromArgs([]string{
+			"ls", "oss://b", "--skip-secure-verify", "--recursive",
+		})
+		assert.Equal(t, []string{"ls", "oss://b", "--recursive"}, got)
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		assert.Empty(t, stripCliOnlyFlagsFromArgs(nil))
+		assert.Empty(t, stripCliOnlyFlagsFromArgs([]string{}))
+	})
+}
+
+func TestOssKnownOptionNames_IncludesEndpointAndRegion(t *testing.T) {
+	known := ossKnownOptionNames()
+	_, hasEndpoint := known["--endpoint"]
+	_, hasRegion := known["--region"]
+	_, hasProfile := known["--profile"]
+	assert.True(t, hasEndpoint)
+	assert.True(t, hasRegion)
+	assert.False(t, hasProfile)
 }
 
 func newEndpointTestContext(t *testing.T) *cli.Context {
@@ -335,6 +418,124 @@ func TestParseAndRunCommandFromCli(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseAndRunCommandFromCli_ProfileFlagStrippedAndApplied(t *testing.T) {
+	clearEndpointTestEnv(t)
+	originalParseAndRunCommand := parseAndRunCommandImpl
+	defer func() { parseAndRunCommandImpl = originalParseAndRunCommand }()
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "current": "default",
+  "profiles": [
+    {
+      "name": "default",
+      "mode": "AK",
+      "access_key_id": "default-ak",
+      "access_key_secret": "default-sk",
+      "region_id": "cn-hangzhou",
+      "output_format": "json",
+      "language": "en"
+    },
+    {
+      "name": "mac16@oyj",
+      "mode": "AK",
+      "access_key_id": "profile-ak",
+      "access_key_secret": "profile-sk",
+      "region_id": "cn-beijing",
+      "output_format": "json",
+      "language": "en"
+    }
+  ]
+}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	ctx := newEndpointTestContext(t)
+	cmd := &cli.Command{Name: "cp"}
+	ctx.SetCommand(cmd)
+	config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+	config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+	var capturedArgs []string
+	parseAndRunCommandImpl = func() error {
+		capturedArgs = append([]string{}, os.Args...)
+		return nil
+	}
+
+	err := ParseAndRunCommandFromCli(ctx, []string{
+		"oss://oyj-test-role/file.vsix",
+		"/tmp/Downloads",
+		"--profile", "mac16@oyj",
+	})
+	require.NoError(t, err)
+
+	joined := strings.Join(capturedArgs, " ")
+	assert.NotContains(t, joined, "--profile")
+	assert.NotContains(t, joined, "mac16@oyj")
+	assert.Contains(t, joined, "--access-key-id")
+	assert.Contains(t, joined, "profile-ak")
+	assert.Contains(t, joined, "profile-sk")
+	assert.Contains(t, joined, "oss://oyj-test-role/file.vsix")
+	assert.Contains(t, joined, "/tmp/Downloads")
+}
+
+func TestParseAndRunCommandFromCli_ProfileEqualsForm(t *testing.T) {
+	clearEndpointTestEnv(t)
+	originalParseAndRunCommand := parseAndRunCommandImpl
+	defer func() { parseAndRunCommandImpl = originalParseAndRunCommand }()
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	content := `{
+  "current": "default",
+  "profiles": [
+    {
+      "name": "default",
+      "mode": "AK",
+      "access_key_id": "default-ak",
+      "access_key_secret": "default-sk",
+      "region_id": "cn-hangzhou",
+      "output_format": "json",
+      "language": "en"
+    },
+    {
+      "name": "alt",
+      "mode": "AK",
+      "access_key_id": "alt-ak",
+      "access_key_secret": "alt-sk",
+      "region_id": "cn-shanghai",
+      "output_format": "json",
+      "language": "en"
+    }
+  ]
+}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	ctx := newEndpointTestContext(t)
+	ctx.SetCommand(&cli.Command{Name: "ls"})
+	config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+	config.ConfigurePathFlag(ctx.Flags()).SetValue(path)
+
+	var capturedArgs []string
+	parseAndRunCommandImpl = func() error {
+		capturedArgs = append([]string{}, os.Args...)
+		return nil
+	}
+
+	err := ParseAndRunCommandFromCli(ctx, []string{"oss://bucket", "--profile=alt"})
+	require.NoError(t, err)
+
+	joined := strings.Join(capturedArgs, " ")
+	assert.NotContains(t, joined, "--profile")
+	assert.NotContains(t, joined, "--profile=alt")
+	assert.Contains(t, joined, "alt-ak")
+	assert.Contains(t, joined, "oss://bucket")
 }
 
 // Helper functions for creating mock contexts and profiles


### PR DESCRIPTION
## Summary

- Strip CLI-only config flags such as `--profile` / `-p` before forwarding args to the built-in OSS goopt parser.
- Resolve credentials from the selected profile first, so trailing `--profile` switches accounts without `Bad flag: --profile`.
- Keep shared OSS options (`--endpoint`, `--region`, credentials flags) unchanged for forward compatibility.