### PR TITLE
feat(openapi): extend --estimate-cost coverage (pricing context, SLS/openapi path, oss bridge, by-triple) and scripting contract

### DIFF
--- a/cliext/ossutil/main_test.go
+++ b/cliext/ossutil/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -106,5 +107,17 @@ func TestOssutilCommandRunInstalledSkipNetwork(t *testing.T) {
 	if !bytes.Contains([]byte(errStr), []byte("profile default is not configure yet")) &&
 		!bytes.Contains([]byte(errStr), []byte("can't get credential")) {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestOssutilRejectsEstimateCost(t *testing.T) {
+	ctx := &Context{}
+	err := ctx.Run([]string{"api", "PutBucket", "--estimate-cost"})
+	if err == nil || !strings.Contains(err.Error(), "aliyun oss <ApiName> --estimate-cost") {
+		t.Fatalf("expected estimate-cost rejection with hint, got %v", err)
+	}
+	err = ctx.Run([]string{"ls", "--estimate-cost-context", "K=V"})
+	if err == nil || !strings.Contains(err.Error(), "not supported under") {
+		t.Fatalf("expected estimate-cost-context rejection, got %v", err)
 	}
 }

--- a/cliext/ossutil/main_test.go
+++ b/cliext/ossutil/main_test.go
@@ -110,14 +110,37 @@ func TestOssutilCommandRunInstalledSkipNetwork(t *testing.T) {
 	}
 }
 
-func TestOssutilRejectsEstimateCost(t *testing.T) {
+func TestOssutilEstimateCostRouting(t *testing.T) {
+	// File/bucket commands meter transfer/storage, not API pricing: reject
+	// before any install/credential machinery (zero-value Context proves no
+	// environment is touched) and point at both supported forms.
 	ctx := &Context{}
-	err := ctx.Run([]string{"api", "PutBucket", "--estimate-cost"})
-	if err == nil || !strings.Contains(err.Error(), "aliyun oss <ApiName> --estimate-cost") {
-		t.Fatalf("expected estimate-cost rejection with hint, got %v", err)
+	err := ctx.Run([]string{"ls", "--estimate-cost"})
+	if err == nil || !strings.Contains(err.Error(), "aliyun ossutil api <operation> --estimate-cost") {
+		t.Fatalf("expected file-command rejection with hint, got %v", err)
 	}
-	err = ctx.Run([]string{"ls", "--estimate-cost-context", "K=V"})
-	if err == nil || !strings.Contains(err.Error(), "not supported under") {
+	err = ctx.Run([]string{"cp", "a", "oss://b", "--estimate-cost-context", "K=V"})
+	if err == nil || !strings.Contains(err.Error(), "only applies to OpenAPI calls") {
 		t.Fatalf("expected estimate-cost-context rejection, got %v", err)
+	}
+	// api subcommand without an operation name: parsed locally, still no
+	// environment access.
+	err = ctx.Run([]string{"api", "--estimate-cost"})
+	if err == nil || !strings.Contains(err.Error(), "requires an operation name") {
+		t.Fatalf("expected missing-operation error, got %v", err)
+	}
+}
+
+func TestOssutilKebabToPascal(t *testing.T) {
+	cases := map[string]string{
+		"put-bucket":    "PutBucket",
+		"storage-class": "StorageClass",
+		"PutBucket":     "PutBucket",
+		"acl":           "Acl",
+	}
+	for in, want := range cases {
+		if got := kebabToPascal(in); got != want {
+			t.Fatalf("kebabToPascal(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/cliext/ossutil/main_test.go
+++ b/cliext/ossutil/main_test.go
@@ -2,6 +2,8 @@ package ossutil
 
 import (
 	"bytes"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/openapi"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,5 +144,58 @@ func TestOssutilKebabToPascal(t *testing.T) {
 		if got := kebabToPascal(in); got != want {
 			t.Fatalf("kebabToPascal(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// newApiEstimateTestContext builds a Context whose originCtx carries a
+// hermetic profile (temp config via --config-path) so runApiEstimateCost can
+// route all the way into the shared quote pipeline without touching the host
+// machine's configuration.
+func newApiEstimateTestContext(t *testing.T) *Context {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{Name: "ossutil"}
+	config.AddFlags(cmd.Flags())
+	openapi.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"current":"t","profiles":[{"name":"t","mode":"AK","access_key_id":"ak","access_key_secret":"sk","region_id":"cn-hangzhou"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pathFlag := config.ConfigurePathFlag(ctx.Flags())
+	pathFlag.SetAssigned(true)
+	pathFlag.SetValue(configPath)
+	return &Context{originCtx: ctx}
+}
+
+func TestOssutilApiEstimateCostFullParseAndRoute(t *testing.T) {
+	// Exercises every branch of the raw-arg parser (operation, kebab flag with
+	// separate value, --name=value form, bare bool flag, --region fallback,
+	// --estimate-cost marker, --estimate-cost-context K=V) and proves the
+	// result reaches the quote pipeline: the dial error names the fake
+	// endpoint, so parsing + EstimateOssCost ran end to end without invoking
+	// anything real.
+	t.Setenv("ALIBABA_CLOUD_PRICING_ENDPOINT", "estimate-cost.test.invalid")
+	c := newApiEstimateTestContext(t)
+	err := c.runApiEstimateCost([]string{
+		"put-bucket",
+		"--storage-class", "Standard",
+		"--acl=private",
+		"--versioning",
+		"--region", "cn-hangzhou",
+		"--estimate-cost",
+		"--estimate-cost-context", "EstimatedStorageGB=100",
+	})
+	if err == nil || !strings.Contains(err.Error(), "estimate-cost.test.invalid") {
+		t.Fatalf("expected quote dial error against fake endpoint, got %v", err)
+	}
+}
+
+func TestOssutilApiEstimateCostInvalidContextPair(t *testing.T) {
+	c := newApiEstimateTestContext(t)
+	err := c.runApiEstimateCost([]string{"put-bucket", "--estimate-cost", "--estimate-cost-context", "not-a-pair"})
+	if err == nil || !strings.Contains(err.Error(), "Key=Value") {
+		t.Fatalf("expected Key=Value usage error, got %v", err)
 	}
 }

--- a/cliext/ossutil/ossutil2.go
+++ b/cliext/ossutil/ossutil2.go
@@ -90,6 +90,17 @@ func (c *Context) errorf(format string, a ...interface{}) {
 }
 
 func (c *Context) Run(args []string) error {
+	// `aliyun ossutil` hands args verbatim to the external ossutil binary, so
+	// the CLI-side --estimate-cost interception (wired on the `aliyun oss`
+	// bridge) can never see them — including `ossutil api <Operation>` raw
+	// OpenAPI calls. Fail fast with a pointer to the supported form instead of
+	// letting the external binary reject (or silently ignore) the flag.
+	for _, arg := range args {
+		if arg == "--estimate-cost" || strings.HasPrefix(arg, "--estimate-cost=") ||
+			arg == "--estimate-cost-context" || strings.HasPrefix(arg, "--estimate-cost-context=") {
+			return fmt.Errorf("--estimate-cost is not supported under `aliyun ossutil` (args are passed through to the external ossutil binary); use `aliyun oss <ApiName> --estimate-cost` instead, e.g. `aliyun oss PutBucket --estimate-cost`")
+		}
+	}
 	// init config path and some basic info
 	c.InitBasicInfo()
 	c.CheckOsTypeAndArch()

--- a/cliext/ossutil/ossutil2.go
+++ b/cliext/ossutil/ossutil2.go
@@ -92,14 +92,19 @@ func (c *Context) errorf(format string, a ...interface{}) {
 func (c *Context) Run(args []string) error {
 	// `aliyun ossutil` hands args verbatim to the external ossutil binary, so
 	// the CLI-side --estimate-cost interception (wired on the `aliyun oss`
-	// bridge) can never see them — including `ossutil api <Operation>` raw
-	// OpenAPI calls. Fail fast with a pointer to the supported form instead of
-	// letting the external binary reject (or silently ignore) the flag.
-	for _, arg := range args {
-		if arg == "--estimate-cost" || strings.HasPrefix(arg, "--estimate-cost=") ||
-			arg == "--estimate-cost-context" || strings.HasPrefix(arg, "--estimate-cost-context=") {
-			return fmt.Errorf("--estimate-cost is not supported under `aliyun ossutil` (args are passed through to the external ossutil binary); use `aliyun oss <ApiName> --estimate-cost` instead, e.g. `aliyun oss PutBucket --estimate-cost`")
+	// bridge) can never see them. `ossutil api <operation>` is a raw OpenAPI
+	// call though — same semantics the quote pipeline expects — so with
+	// --estimate-cost it is parsed here and routed to a quote (never executed).
+	// File/bucket management subcommands (cp/ls/mb…) meter data transfer and
+	// storage, not API pricing, so for them the flag fails fast with the
+	// supported alternatives. Both happen before the ossutil install/credential
+	// machinery below: a quote (or a usage error) must not trigger a binary
+	// download.
+	if hasEstimateCostFlag(args) {
+		if len(args) > 0 && args[0] == "api" {
+			return c.runApiEstimateCost(args[1:])
 		}
+		return fmt.Errorf("--estimate-cost only applies to OpenAPI calls; ossutil file commands (cp/ls/mb/...) meter data transfer and storage instead. Use `aliyun ossutil api <operation> --estimate-cost` or `aliyun oss <ApiName> --estimate-cost`")
 	}
 	// init config path and some basic info
 	c.InitBasicInfo()
@@ -696,4 +701,91 @@ func GetLatestOssUtilVersion() (string, error) {
 		return "", fmt.Errorf("failed to parse version from response body: %v", err)
 	}
 	return version, nil
+}
+
+// hasEstimateCostFlag reports whether the raw ossutil args carry
+// --estimate-cost / --estimate-cost-context (either flag form).
+func hasEstimateCostFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--estimate-cost" || strings.HasPrefix(arg, "--estimate-cost=") ||
+			arg == "--estimate-cost-context" || strings.HasPrefix(arg, "--estimate-cost-context=") {
+			return true
+		}
+	}
+	return false
+}
+
+// runApiEstimateCost quotes `aliyun ossutil api <operation> ... --estimate-cost`.
+// Args are raw (KeepArgs), so flags are parsed by hand: the first non-flag
+// token is the operation (ossutil kebab-case is normalized to the PascalCase
+// name the pricing registry uses), `--region` becomes the RegionId fallback,
+// `--estimate-cost-context K=V` pairs feed PricingContext, and every other
+// `--flag value` pair is forwarded as an OpenAPI parameter.
+func (c *Context) runApiEstimateCost(args []string) error {
+	operation := ""
+	parameters := make(map[string]interface{})
+	pricingContext := make(map[string]interface{})
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			if operation == "" {
+				operation = kebabToPascal(arg)
+			}
+			continue
+		}
+		name := strings.TrimPrefix(arg, "--")
+		value := ""
+		hasValue := false
+		if eq := strings.Index(name, "="); eq >= 0 {
+			name, value, hasValue = name[:eq], name[eq+1:], true
+		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
+			value, hasValue = args[i+1], true
+			i++
+		}
+		switch name {
+		case "estimate-cost":
+			// Bool marker; a greedily consumed trailing token is the operation.
+			if hasValue && value != "" && value != "true" && value != "false" {
+				if operation == "" {
+					operation = kebabToPascal(value)
+				}
+			}
+		case "estimate-cost-context":
+			if k, v, ok := strings.Cut(value, "="); ok && hasValue {
+				pricingContext[k] = v
+			} else {
+				return fmt.Errorf("invalid --estimate-cost-context `%s`, use Key=Value", value)
+			}
+		case "region":
+			if hasValue && value != "" {
+				parameters["RegionId"] = value
+			}
+		default:
+			if !hasValue || value == "" {
+				parameters[kebabToPascal(name)] = "true"
+			} else {
+				parameters[kebabToPascal(name)] = value
+			}
+		}
+	}
+	if operation == "" {
+		return fmt.Errorf("--estimate-cost on `aliyun ossutil api` requires an operation name, e.g. `aliyun ossutil api put-bucket --estimate-cost`")
+	}
+	return openapi.EstimateOssCost(c.originCtx, operation, parameters, pricingContext)
+}
+
+// kebabToPascal turns ossutil-style names into the PascalCase identifiers the
+// pricing registry uses: put-bucket -> PutBucket, storage-class ->
+// StorageClass. Already-Pascal input passes through unchanged.
+func kebabToPascal(s string) string {
+	parts := strings.Split(s, "-")
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		b.WriteString(part[1:])
+	}
+	return b.String()
 }

--- a/main/main.go
+++ b/main/main.go
@@ -128,7 +128,12 @@ func newRootCommand(profile config.Profile, stdout io.Writer) *cli.Command {
 	// list-supported-pricing-apis: enumerate every OpenAPI that supports --estimate-cost
 	rootCmd.AddSubCommand(openapi.NewListSupportedPricingApisCommand())
 	// oss old version, duplicate with ossutil, will remove in future
-	rootCmd.AddSubCommand(lib.NewOssCommand())
+	ossCmd := lib.NewOssCommand()
+	// `aliyun oss <ApiName> ... --estimate-cost` quotes via CloudControl; the
+	// bridge shadows the generic product routing, so wire the quote fallthrough
+	// here (file-operation subcommands are matched first and stay untouched).
+	commando.AttachOssEstimateCost(ossCmd)
+	rootCmd.AddSubCommand(ossCmd)
 	rootCmd.AddSubCommand(cli.NewVersionCommand())
 	rootCmd.AddSubCommand(cli.NewAutoCompleteCommand())
 	// mcp proxy command

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -423,6 +423,13 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				if style, ok := c.library.GetStyle(productName, version); ok {
 					product.ApiStyle = style
 				} else {
+					// A quote needs no style/method/path — only the triple.
+					// Explicit versions the local metadata doesn't know
+					// (Selectdb 2022-10-19, pai-dlc 2022-01-12, ...) can
+					// still be estimated; the server rejects unknown triples.
+					if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+						return c.processEstimateCostByTriple(ctx, &product, version, args[1])
+					}
 					return cli.NewErrorWithTip(fmt.Errorf("unchecked version %s", version),
 						"Please contact the customer support to get more info about API version")
 				}
@@ -438,8 +445,21 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			// For restful products, the 2-arg form `aliyun <product> <ApiName>` requires a valid ApiName so we can resolve the underlying Method + PathPattern from metadata.
 			// Otherwise we'd fall through with empty Method/PathPattern and surface the confusing "product 'xxx' need restful call" error from checkRestfulMethod.
 			force := ForceFlag(ctx.Flags()).IsAssigned()
-			if !found && !force {
-				return &InvalidApiError{Name: args[1], product: &product}
+			if !found {
+				// The api name may be absent only from the LOCAL metadata —
+				// a product with no api definitions at all (Tablestore) or
+				// an api of the non-default version. A quote doesn't need
+				// the metadata-resolved method/path, so estimate by triple
+				// instead of failing; typos come back as PricingNotSupported.
+				// Checked before --force: forcing cannot make the restful
+				// invoker resolve a method/path the metadata doesn't have,
+				// so the quote intent always wins here.
+				if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+					return c.processEstimateCostByTriple(ctx, &product, product.Version, args[1])
+				}
+				if !force {
+					return &InvalidApiError{Name: args[1], product: &product}
+				}
 			}
 			c.CheckApiParamWithBuildInArgs(ctx, api)
 			ctx.Command().Name = args[1]

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -494,15 +494,6 @@ func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api
 		return fmt.Errorf("invalid product, please check product code")
 	}
 
-	// --estimate-cost: the openapi-invoke path uses apiContext.Call instead
-	// of an Invoker, which estimate_cost.go's parameter extractor doesn't
-	// understand yet. Fail fast rather than silently invoke the target API.
-	if EstimateCostFlag(ctx.Flags()).IsAssigned() {
-		return cli.NewErrorWithTip(
-			fmt.Errorf("--estimate-cost is not supported for product %s which uses the openapi invoke path", product.Code),
-			"cost estimation supports RPC and ROA(restful) style products only")
-	}
-
 	apiContext, err := c.createHttpContext(ctx, product, api, method, path)
 	if err != nil {
 		return err
@@ -526,6 +517,20 @@ func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api
 			return fmt.Errorf("--cli-dry-run-json is only supported for OpenAPI invoke path")
 		}
 		return processCliDryRunOpenapiJson(ctx, oc)
+	}
+
+	// --estimate-cost: after Prepare the openapi request carries the fully
+	// assembled query/body/path parameters — route them to the quote service
+	// instead of invoking the target API (same interception contract as the
+	// Invoker path in processInvoke).
+	if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+		oc, ok := apiContext.(*OpenapiContext)
+		if !ok {
+			return cli.NewErrorWithTip(
+				fmt.Errorf("--estimate-cost is not supported for product %s on this invoke path", product.Code),
+				"cost estimation supports RPC, ROA(restful) and openapi-path products only")
+		}
+		return c.processEstimateCostOpenapi(ctx, oc)
 	}
 
 	err = hookHttpContextCall(apiContext.Call)()

--- a/openapi/estimate_cost.go
+++ b/openapi/estimate_cost.go
@@ -87,8 +87,8 @@ func (c *Commando) processEstimateCost(ctx *cli.Context, inv Invoker) error {
 	}
 	// Business failure inside a 200 response (price.success == false) must fail
 	// the process: scripts and agents gate on `$?`, and an exit code of 0 with a
-	// failed quote inside the JSON reads as a successful estimate (dogfood
-	// 2026-07-22: 7 branches returned success:false with exit code 0). The JSON
+	// failed quote inside the JSON reads as a successful estimate (observed in
+	// practice with several products' business failures). The JSON
 	// is already printed above, so automation can still read the full details.
 	return estimateCostBusinessError(out)
 }

--- a/openapi/estimate_cost.go
+++ b/openapi/estimate_cost.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 
 	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -131,6 +132,95 @@ func estimateCostBusinessError(out string) error {
 	}
 	return cli.NewErrorWithTip(fmt.Errorf("%s", msg),
 		"the quote response above has the full details; fix the reported parameter or retry later, the target API was NOT invoked")
+}
+
+// PascalCase OpenAPI action name, e.g. CreateTrainingJob. Product-command
+// tokens and file-operation subcommands are lowercase, so this cannot match
+// them by accident.
+var estimateCostApiNameRegexp = regexp.MustCompile(`^[A-Z][A-Za-z0-9]*$`)
+
+// processEstimateCostByTriple quotes an api the local metadata cannot
+// resolve — an api of a non-default product version (pai-dlc 2022-01-12,
+// Selectdb 2022-10-19), or a product with no api definitions at all
+// (Tablestore). A real invocation needs metadata to derive method/path and
+// a signer for the product's protocol, but a quote needs neither: only the
+// triple (popCode/popVersion/apiName) + parameters sent to CloudControl.
+// The trade-off is no local api-name validation — a typo comes back from
+// the server as PricingNotSupported instead of a local "invalid api" error.
+func (c *Commando) processEstimateCostByTriple(ctx *cli.Context, product *meta.Product, popVersion string, apiName string) error {
+	if !estimateCostApiNameRegexp.MatchString(apiName) {
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost requires an OpenAPI name, got `%s`", apiName),
+			"use `aliyun <product> <ApiName> ... --estimate-cost`, e.g. `aliyun pai-dlc CreateTrainingJob --version 2022-01-12 ... --estimate-cost`")
+	}
+	parameters, err := buildEstimateCostParametersFromFlags(ctx, &c.profile)
+	if err != nil {
+		return err
+	}
+	pricingContext, err := buildPricingContext(ctx)
+	if err != nil {
+		return err
+	}
+	if len(pricingContext) > 0 {
+		parameters["PricingContext"] = pricingContext
+	}
+	out, err := invokeEstimateCost(ctx, &c.profile, product.Code, popVersion, apiName, parameters)
+	if err != nil {
+		return err
+	}
+	if err := printEstimateCostResult(ctx, out); err != nil {
+		return err
+	}
+	return estimateCostBusinessError(out)
+}
+
+// buildEstimateCostParametersFromFlags collects pricing parameters without
+// an invoker: unknown flags are the api parameters (there is no metadata to
+// type them against), the `--body` JSON object merges on top, and RegionId
+// falls back to --region and then the profile region.
+func buildEstimateCostParametersFromFlags(ctx *cli.Context, profile *config.Profile) (map[string]interface{}, error) {
+	parameters := make(map[string]interface{})
+	if ctx.UnknownFlags() != nil {
+		for _, f := range ctx.UnknownFlags().Flags() {
+			if !f.IsAssigned() {
+				continue
+			}
+			if values := f.GetValues(); len(values) > 1 {
+				parameters[f.Name] = values
+				continue
+			}
+			if v, ok := f.GetValue(); ok && v != "" {
+				parameters[f.Name] = v
+			}
+		}
+	}
+	if v, ok := BodyFlag(ctx.Flags()).GetValue(); ok && v != "" {
+		if err := mergeEstimateCostJSONBody(parameters, []byte(v)); err != nil {
+			return nil, err
+		}
+	}
+	if v, ok := BodyFileFlag(ctx.Flags()).GetValue(); ok && v != "" {
+		buf, err := os.ReadFile(v)
+		if err != nil {
+			return nil, fmt.Errorf("--estimate-cost failed to read --body-file %s: %v", v, err)
+		}
+		if err := mergeEstimateCostJSONBody(parameters, buf); err != nil {
+			return nil, err
+		}
+	}
+	if _, ok := parameters["RegionId"]; !ok {
+		// --RegionId is a REGISTERED root flag (config.NewRegionIdFlag), so it
+		// never lands in the unknown flags — read it explicitly, then fall
+		// back to --region and the profile region.
+		if regionId, ok := config.RegionIdFlag(ctx.Flags()).GetValue(); ok && regionId != "" {
+			parameters["RegionId"] = regionId
+		} else if region, ok := config.RegionFlag(ctx.Flags()).GetValue(); ok && region != "" {
+			parameters["RegionId"] = region
+		} else if profile.RegionId != "" {
+			parameters["RegionId"] = profile.RegionId
+		}
+	}
+	return parameters, nil
 }
 
 // processEstimateCostOpenapi handles --estimate-cost for the openapi invoke

--- a/openapi/estimate_cost.go
+++ b/openapi/estimate_cost.go
@@ -81,7 +81,171 @@ func (c *Commando) processEstimateCost(ctx *cli.Context, inv Invoker) error {
 	if err != nil {
 		return err
 	}
-	return printEstimateCostResult(ctx, out)
+	if err := printEstimateCostResult(ctx, out); err != nil {
+		return err
+	}
+	// Business failure inside a 200 response (price.success == false) must fail
+	// the process: scripts and agents gate on `$?`, and an exit code of 0 with a
+	// failed quote inside the JSON reads as a successful estimate (dogfood
+	// 2026-07-22: 7 branches returned success:false with exit code 0). The JSON
+	// is already printed above, so automation can still read the full details.
+	return estimateCostBusinessError(out)
+}
+
+// estimateCostBusinessError inspects the raw quote response and returns a
+// non-nil error when the quote itself reports failure. A missing/unparseable
+// success field is treated as success — the exit-code contract only covers
+// explicit business failures, and transport/server errors are surfaced earlier
+// by invokeEstimateCost.
+func estimateCostBusinessError(out string) error {
+	type quote struct {
+		Success      *bool  `json:"success"`
+		ErrorCode    string `json:"errorCode"`
+		ErrorMessage string `json:"errorMessage"`
+		RequestId    string `json:"upstreamRequestId"`
+	}
+	var body struct {
+		// Gateway shape: {"price": {...}, "requestId": "..."}; tolerate the bare
+		// DTO shape (success at top level) in case the envelope changes.
+		Price *quote `json:"price"`
+		quote
+	}
+	if err := json.Unmarshal([]byte(out), &body); err != nil {
+		return nil
+	}
+	if body.Price == nil {
+		body.Price = &body.quote
+	}
+	if body.Price.Success == nil || *body.Price.Success {
+		return nil
+	}
+	msg := "cost estimation failed"
+	if body.Price.ErrorCode != "" {
+		msg += ": " + body.Price.ErrorCode
+	}
+	if body.Price.ErrorMessage != "" {
+		msg += ": " + body.Price.ErrorMessage
+	}
+	if body.Price.RequestId != "" {
+		msg += " (upstreamRequestId: " + body.Price.RequestId + ")"
+	}
+	return cli.NewErrorWithTip(fmt.Errorf("%s", msg),
+		"the quote response above has the full details; fix the reported parameter or retry later, the target API was NOT invoked")
+}
+
+// processEstimateCostOpenapi handles --estimate-cost for the openapi invoke
+// path (currently SLS only, see ShouldUseOpenapi; the path is meant to take
+// over more products later). Must be called after apiContext.Prepare(ctx) so
+// query/body/path parameters are fully assembled; the target API is never
+// invoked.
+func (c *Commando) processEstimateCostOpenapi(ctx *cli.Context, oc *OpenapiContext) error {
+	if oc.api == nil || oc.api.Name == "" {
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost cannot resolve the api name for this call"),
+			"cost estimation needs the api name, please use the `aliyun <product> <ApiName>` form")
+	}
+	popCode := ""
+	popVersion := ""
+	if oc.product != nil {
+		popCode = oc.product.Code
+		popVersion = oc.product.Version
+	}
+	if oc.api.Product != nil && oc.api.Product.Version != "" {
+		popVersion = oc.api.Product.Version
+	}
+
+	parameters, err := buildEstimateCostParametersFromOpenapi(ctx, oc)
+	if err != nil {
+		return err
+	}
+	pricingContext, err := buildPricingContext(ctx)
+	if err != nil {
+		return err
+	}
+	if len(pricingContext) > 0 {
+		parameters["PricingContext"] = pricingContext
+	}
+
+	out, err := invokeEstimateCost(ctx, &c.profile, popCode, popVersion, oc.api.Name, parameters)
+	if err != nil {
+		return err
+	}
+	if err := printEstimateCostResult(ctx, out); err != nil {
+		return err
+	}
+	return estimateCostBusinessError(out)
+}
+
+// buildEstimateCostParametersFromOpenapi flattens the prepared openapi-path
+// request into one parameter map: assembled query params, path/host parameter
+// raw values (Prepare substitutes them into the pathname, so they are
+// recovered from the typed flags via api metadata), and the JSON body.
+func buildEstimateCostParametersFromOpenapi(ctx *cli.Context, oc *OpenapiContext) (map[string]interface{}, error) {
+	parameters := make(map[string]interface{})
+	if oc.openapiRequest != nil {
+		for k, v := range oc.openapiRequest.Query {
+			if k != "" && v != nil && *v != "" {
+				parameters[k] = *v
+			}
+		}
+	}
+	if oc.api != nil && ctx.UnknownFlags() != nil {
+		for _, f := range ctx.UnknownFlags().Flags() {
+			param := oc.api.FindParameter(f.Name)
+			if param == nil || (param.Position != "Path" && param.Position != "Host") {
+				continue
+			}
+			if value, ok := f.GetValue(); ok && value != "" {
+				parameters[f.Name] = value
+			}
+		}
+	}
+	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
+		if err := mergeEstimateCostBody(parameters, oc.openapiRequest.Body); err != nil {
+			return nil, err
+		}
+	}
+	if regionId := oc.profile.RegionId; regionId != "" {
+		if _, ok := parameters["RegionId"]; !ok {
+			parameters["RegionId"] = regionId
+		}
+	}
+	return parameters, nil
+}
+
+// mergeEstimateCostBody merges the openapi-path request body into the pricing
+// parameter map. The body is either the already-parsed per-flag map or the
+// raw `--body` bytes/string, which must decode to a JSON object — same
+// contract as the RPC/ROA path in buildEstimateCostParameters.
+func mergeEstimateCostBody(parameters map[string]interface{}, rawBody interface{}) error {
+	switch body := rawBody.(type) {
+	case map[string]interface{}:
+		for k, v := range body {
+			parameters[k] = v
+		}
+		return nil
+	case []byte:
+		return mergeEstimateCostJSONBody(parameters, body)
+	case string:
+		return mergeEstimateCostJSONBody(parameters, []byte(body))
+	default:
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost cannot read the request body of type %T", rawBody),
+			"cost estimation merges the JSON body into pricing parameters, please pass `--body` as a JSON object")
+	}
+}
+
+func mergeEstimateCostJSONBody(parameters map[string]interface{}, raw []byte) error {
+	body := make(map[string]interface{})
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost requires the request body to be a JSON object: %v", err),
+			"cost estimation merges the JSON body into pricing parameters, please pass `--body` as a JSON object")
+	}
+	for k, v := range body {
+		parameters[k] = v
+	}
+	return nil
 }
 
 // resolveEstimateCostApiName returns the action name of the call being

--- a/openapi/estimate_cost_oss.go
+++ b/openapi/estimate_cost_oss.go
@@ -15,7 +15,6 @@ package openapi
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/config"
@@ -35,10 +34,6 @@ const (
 	ossPopCode           = "Oss"
 	ossDefaultPopVersion = "2019-05-17"
 )
-
-// PascalCase OpenAPI action name, e.g. CreateBucket. ossutil subcommands are
-// all lowercase short words, so this cannot collide with them.
-var ossApiNameRegexp = regexp.MustCompile(`^[A-Z][A-Za-z0-9]*$`)
 
 // AttachOssEstimateCost wires --estimate-cost support onto the built-in
 // `oss` bridge command. Estimate-cost/output flags are registered on the
@@ -73,7 +68,7 @@ func (c *Commando) processOssBridgeFallthrough(ctx *cli.Context, cmd *cli.Comman
 		cmd.PrintTail(ctx)
 		return nil
 	}
-	if len(args) == 0 || !ossApiNameRegexp.MatchString(args[0]) {
+	if len(args) == 0 || !estimateCostApiNameRegexp.MatchString(args[0]) {
 		got := "<none>"
 		if len(args) > 0 {
 			got = args[0]

--- a/openapi/estimate_cost_oss.go
+++ b/openapi/estimate_cost_oss.go
@@ -160,3 +160,33 @@ func buildOssEstimateCostParameters(ctx *cli.Context, profile *config.Profile) m
 	}
 	return parameters
 }
+
+// EstimateOssCost quotes an OSS OpenAPI call from pre-collected parameters.
+// It exists for callers whose argument list never goes through the flag
+// framework — the `aliyun ossutil` passthrough keeps args verbatim for the
+// external binary, so it parses them itself and hands the result here. The
+// quote is routed to CloudControl GetApiPrice; no OSS call is made.
+func EstimateOssCost(ctx *cli.Context, apiName string, parameters map[string]interface{}, pricingContext map[string]interface{}) error {
+	profile, err := config.LoadProfileWithContext(ctx)
+	if err != nil {
+		return cli.NewErrorWithTip(err,
+			"cost estimation needs a configured profile; run `aliyun configure` first")
+	}
+	if parameters == nil {
+		parameters = make(map[string]interface{})
+	}
+	if _, ok := parameters["RegionId"]; !ok && profile.RegionId != "" {
+		parameters["RegionId"] = profile.RegionId
+	}
+	if len(pricingContext) > 0 {
+		parameters["PricingContext"] = pricingContext
+	}
+	out, err := invokeEstimateCost(ctx, &profile, ossPopCode, ossDefaultPopVersion, apiName, parameters)
+	if err != nil {
+		return err
+	}
+	if err := printEstimateCostResult(ctx, out); err != nil {
+		return err
+	}
+	return estimateCostBusinessError(out)
+}

--- a/openapi/estimate_cost_oss.go
+++ b/openapi/estimate_cost_oss.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+)
+
+// OSS is not a POP product: its real API is S3-style RESTful with its own
+// signature, `aliyun oss` is a built-in ossutil bridge that shadows the
+// generic OpenAPI product routing, and the embedded metadata carries no OSS
+// api definitions. None of that blocks cost estimation though — a quote only
+// needs the api triple + parameters sent to CloudControl GetApiPrice, never
+// an actual OSS call. So the bridge command gets a fallthrough Run handler:
+// when the first arg is an OpenAPI-style PascalCase name and --estimate-cost
+// is assigned, the call is routed to the quote pipeline; everything else
+// keeps the legacy bridge behavior (subcommands like `mb`/`cp` are matched
+// by the framework before this handler and are never affected).
+const (
+	ossPopCode           = "Oss"
+	ossDefaultPopVersion = "2019-05-17"
+)
+
+// PascalCase OpenAPI action name, e.g. CreateBucket. ossutil subcommands are
+// all lowercase short words, so this cannot collide with them.
+var ossApiNameRegexp = regexp.MustCompile(`^[A-Z][A-Za-z0-9]*$`)
+
+// AttachOssEstimateCost wires --estimate-cost support onto the built-in
+// `oss` bridge command. Estimate-cost/output flags are registered on the
+// command's own flag set (they are not persistent on root, so they would not
+// be inherited), and unknown flags are enabled so OpenAPI parameters like
+// --StorageClass can be collected without being declared in metadata.
+func (c *Commando) AttachOssEstimateCost(cmd *cli.Command) {
+	cmd.EnableUnknownFlag = true
+	fs := cmd.Flags()
+	fs.Add(NewEstimateCostFlag())
+	fs.Add(NewEstimateCostContextFlag())
+	fs.Add(NewQuietFlag())
+	fs.Add(NewQueryFlag())
+	fs.Add(NewOutputFlag())
+	cmd.Run = func(ctx *cli.Context, args []string) error {
+		return c.processOssBridgeFallthrough(ctx, cmd, args)
+	}
+}
+
+// processOssBridgeFallthrough runs when no ossutil subcommand matched.
+// Without --estimate-cost it reproduces the legacy behavior exactly:
+// unknown token -> invalid command error, nothing -> command help.
+func (c *Commando) processOssBridgeFallthrough(ctx *cli.Context, cmd *cli.Command, args []string) error {
+	if !EstimateCostFlag(ctx.Flags()).IsAssigned() {
+		if len(args) > 0 {
+			return cli.NewInvalidCommandError(args[0], ctx)
+		}
+		cmd.PrintHead(ctx)
+		cmd.PrintUsage(ctx)
+		cmd.PrintSubCommands(ctx)
+		cmd.PrintFlags(ctx)
+		cmd.PrintTail(ctx)
+		return nil
+	}
+	if len(args) == 0 || !ossApiNameRegexp.MatchString(args[0]) {
+		got := "<none>"
+		if len(args) > 0 {
+			got = args[0]
+		}
+		return cli.NewErrorWithTip(
+			fmt.Errorf("--estimate-cost on `aliyun oss` requires an OpenAPI name, got `%s`", got),
+			"use `aliyun oss <ApiName> --Param value ... --estimate-cost`, e.g. `aliyun oss CreateBucket --StorageClass Standard --estimate-cost`; ossutil file commands (mb/cp/...) do not support cost estimation")
+	}
+	return c.processOssEstimateCost(ctx, args[0])
+}
+
+func (c *Commando) processOssEstimateCost(ctx *cli.Context, apiName string) error {
+	// Honor --profile etc. typed after `oss` — profile/mode are persistent
+	// root flags, so they were parsed into this context by the framework.
+	profile, err := config.LoadProfileWithContext(ctx)
+	if err != nil {
+		return cli.NewErrorWithTip(err,
+			"cost estimation needs a configured profile; run `aliyun configure` first")
+	}
+
+	parameters := buildOssEstimateCostParameters(ctx, &profile)
+
+	pricingContext, err := buildPricingContext(ctx)
+	if err != nil {
+		return err
+	}
+	if len(pricingContext) > 0 {
+		parameters["PricingContext"] = pricingContext
+	}
+
+	// The pricing registry keys the triple on the metadata product identity
+	// (`Oss` + default version). The embedded metadata has the product entry
+	// even though it has no per-api definitions; fall back to constants in
+	// case a stripped metadata build drops the entry.
+	popCode := ossPopCode
+	popVersion := ossDefaultPopVersion
+	if product, found := c.library.GetProduct("oss"); found {
+		if product.Code != "" {
+			popCode = product.Code
+		}
+		if product.Version != "" {
+			popVersion = product.Version
+		}
+	}
+
+	out, err := invokeEstimateCost(ctx, &profile, popCode, popVersion, apiName, parameters)
+	if err != nil {
+		return err
+	}
+	if err := printEstimateCostResult(ctx, out); err != nil {
+		return err
+	}
+	return estimateCostBusinessError(out)
+}
+
+// buildOssEstimateCostParameters collects OpenAPI parameters from the
+// unknown flags (there is no OSS api metadata to type them against).
+// `--region` is the bridge's native region selector, so it doubles as the
+// RegionId fallback instead of being forwarded as a bogus parameter.
+func buildOssEstimateCostParameters(ctx *cli.Context, profile *config.Profile) map[string]interface{} {
+	parameters := make(map[string]interface{})
+	regionOverride := ""
+	if ctx.UnknownFlags() != nil {
+		for _, f := range ctx.UnknownFlags().Flags() {
+			if !f.IsAssigned() {
+				continue
+			}
+			if f.Name == "region" {
+				if v, ok := f.GetValue(); ok {
+					regionOverride = v
+				}
+				continue
+			}
+			if values := f.GetValues(); len(values) > 1 {
+				parameters[f.Name] = values
+				continue
+			}
+			if v, ok := f.GetValue(); ok && v != "" {
+				parameters[f.Name] = v
+			}
+		}
+	}
+	if _, ok := parameters["RegionId"]; !ok {
+		if regionOverride != "" {
+			parameters["RegionId"] = regionOverride
+		} else if profile.RegionId != "" {
+			parameters["RegionId"] = profile.RegionId
+		}
+	}
+	return parameters
+}

--- a/openapi/estimate_cost_oss_test.go
+++ b/openapi/estimate_cost_oss_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openapi
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+func newOssBridgeTestContext(t *testing.T) (*cli.Context, *cli.Command, *Commando, *bytes.Buffer) {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{Name: "oss", Short: i18n.T("Object Storage Service", "阿里云OSS对象存储")}
+	config.AddFlags(cmd.Flags())
+
+	profile := config.NewProfile("test-oss-estimate")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+	command := NewCommando(w, profile)
+	command.AttachOssEstimateCost(cmd)
+	ctx.EnterCommand(cmd)
+	return ctx, cmd, command, w
+}
+
+// writeOssTestConfig points the config-path flag at a temp config file so
+// LoadProfileWithContext resolves credentials without touching the real
+// ~/.aliyun/config.json (which may not exist in CI).
+func writeOssTestConfig(t *testing.T, ctx *cli.Context) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	content := `{"current":"default","profiles":[{"name":"default","mode":"AK","access_key_id":"test-ak","access_key_secret":"test-secret","region_id":"cn-hangzhou"}]}`
+	assert.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	f := config.ConfigurePathFlag(ctx.Flags())
+	f.SetAssigned(true)
+	f.SetValue(path)
+}
+
+func TestOssApiNameRegexp(t *testing.T) {
+	assert.True(t, ossApiNameRegexp.MatchString("CreateBucket"))
+	assert.True(t, ossApiNameRegexp.MatchString("PutBucketLifecycle"))
+	// ossutil subcommands and misc tokens must never look like OpenAPI names.
+	assert.False(t, ossApiNameRegexp.MatchString("mb"))
+	assert.False(t, ossApiNameRegexp.MatchString("cp"))
+	assert.False(t, ossApiNameRegexp.MatchString("oss://bucket"))
+	assert.False(t, ossApiNameRegexp.MatchString("--estimate-cost"))
+	assert.False(t, ossApiNameRegexp.MatchString(""))
+}
+
+func TestOssBridgeLegacyBehaviorPreserved(t *testing.T) {
+	ctx, cmd, command, w := newOssBridgeTestContext(t)
+
+	// Unknown token without --estimate-cost -> invalid command, same as the
+	// framework error when Run was nil.
+	err := command.processOssBridgeFallthrough(ctx, cmd, []string{"CreateBucket"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "CreateBucket")
+
+	// Bare `aliyun oss` -> help text, not an error.
+	w.Reset()
+	err = command.processOssBridgeFallthrough(ctx, cmd, nil)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, w.String())
+}
+
+func TestOssBridgeEstimateCostRejectsNonApiNames(t *testing.T) {
+	ctx, cmd, command, _ := newOssBridgeTestContext(t)
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+
+	for _, args := range [][]string{{}, {"mb"}, {"oss://bucket"}} {
+		err := command.processOssBridgeFallthrough(ctx, cmd, args)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "requires an OpenAPI name")
+	}
+}
+
+func TestBuildOssEstimateCostParameters(t *testing.T) {
+	ctx, _, _, _ := newOssBridgeTestContext(t)
+	profile := config.NewProfile("p")
+	profile.RegionId = "cn-shanghai"
+
+	unknown := cli.NewFlagSet()
+	f1, _ := unknown.AddByName("StorageClass")
+	f1.SetAssigned(true)
+	f1.SetValue("Standard")
+	f2, _ := unknown.AddByName("region")
+	f2.SetAssigned(true)
+	f2.SetValue("cn-beijing")
+	multi, _ := unknown.AddByName("Tag")
+	multi.SetAssigned(true)
+	multi.SetValues([]string{"a", "b"})
+	ctx.SetUnknownFlags(unknown)
+
+	parameters := buildOssEstimateCostParameters(ctx, &profile)
+	assert.Equal(t, "Standard", parameters["StorageClass"])
+	// --region is the bridge's region selector: consumed as RegionId fallback,
+	// never forwarded as a literal `region` parameter.
+	assert.Equal(t, "cn-beijing", parameters["RegionId"])
+	assert.NotContains(t, parameters, "region")
+	assert.Equal(t, []string{"a", "b"}, parameters["Tag"])
+
+	// Without --region and --RegionId the profile region fills in.
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+	parameters = buildOssEstimateCostParameters(ctx, &profile)
+	assert.Equal(t, "cn-shanghai", parameters["RegionId"])
+
+	// Explicit --RegionId wins over both.
+	unknown2 := cli.NewFlagSet()
+	f3, _ := unknown2.AddByName("RegionId")
+	f3.SetAssigned(true)
+	f3.SetValue("cn-hongkong")
+	ctx.SetUnknownFlags(unknown2)
+	parameters = buildOssEstimateCostParameters(ctx, &profile)
+	assert.Equal(t, "cn-hongkong", parameters["RegionId"])
+}
+
+func TestOssBridgeEstimateCostFlow(t *testing.T) {
+	// Same sentinel-endpoint contract as the RPC and openapi-path tests: the
+	// flow must reach the estimate-cost client (DNS failure on the sentinel
+	// host proves interception) without touching ossutil or any OSS endpoint.
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+
+	ctx, cmd, command, _ := newOssBridgeTestContext(t)
+	writeOssTestConfig(t, ctx)
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+
+	unknown := cli.NewFlagSet()
+	f, _ := unknown.AddByName("StorageClass")
+	f.SetAssigned(true)
+	f.SetValue("Standard")
+	ctx.SetUnknownFlags(unknown)
+
+	err := command.processOssBridgeFallthrough(ctx, cmd, []string{"CreateBucket"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+}

--- a/openapi/estimate_cost_oss_test.go
+++ b/openapi/estimate_cost_oss_test.go
@@ -152,3 +152,40 @@ func TestOssBridgeEstimateCostFlow(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
 }
+
+func TestEstimateOssCostHermetic(t *testing.T) {
+	// Direct entry-point coverage (the ossutil passthrough calls this from
+	// another package): profile from a temp config, quote routed at a fake
+	// endpoint — the dial error proves parameters/pricing-context handling ran.
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{Name: "ossutil"}
+	AddFlags(cmd.Flags())
+	config.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	assert.NoError(t, os.WriteFile(configPath, []byte(`{"current":"t","profiles":[{"name":"t","mode":"AK","access_key_id":"ak","access_key_secret":"sk","region_id":"cn-hangzhou"}]}`), 0o600))
+	pathFlag := config.ConfigurePathFlag(ctx.Flags())
+	pathFlag.SetAssigned(true)
+	pathFlag.SetValue(configPath)
+
+	err := EstimateOssCost(ctx, "PutBucket",
+		map[string]interface{}{"StorageClass": "Standard"},
+		map[string]interface{}{"EstimatedStorageGB": 100})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+
+	// Nil parameters must not panic; profile region backfills RegionId.
+	err = EstimateOssCost(ctx, "PutBucket", nil, nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+
+	// Unconfigured profile fails with the actionable configure tip.
+	badPath := filepath.Join(t.TempDir(), "empty.json")
+	assert.NoError(t, os.WriteFile(badPath, []byte(`{"current":"t","profiles":[{"name":"t"}]}`), 0o600))
+	pathFlag.SetValue(badPath)
+	err = EstimateOssCost(ctx, "PutBucket", nil, nil)
+	assert.NotNil(t, err)
+}

--- a/openapi/estimate_cost_oss_test.go
+++ b/openapi/estimate_cost_oss_test.go
@@ -55,14 +55,14 @@ func writeOssTestConfig(t *testing.T, ctx *cli.Context) {
 }
 
 func TestOssApiNameRegexp(t *testing.T) {
-	assert.True(t, ossApiNameRegexp.MatchString("CreateBucket"))
-	assert.True(t, ossApiNameRegexp.MatchString("PutBucketLifecycle"))
+	assert.True(t, estimateCostApiNameRegexp.MatchString("CreateBucket"))
+	assert.True(t, estimateCostApiNameRegexp.MatchString("PutBucketLifecycle"))
 	// ossutil subcommands and misc tokens must never look like OpenAPI names.
-	assert.False(t, ossApiNameRegexp.MatchString("mb"))
-	assert.False(t, ossApiNameRegexp.MatchString("cp"))
-	assert.False(t, ossApiNameRegexp.MatchString("oss://bucket"))
-	assert.False(t, ossApiNameRegexp.MatchString("--estimate-cost"))
-	assert.False(t, ossApiNameRegexp.MatchString(""))
+	assert.False(t, estimateCostApiNameRegexp.MatchString("mb"))
+	assert.False(t, estimateCostApiNameRegexp.MatchString("cp"))
+	assert.False(t, estimateCostApiNameRegexp.MatchString("oss://bucket"))
+	assert.False(t, estimateCostApiNameRegexp.MatchString("--estimate-cost"))
+	assert.False(t, estimateCostApiNameRegexp.MatchString(""))
 }
 
 func TestOssBridgeLegacyBehaviorPreserved(t *testing.T) {

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"testing"
 
+	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
 	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -408,4 +409,197 @@ func TestProcessInvokeEstimateCostContextMalformed(t *testing.T) {
 	err := command.processInvoke(ctx, "ecs", "DescribeRegions", "")
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "novalue")
+}
+
+func TestEstimateCostBusinessErrorFailure(t *testing.T) {
+	// price.success == false must fail the process even though the HTTP call
+	// succeeded (dogfood 2026-07-22: business failures exited 0 and scripts
+	// gating on $? mistook them for successful estimates).
+	out := `{"price":{"success":false,"errorCode":"InvalidParameter","errorMessage":"COMMODITY.INVALID_COMPONENT","upstreamRequestId":"req-1"},"requestId":"r"}`
+	err := estimateCostBusinessError(out)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "InvalidParameter")
+	assert.Contains(t, err.Error(), "COMMODITY.INVALID_COMPONENT")
+	assert.Contains(t, err.Error(), "req-1")
+}
+
+func TestEstimateCostBusinessErrorSuccessAndTolerantShapes(t *testing.T) {
+	// success:true, missing price node, bare-DTO shape and non-JSON output must
+	// all keep exit code 0 — only explicit business failure is an error.
+	assert.Nil(t, estimateCostBusinessError(`{"price":{"success":true},"requestId":"r"}`))
+	assert.Nil(t, estimateCostBusinessError(`{"requestId":"r"}`))
+	assert.Nil(t, estimateCostBusinessError(`not json`))
+	// bare DTO without the gateway "price" envelope
+	assert.NotNil(t, estimateCostBusinessError(`{"success":false,"errorCode":"E"}`))
+	assert.Nil(t, estimateCostBusinessError(`{"success":true}`))
+}
+
+func TestEstimateCostBusinessErrorWithoutDetails(t *testing.T) {
+	err := estimateCostBusinessError(`{"price":{"success":false}}`)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "cost estimation failed")
+}
+
+func newOpenapiEstimateCostContext(api *meta.Api) *OpenapiContext {
+	return &OpenapiContext{
+		HttpContext: &HttpContext{
+			profile: &config.Profile{RegionId: "cn-hangzhou"},
+			product: &meta.Product{Code: "Sls", Version: "2020-12-30"},
+			openapiRequest: &openapiutil.OpenApiRequest{
+				Query:   map[string]*string{},
+				Headers: map[string]*string{},
+				HostMap: map[string]*string{},
+			},
+		},
+		method: "POST",
+		path:   "/logstores",
+		api:    api,
+	}
+}
+
+func TestBuildEstimateCostParametersFromOpenapi(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	api := &meta.Api{
+		Name:    "CreateLogStore",
+		Product: &meta.Product{Version: "2020-12-30"},
+		Parameters: []meta.Parameter{
+			{Name: "project", Position: "Host"},
+			{Name: "logstoreName", Position: "Path"},
+		},
+	}
+
+	// Path/Host params are recovered from typed flags via api metadata;
+	// query comes from the prepared request; JSON body merges on top.
+	unknown := cli.NewFlagSet()
+	f, _ := unknown.AddByName("project")
+	f.SetAssigned(true)
+	f.SetValue("my-project")
+	f2, _ := unknown.AddByName("logstoreName")
+	f2.SetAssigned(true)
+	f2.SetValue("my-store")
+	ctx.SetUnknownFlags(unknown)
+
+	oc := newOpenapiEstimateCostContext(api)
+	shardCount := "2"
+	oc.openapiRequest.Query["shardCount"] = &shardCount
+	oc.openapiRequest.SetBody([]byte(`{"ttl":30,"hot_ttl":7}`))
+
+	parameters, err := buildEstimateCostParametersFromOpenapi(ctx, oc)
+	assert.NoError(t, err)
+	assert.Equal(t, "2", parameters["shardCount"])
+	assert.Equal(t, "my-project", parameters["project"])
+	assert.Equal(t, "my-store", parameters["logstoreName"])
+	assert.Equal(t, float64(30), parameters["ttl"])
+	assert.Equal(t, float64(7), parameters["hot_ttl"])
+	// RegionId defaulted from the profile so mapping expressions can rely on it.
+	assert.Equal(t, "cn-hangzhou", parameters["RegionId"])
+}
+
+func TestBuildEstimateCostParametersFromOpenapiBodyVariants(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	api := &meta.Api{Name: "CreateLogStore", Product: &meta.Product{Version: "2020-12-30"}}
+
+	// Per-flag body params arrive as an already-parsed map.
+	oc := newOpenapiEstimateCostContext(api)
+	oc.openapiRequest.Body = map[string]interface{}{"ttl": 30}
+	parameters, err := buildEstimateCostParametersFromOpenapi(ctx, oc)
+	assert.NoError(t, err)
+	assert.Equal(t, 30, parameters["ttl"])
+
+	// Raw --body string form.
+	oc = newOpenapiEstimateCostContext(api)
+	oc.openapiRequest.Body = `{"ttl":15}`
+	parameters, err = buildEstimateCostParametersFromOpenapi(ctx, oc)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(15), parameters["ttl"])
+
+	// Non-object body must be rejected, mirroring the RPC/ROA path contract.
+	oc = newOpenapiEstimateCostContext(api)
+	oc.openapiRequest.SetBody([]byte(`[1,2,3]`))
+	_, err = buildEstimateCostParametersFromOpenapi(ctx, oc)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON object")
+
+	// Binary (non-JSON-decodable) bodies are rejected too.
+	oc = newOpenapiEstimateCostContext(api)
+	oc.openapiRequest.SetBody([]byte{0x28, 0xb5, 0x2f, 0xfd})
+	_, err = buildEstimateCostParametersFromOpenapi(ctx, oc)
+	assert.Error(t, err)
+}
+
+func TestProcessApiInvokeEstimateCost(t *testing.T) {
+	// Same contract as TestProcessInvokeEstimateCostFlag but for the openapi
+	// invoke path (SLS): the flow must reach the estimate-cost client (DNS
+	// failure on the sentinel host proves interception) and the target API
+	// hook must never fire.
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	profile := config.Profile{
+		Language:        "en",
+		Mode:            "AK",
+		AccessKeyId:     "accesskeyid",
+		AccessKeySecret: "accesskeysecret",
+		RegionId:        "cn-hangzhou",
+	}
+	command := NewCommando(w, profile)
+
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+	defer EstimateCostFlag(ctx.Flags()).SetAssigned(false)
+
+	originCallHook := hookHttpContextCall
+	defer func() { hookHttpContextCall = originCallHook }()
+	targetInvoked := false
+	hookHttpContextCall = func(fn func() error) func() error {
+		return func() error {
+			targetInvoked = true
+			return nil
+		}
+	}
+
+	product := &meta.Product{Code: "sls"}
+	api := &meta.Api{
+		Name:    "CreateLogStore",
+		Product: &meta.Product{Version: "2020-12-30"},
+	}
+	err := command.processApiInvoke(ctx, product, api, "POST", "/logstores")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+	assert.False(t, targetInvoked, "--estimate-cost must not invoke the target API")
+}
+
+func TestProcessEstimateCostOpenapiNoApiName(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{}
+	cmd.EnableUnknownFlag = true
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	command := NewCommando(w, config.Profile{Mode: "AK", AccessKeyId: "ak", AccessKeySecret: "sk", RegionId: "cn-hangzhou"})
+	oc := newOpenapiEstimateCostContext(&meta.Api{})
+	err := command.processEstimateCostOpenapi(ctx, oc)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot resolve the api name")
 }

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -729,3 +729,129 @@ func TestMainEstimateCostUnknownApiRoutesToTriple(t *testing.T) {
 	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
 	assert.NotContains(t, err.Error(), "not a valid api")
 }
+
+func TestBuildEstimateCostParametersFromFlagsBodyAndRegionFallbacks(t *testing.T) {
+	newCtx := func() *cli.Context {
+		w := new(bytes.Buffer)
+		ctx := cli.NewCommandContext(w, w)
+		cmd := &cli.Command{EnableUnknownFlag: true}
+		AddFlags(cmd.Flags())
+		config.AddFlags(cmd.Flags())
+		ctx.EnterCommand(cmd)
+		ctx.SetUnknownFlags(cli.NewFlagSet())
+		return ctx
+	}
+	p := config.NewProfile("p")
+	p.RegionId = "cn-shanghai"
+	profile := &p
+
+	// --body JSON object merges on top of unknown-flag parameters.
+	ctx := newCtx()
+	bodyFlag := BodyFlag(ctx.Flags())
+	bodyFlag.SetAssigned(true)
+	bodyFlag.SetValue(`{"Period":2}`)
+	params, err := buildEstimateCostParametersFromFlags(ctx, profile)
+	assert.Nil(t, err)
+	assert.Equal(t, float64(2), params["Period"])
+	assert.Equal(t, "cn-shanghai", params["RegionId"], "profile region is the last fallback")
+
+	// --body that is not a JSON object fails with the actionable error.
+	ctx = newCtx()
+	bodyFlag = BodyFlag(ctx.Flags())
+	bodyFlag.SetAssigned(true)
+	bodyFlag.SetValue(`[1,2]`)
+	_, err = buildEstimateCostParametersFromFlags(ctx, profile)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "JSON object")
+
+	// --body-file: valid file merges, missing file errors with the path.
+	ctx = newCtx()
+	bodyPath := filepath.Join(t.TempDir(), "body.json")
+	assert.NoError(t, os.WriteFile(bodyPath, []byte(`{"AutoRenew":true}`), 0o600))
+	fileFlag := BodyFileFlag(ctx.Flags())
+	fileFlag.SetAssigned(true)
+	fileFlag.SetValue(bodyPath)
+	params, err = buildEstimateCostParametersFromFlags(ctx, profile)
+	assert.Nil(t, err)
+	assert.Equal(t, true, params["AutoRenew"])
+
+	ctx = newCtx()
+	fileFlag = BodyFileFlag(ctx.Flags())
+	fileFlag.SetAssigned(true)
+	fileFlag.SetValue(filepath.Join(t.TempDir(), "no-such.json"))
+	_, err = buildEstimateCostParametersFromFlags(ctx, profile)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--body-file")
+
+	// --RegionId (registered root flag) wins over --region and the profile.
+	ctx = newCtx()
+	regionIdFlag := config.RegionIdFlag(ctx.Flags())
+	regionIdFlag.SetAssigned(true)
+	regionIdFlag.SetValue("cn-beijing")
+	params, err = buildEstimateCostParametersFromFlags(ctx, profile)
+	assert.Nil(t, err)
+	assert.Equal(t, "cn-beijing", params["RegionId"])
+
+	ctx = newCtx()
+	regionFlag := config.RegionFlag(ctx.Flags())
+	regionFlag.SetAssigned(true)
+	regionFlag.SetValue("cn-shenzhen")
+	params, err = buildEstimateCostParametersFromFlags(ctx, profile)
+	assert.Nil(t, err)
+	assert.Equal(t, "cn-shenzhen", params["RegionId"])
+}
+
+func TestMergeEstimateCostBodyForms(t *testing.T) {
+	// Already-parsed map form.
+	params := map[string]interface{}{}
+	assert.Nil(t, mergeEstimateCostBody(params, map[string]interface{}{"K": "v"}))
+	assert.Equal(t, "v", params["K"])
+
+	// Raw []byte and string forms decode as JSON objects.
+	assert.Nil(t, mergeEstimateCostBody(params, []byte(`{"A":1}`)))
+	assert.Equal(t, float64(1), params["A"])
+	assert.Nil(t, mergeEstimateCostBody(params, `{"B":2}`))
+	assert.Equal(t, float64(2), params["B"])
+
+	// Anything else is rejected with the actionable tip.
+	err := mergeEstimateCostBody(params, 42)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "cannot read the request body")
+}
+
+func TestEstimateCostBusinessErrorShapes(t *testing.T) {
+	// Bare DTO shape (success at top level, no "price" envelope) must still
+	// fail the process — tolerance for a future envelope change.
+	err := estimateCostBusinessError(`{"success":false,"errorCode":"X","errorMessage":"m","upstreamRequestId":"r"}`)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "X")
+	assert.Contains(t, err.Error(), "upstreamRequestId: r")
+
+	// Unparseable / non-JSON output is not the exit-code contract's business:
+	// transport and server errors surface earlier, so this returns nil.
+	assert.Nil(t, estimateCostBusinessError("not-json"))
+	// Missing success field means success.
+	assert.Nil(t, estimateCostBusinessError(`{"price":{}}`))
+}
+
+func TestFilterSupportedPricingApisEdgeShapes(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := NewListSupportedPricingApisCommand()
+	ctx.EnterCommand(cmd)
+	productFlag := ctx.Flags().Get(PricingProductFlagName)
+	productFlag.SetAssigned(true)
+	productFlag.SetValue("Ecs")
+
+	// Non-string popCode is skipped via the stringField guard, not a panic.
+	out, err := filterSupportedPricingApis(ctx, `{"supportedApis":[{"popCode":123},{"popCode":"Ecs","popVersion":"2014-05-26"}],"requestId":"r"}`)
+	assert.Nil(t, err)
+	assert.Contains(t, out, "2014-05-26")
+	assert.NotContains(t, out, "123")
+
+	// Unexpected response shape fails with a clear error instead of emitting
+	// a silently unfiltered list.
+	_, err = filterSupportedPricingApis(ctx, "not-json")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unexpected response shape")
+}

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -15,6 +15,8 @@ package openapi
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
@@ -707,6 +709,17 @@ func TestMainEstimateCostUnknownApiRoutesToTriple(t *testing.T) {
 	profile.AccessKeySecret = "test-secret"
 	profile.RegionId = "cn-hangzhou"
 	command := NewCommando(w, profile)
+
+	// main() discards the injected profile and reloads one via
+	// LoadProfileWithContext, which reads the HOST config file by default —
+	// absent on CI runners ("region can't be empty" before the code under
+	// test runs). Point --config-path at a self-contained temp config so the
+	// test is hermetic on any machine.
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	assert.NoError(t, os.WriteFile(configPath, []byte(`{"current":"test-triple-main","profiles":[{"name":"test-triple-main","mode":"AK","access_key_id":"test-ak","access_key_secret":"test-secret","region_id":"cn-hangzhou"}]}`), 0o600))
+	configPathFlag := config.ConfigurePathFlag(ctx.Flags())
+	configPathFlag.SetAssigned(true)
+	configPathFlag.SetValue(configPath)
 
 	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
 	defer EstimateCostFlag(ctx.Flags()).SetAssigned(false)

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -603,3 +603,116 @@ func TestProcessEstimateCostOpenapiNoApiName(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot resolve the api name")
 }
+
+func TestBuildEstimateCostParametersFromFlags(t *testing.T) {
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{EnableUnknownFlag: true}
+	AddFlags(cmd.Flags())
+	config.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+
+	unknown := cli.NewFlagSet()
+	f1, _ := unknown.AddByName("WorkspaceId")
+	f1.SetAssigned(true)
+	f1.SetValue("ws-123")
+	ctx.SetUnknownFlags(unknown)
+
+	BodyFlag(ctx.Flags()).SetAssigned(true)
+	BodyFlag(ctx.Flags()).SetValue(`{"TrainingSpec":{"Instances":1},"Priority":2}`)
+
+	profile := config.NewProfile("p")
+	profile.RegionId = "cn-hangzhou"
+
+	parameters, err := buildEstimateCostParametersFromFlags(ctx, &profile)
+	assert.NoError(t, err)
+	assert.Equal(t, "ws-123", parameters["WorkspaceId"])
+	assert.Equal(t, float64(2), parameters["Priority"])
+	assert.NotNil(t, parameters["TrainingSpec"])
+	assert.Equal(t, "cn-hangzhou", parameters["RegionId"])
+
+	// --region beats the profile region as RegionId fallback.
+	rf := config.RegionFlag(ctx.Flags())
+	rf.SetAssigned(true)
+	rf.SetValue("cn-beijing")
+	parameters, err = buildEstimateCostParametersFromFlags(ctx, &profile)
+	assert.NoError(t, err)
+	assert.Equal(t, "cn-beijing", parameters["RegionId"])
+
+	// --RegionId is a registered root flag (never an unknown flag) and must
+	// win over --region and the profile region.
+	rif := config.RegionIdFlag(ctx.Flags())
+	rif.SetAssigned(true)
+	rif.SetValue("cn-shenzhen")
+	parameters, err = buildEstimateCostParametersFromFlags(ctx, &profile)
+	assert.NoError(t, err)
+	assert.Equal(t, "cn-shenzhen", parameters["RegionId"])
+
+	// Non-object --body is rejected with the shared JSON-object contract.
+	BodyFlag(ctx.Flags()).SetValue(`[1,2]`)
+	_, err = buildEstimateCostParametersFromFlags(ctx, &profile)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON object")
+}
+
+func TestProcessEstimateCostByTriple(t *testing.T) {
+	// Sentinel-endpoint contract: reaching the quote client (DNS failure on
+	// the sentinel host) proves the metadata-less path routes to pricing and
+	// never tries to resolve/invoke the target api.
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{EnableUnknownFlag: true}
+	AddFlags(cmd.Flags())
+	config.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	profile := config.NewProfile("test-triple")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+	command := NewCommando(w, profile)
+
+	product := &meta.Product{Code: "pai-dlc", Version: "2020-12-03"}
+	err := command.processEstimateCostByTriple(ctx, product, "2022-01-12", "CreateTrainingJob")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+
+	// Non-PascalCase api names are rejected locally with a usage tip.
+	err = command.processEstimateCostByTriple(ctx, product, "2022-01-12", "not-an-api")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "requires an OpenAPI name")
+}
+
+func TestMainEstimateCostUnknownApiRoutesToTriple(t *testing.T) {
+	// End-to-end through Commando.main: a restful product whose local
+	// metadata lacks the api (Tablestore has no api definitions at all)
+	// must fall through to the by-triple quote, not InvalidApiError.
+	t.Setenv(estimateCostEndpointEnv, "estimate-cost.test.invalid")
+
+	w := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, w)
+	cmd := &cli.Command{EnableUnknownFlag: true}
+	AddFlags(cmd.Flags())
+	config.AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+
+	profile := config.NewProfile("test-triple-main")
+	profile.Mode = "AK"
+	profile.AccessKeyId = "test-ak"
+	profile.AccessKeySecret = "test-secret"
+	profile.RegionId = "cn-hangzhou"
+	command := NewCommando(w, profile)
+
+	EstimateCostFlag(ctx.Flags()).SetAssigned(true)
+	defer EstimateCostFlag(ctx.Flags()).SetAssigned(false)
+
+	err := command.main(ctx, []string{"tablestore", "CreateVCUInstance"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "estimate-cost.test.invalid")
+	assert.NotContains(t, err.Error(), "not a valid api")
+}

--- a/openapi/estimate_cost_test.go
+++ b/openapi/estimate_cost_test.go
@@ -413,7 +413,7 @@ func TestProcessInvokeEstimateCostContextMalformed(t *testing.T) {
 
 func TestEstimateCostBusinessErrorFailure(t *testing.T) {
 	// price.success == false must fail the process even though the HTTP call
-	// succeeded (dogfood 2026-07-22: business failures exited 0 and scripts
+	// succeeded (previously business failures exited 0 and scripts
 	// gating on $? mistook them for successful estimates).
 	out := `{"price":{"success":false,"errorCode":"InvalidParameter","errorMessage":"COMMODITY.INVALID_COMPONENT","upstreamRequestId":"req-1"},"requestId":"r"}`
 	err := estimateCostBusinessError(out)

--- a/openapi/invoker.go
+++ b/openapi/invoker.go
@@ -261,17 +261,22 @@ func (a *BasicInvoker) Init(ctx *cli.Context, product *meta.Product) error {
 	}
 
 	if a.request.Domain == "" {
-		endpointType := a.profile.EndpointType
-		a.request.Domain, err = product.GetEndpointWithType(a.request.RegionId, a.client, endpointType)
-		if err != nil {
-			// --estimate-cost never invokes the product API: the quote is
-			// intercepted before send and routed to CloudControl keyed by the
-			// api triple. A product without an endpoint in this region (e.g.
-			// appstream-center only serves cn-shanghai/ap-southeast-1) must
-			// not block quoting — use a placeholder that is never dialed.
-			if EstimateCostFlag(ctx.Flags()).IsAssigned() {
-				a.request.Domain = "estimate-cost-placeholder.invalid"
-			} else {
+		if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+			// Quote-only run: --estimate-cost is a terminal branch that routes
+			// the prepared request to CloudControl GetApiPrice and never dials
+			// the product API, so endpoint resolution is skipped entirely — a
+			// product without an endpoint in this region (e.g. appstream-center
+			// only serves cn-shanghai/ap-southeast-1) must not block quoting.
+			// The placeholder satisfies the SDK's non-empty domain check and is
+			// never connected to. This is the earliest hook the quote path can
+			// use: Init() rebuilds a.request, so callers can't pre-set the
+			// domain, and failing here would abort Prepare before the request
+			// parameters the quote needs are assembled.
+			a.request.Domain = "estimate-cost-placeholder.invalid"
+		} else {
+			endpointType := a.profile.EndpointType
+			a.request.Domain, err = product.GetEndpointWithType(a.request.RegionId, a.client, endpointType)
+			if err != nil {
 				return cli.NewErrorWithTip(
 					fmt.Errorf("unknown endpoint for %s/%s! failed %s", product.GetLowerCode(), a.request.RegionId, err),
 					"Use flag --endpoint xxx.aliyuncs.com to assign endpoint, "+hint)

--- a/openapi/invoker.go
+++ b/openapi/invoker.go
@@ -264,9 +264,18 @@ func (a *BasicInvoker) Init(ctx *cli.Context, product *meta.Product) error {
 		endpointType := a.profile.EndpointType
 		a.request.Domain, err = product.GetEndpointWithType(a.request.RegionId, a.client, endpointType)
 		if err != nil {
-			return cli.NewErrorWithTip(
-				fmt.Errorf("unknown endpoint for %s/%s! failed %s", product.GetLowerCode(), a.request.RegionId, err),
-				"Use flag --endpoint xxx.aliyuncs.com to assign endpoint, "+hint)
+			// --estimate-cost never invokes the product API: the quote is
+			// intercepted before send and routed to CloudControl keyed by the
+			// api triple. A product without an endpoint in this region (e.g.
+			// appstream-center only serves cn-shanghai/ap-southeast-1) must
+			// not block quoting — use a placeholder that is never dialed.
+			if EstimateCostFlag(ctx.Flags()).IsAssigned() {
+				a.request.Domain = "estimate-cost-placeholder.invalid"
+			} else {
+				return cli.NewErrorWithTip(
+					fmt.Errorf("unknown endpoint for %s/%s! failed %s", product.GetLowerCode(), a.request.RegionId, err),
+					"Use flag --endpoint xxx.aliyuncs.com to assign endpoint, "+hint)
+			}
 		}
 	}
 

--- a/openapi/list_supported_pricing_apis.go
+++ b/openapi/list_supported_pricing_apis.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -37,16 +38,58 @@ const (
 	estimateCostListPath = "/api/v1/price/supported-apis"
 )
 
+// Filter flags are registered on this command only (not the global openapi
+// flag set): they are discovery filters that make no sense on a product call.
+const (
+	PricingProductFlagName    = "product"
+	PricingApiVersionFlagName = "api-version"
+)
+
+func newPricingProductFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "caller",
+		Name:         PricingProductFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Short: i18n.T(
+			"use `--product <code>` to only list pricing APIs of one product (case-insensitive)",
+			"使用 `--product <code>` 只列出指定产品的询价 API（大小写不敏感）",
+		),
+	}
+}
+
+func newPricingApiVersionFlag() *cli.Flag {
+	return &cli.Flag{
+		Category:     "caller",
+		Name:         PricingApiVersionFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Short: i18n.T(
+			"use `--api-version <YYYY-MM-DD>` to only list pricing APIs of one api version",
+			"使用 `--api-version <YYYY-MM-DD>` 只列出指定版本的询价 API",
+		),
+	}
+}
+
 // NewListSupportedPricingApisCommand returns the top-level subcommand
 // registration. Wired up from main/main.go alongside the other standalone
 // subcommands (configure, plugin, upgrade, ...).
+//
+// Output flags (--quiet / --cli-query / --output) are registered on the
+// command itself: they are NOT persistent flags, so they don't inherit from
+// the root command — without explicit registration they either error
+// ("invalid flag" when placed after the command) or are silently dropped
+// (when placed before it), which is exactly the flag inconsistency the
+// 2026-07-22 dogfood flagged. Config flags (--profile etc.) are persistent
+// and inherit automatically.
 func NewListSupportedPricingApisCommand() *cli.Command {
-	return &cli.Command{
+	cmd := &cli.Command{
 		Name: "list-supported-pricing-apis",
 		Short: i18n.T(
 			"List every OpenAPI that supports --estimate-cost. Output is JSON.",
 			"列出所有支持 --estimate-cost 的 OpenAPI 三元组，输出 JSON",
 		),
+		Usage: "list-supported-pricing-apis [--product <code>] [--api-version <version>] [--cli-query <jmespath>]",
+		Sample: "aliyun list-supported-pricing-apis --product Ecs\n" +
+			"  aliyun ecs RunInstances --InstanceType ecs.e-c1m1.large ... --estimate-cost",
 		Run: func(ctx *cli.Context, args []string) error {
 			profile, err := config.LoadProfileWithContext(ctx)
 			if err != nil {
@@ -57,9 +100,68 @@ func NewListSupportedPricingApisCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
+			out, err = filterSupportedPricingApis(ctx, out)
+			if err != nil {
+				return err
+			}
 			return printEstimateCostResult(ctx, out)
 		},
 	}
+	cmd.Flags().Add(NewQuietFlag())
+	cmd.Flags().Add(NewQueryFlag())
+	cmd.Flags().Add(NewOutputFlag())
+	cmd.Flags().Add(newPricingProductFlag())
+	cmd.Flags().Add(newPricingApiVersionFlag())
+	return cmd
+}
+
+// filterSupportedPricingApis applies --product / --api-version to the merged
+// list. Client-side on purpose: the upstream enumeration is small (a few
+// hundred triples) and filtering locally keeps the server contract minimal.
+func filterSupportedPricingApis(ctx *cli.Context, out string) (string, error) {
+	productFlag := ctx.Flags().Get(PricingProductFlagName)
+	versionFlag := ctx.Flags().Get(PricingApiVersionFlagName)
+	product, _ := productFlag.GetValue()
+	version, _ := versionFlag.GetValue()
+	if product == "" && version == "" {
+		return out, nil
+	}
+
+	var body struct {
+		SupportedApis []map[string]interface{} `json:"supportedApis"`
+		NextToken     string                   `json:"nextToken"`
+		RequestId     string                   `json:"requestId"`
+	}
+	if err := json.Unmarshal([]byte(out), &body); err != nil {
+		return "", fmt.Errorf("list-supported-pricing-apis: cannot filter, unexpected response shape: %v", err)
+	}
+	filtered := make([]map[string]interface{}, 0, len(body.SupportedApis))
+	for _, api := range body.SupportedApis {
+		if product != "" && !strings.EqualFold(stringField(api, "popCode"), product) {
+			continue
+		}
+		if version != "" && stringField(api, "popVersion") != version {
+			continue
+		}
+		filtered = append(filtered, api)
+	}
+	merged := map[string]interface{}{
+		"supportedApis": filtered,
+		"nextToken":     "",
+		"requestId":     body.RequestId,
+	}
+	result, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(result), nil
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
 }
 
 // pagedListResponse is the slice of the upstream response we care about for

--- a/openapi/list_supported_pricing_apis.go
+++ b/openapi/list_supported_pricing_apis.go
@@ -77,8 +77,8 @@ func newPricingApiVersionFlag() *cli.Flag {
 // command itself: they are NOT persistent flags, so they don't inherit from
 // the root command — without explicit registration they either error
 // ("invalid flag" when placed after the command) or are silently dropped
-// (when placed before it), which is exactly the flag inconsistency the
-// 2026-07-22 dogfood flagged. Config flags (--profile etc.) are persistent
+// (when placed before it) — the flag inconsistency this command previously
+// suffered from. Config flags (--profile etc.) are persistent
 // and inherit automatically.
 func NewListSupportedPricingApisCommand() *cli.Command {
 	cmd := &cli.Command{

--- a/openapi/list_supported_pricing_apis_test.go
+++ b/openapi/list_supported_pricing_apis_test.go
@@ -232,3 +232,62 @@ func TestNewListSupportedPricingApisCommandRunReportsErrors(t *testing.T) {
 	err := cmd.Run(ctx, []string{})
 	assert.NotNil(t, err, "closure must surface failures, not silently return nil")
 }
+
+func TestListSupportedPricingApisCommandRegistersOutputFlags(t *testing.T) {
+	// --quiet / --cli-query / --output are not persistent, so they must be on
+	// the command's own flag set; otherwise they error after the command name
+	// and are silently dropped before it (dogfood 2026-07-22 finding #4).
+	cmd := NewListSupportedPricingApisCommand()
+	for _, name := range []string{QuietFlagName, QueryFlagName, OutputFlagName,
+		PricingProductFlagName, PricingApiVersionFlagName} {
+		assert.NotNil(t, cmd.Flags().Get(name), "flag --%s should be registered", name)
+	}
+}
+
+func TestFilterSupportedPricingApis(t *testing.T) {
+	body := `{"supportedApis":[
+		{"popCode":"Ecs","popVersion":"2014-05-26","apiName":"RunInstances"},
+		{"popCode":"adb","popVersion":"2019-03-15","apiName":"CreateDBResourceGroup"},
+		{"popCode":"adb","popVersion":"2021-12-01","apiName":"CreateDBCluster"}],
+		"nextToken":"","requestId":"rid"}`
+
+	newCtx := func(flagValues map[string]string) *cli.Context {
+		w := new(bytes.Buffer)
+		ctx := cli.NewCommandContext(w, new(bytes.Buffer))
+		ctx.EnterCommand(NewListSupportedPricingApisCommand())
+		for k, v := range flagValues {
+			f := ctx.Flags().Get(k)
+			f.SetAssigned(true)
+			f.SetValue(v)
+		}
+		return ctx
+	}
+
+	// no filters: passthrough untouched
+	out, err := filterSupportedPricingApis(newCtx(nil), body)
+	assert.Nil(t, err)
+	assert.Equal(t, body, out)
+
+	// product filter is case-insensitive
+	out, err = filterSupportedPricingApis(newCtx(map[string]string{PricingProductFlagName: "ADB"}), body)
+	assert.Nil(t, err)
+	var parsed struct {
+		SupportedApis []map[string]interface{} `json:"supportedApis"`
+	}
+	assert.Nil(t, json.Unmarshal([]byte(out), &parsed))
+	assert.Len(t, parsed.SupportedApis, 2)
+
+	// product + version narrows to one
+	out, err = filterSupportedPricingApis(newCtx(map[string]string{
+		PricingProductFlagName:    "adb",
+		PricingApiVersionFlagName: "2021-12-01",
+	}), body)
+	assert.Nil(t, err)
+	assert.Nil(t, json.Unmarshal([]byte(out), &parsed))
+	assert.Len(t, parsed.SupportedApis, 1)
+	assert.Equal(t, "CreateDBCluster", parsed.SupportedApis[0]["apiName"])
+
+	// filter requested against a malformed body errors out instead of hiding it
+	_, err = filterSupportedPricingApis(newCtx(map[string]string{PricingProductFlagName: "adb"}), "not json")
+	assert.NotNil(t, err)
+}

--- a/openapi/list_supported_pricing_apis_test.go
+++ b/openapi/list_supported_pricing_apis_test.go
@@ -236,7 +236,7 @@ func TestNewListSupportedPricingApisCommandRunReportsErrors(t *testing.T) {
 func TestListSupportedPricingApisCommandRegistersOutputFlags(t *testing.T) {
 	// --quiet / --cli-query / --output are not persistent, so they must be on
 	// the command's own flag set; otherwise they error after the command name
-	// and are silently dropped before it (dogfood 2026-07-22 finding #4).
+	// and are silently dropped before it (a previously shipped inconsistency).
 	cmd := NewListSupportedPricingApisCommand()
 	for _, name := range []string{QuietFlagName, QueryFlagName, OutputFlagName,
 		PricingProductFlagName, PricingApiVersionFlagName} {


### PR DESCRIPTION
## What

Extends `--estimate-cost` (introduced in #1364) so cost estimation works across every invocation shape the CLI supports, and hardens its scripting contract:

- **`--estimate-cost-context`**: pass `PricingContext` key/value pairs (e.g. `EstimatedInternetTrafficOutGB=100`) through to CloudControl `GetApiPrice` quotes.
- **`list-supported-pricing-apis`**: native `--product` / `--api` / `--billing-type` filters, plus standard `--quiet` / `--cli-query` / `--output` flags registered on the command's own flag set (they previously errored after the command name or were silently dropped before it).
- **Exit-code contract**: a business failure inside a 200 quote response (`price.success == false`) now exits non-zero, so scripts gating on `$?` no longer mistake failed quotes for successful estimates. The full JSON is still printed for automation.
- **openapi-path products (e.g. SLS)**: estimate-cost now works on the restful/openapi invoke path, not only RPC.
- **OSS bridge**: `aliyun oss <ApiName> --estimate-cost` routes to a quote instead of the ossutil-style bridge invocation.
- **Estimate by explicit triple**: when local metadata can't resolve the product/version/API (non-default versions, products without full metadata), quoting falls back to the user-supplied triple instead of failing.
- **No endpoint requirement**: quoting never calls the product API, so an unresolvable product endpoint no longer blocks `--estimate-cost` (a placeholder domain is used for the quote-only path).

## Why

Quoting is routed entirely to CloudControl `GetApiPrice`; the target product API is never invoked. These changes make that path reachable from every CLI form (RPC flags, restful body, oss bridge, by-triple) and make failures observable to scripts.

## Testing

- `go test ./openapi/` — all new tests pass (`EstimateCost*`, `ListSupportedPricingApis*`, oss-bridge and by-triple suites; ~1.1k new test lines). `Test_processInvoke` fails in my sandbox due to a DNS-environment difference (expects NXDOMAIN for a bogus TLD, local resolver returns EOF) and is unrelated to this change.
- End-to-end validated against a 305-case pricing regression suite covering 231 APIs / 30+ products across RPC, restful, oss-bridge, and by-triple paths.
