### PR TITLE
feat: add agentic JSON error envelope

### DIFF
--- a/aliyun-openapi-runtime/engine/builder.go
+++ b/aliyun-openapi-runtime/engine/builder.go
@@ -188,7 +188,7 @@ func (e *Engine) Dispatch(req Request) error {
 
 	args := req.Args
 	if len(args) < 2 {
-		return errors.New("expected <product> <command>")
+		return &UsageError{Code: "MISSING_COMMAND", Err: errors.New("expected <product> <command>")}
 	}
 	product := args[0]
 	if err := ldr.EnsureProduct(product); err != nil {
@@ -211,9 +211,12 @@ func (e *Engine) Dispatch(req Request) error {
 	if err != nil {
 		var ufe *argparser.UnknownFlagError
 		if errors.As(err, &ufe) {
-			return fmt.Errorf("%v (run `aliyun %s %s --help` for accepted flags)", err, product, cmdName)
+			return &UsageError{
+				Code: "UNKNOWN_FLAG",
+				Err:  fmt.Errorf("%w (run `aliyun %s %s --help` for accepted flags)", err, product, cmdName),
+			}
 		}
-		return err
+		return &UsageError{Code: "INVALID_ARGUMENT", Err: err}
 	}
 
 	if res.Reserved.Help {
@@ -221,11 +224,14 @@ func (e *Engine) Dispatch(req Request) error {
 	}
 
 	if err := runtime.ValidateRequired(api, res.Args, res.Reserved.BodySet || res.Reserved.BodyFileSet); err != nil {
-		return fmt.Errorf("%w\nrun `aliyun %s %s --help` to see all parameters", err, product, cmdName)
+		return &UsageError{
+			Code: "MISSING_REQUIRED_PARAMETER",
+			Err:  fmt.Errorf("%w\nrun `aliyun %s %s --help` to see all parameters", err, product, cmdName),
+		}
 	}
 
 	if err := validateDispatchOptions(res); err != nil {
-		return err
+		return &UsageError{Code: "INVALID_OPTION_COMBINATION", Err: err}
 	}
 
 	ec, err := buildExecContext(req, api, res)
@@ -256,7 +262,7 @@ func (e *Engine) dispatchBuiltin(req Request, ldr loader.Loader, product, comman
 		ExternalFlags: e.externalFlags,
 	})
 	if err != nil {
-		return true, err
+		return true, &UsageError{Code: "INVALID_ARGUMENT", Err: err}
 	}
 	if res.Reserved.Help {
 		return true, printAPIVersionsHelp(req.Out, productMeta, req.Lang)
@@ -306,7 +312,10 @@ func buildExecContext(req Request, api *meta.API, res *argparser.Result) (*runti
 		for _, header := range res.Reserved.Headers {
 			name, value, ok := strings.Cut(header, "=")
 			if !ok || strings.TrimSpace(name) == "" {
-				return nil, fmt.Errorf("invalid header format %q, expected Name=Value", header)
+				return nil, &UsageError{
+					Code: "INVALID_HEADER",
+					Err:  fmt.Errorf("invalid header format %q, expected Name=Value", header),
+				}
 			}
 			ec.ExtraHeaders[strings.TrimSpace(name)] = strings.TrimSpace(value)
 		}
@@ -322,7 +331,7 @@ func buildExecContext(req Request, api *meta.API, res *argparser.Result) (*runti
 			body, err = os.ReadFile(res.Reserved.BodyFile)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("--body-file: %w", err)
+			return nil, &UsageError{Code: "INVALID_BODY_FILE", Err: fmt.Errorf("--body-file: %w", err)}
 		}
 		ec.RawBody = string(body)
 	}
@@ -343,11 +352,11 @@ func buildExecContext(req Request, api *meta.API, res *argparser.Result) (*runti
 	}
 	if !ec.DryRun || res.Reserved.EstimateCost {
 		if req.Host == nil {
-			return nil, errors.New("no credential source configured; run `aliyun configure` or pass --cli-dry-run")
+			return nil, &CredentialError{Err: errors.New("no credential source configured; run `aliyun configure` or pass --cli-dry-run")}
 		}
 		credential, err := req.Host.Credential()
 		if err != nil {
-			return nil, fmt.Errorf("resolve credential: %w", err)
+			return nil, &CredentialError{Err: fmt.Errorf("resolve credential: %w", err)}
 		}
 		ec.Credential = credential
 	}

--- a/aliyun-openapi-runtime/engine/builder_test.go
+++ b/aliyun-openapi-runtime/engine/builder_test.go
@@ -15,13 +15,114 @@
 package engine
 
 import (
+	"errors"
+	"io"
+	"reflect"
 	"testing"
 
 	"github.com/aliyun/aliyun-openapi-runtime/argparser"
+	"github.com/aliyun/aliyun-openapi-runtime/loader"
 	"github.com/aliyun/aliyun-openapi-runtime/meta"
 	"github.com/aliyun/aliyun-openapi-runtime/runtime"
 	"github.com/aliyun/aliyun-openapi-runtime/source"
 )
+
+type dispatchErrorTestSource struct{}
+
+func (dispatchErrorTestSource) Kind() source.Kind { return source.KindBaseline }
+
+func (dispatchErrorTestSource) LoadProduct(code string) (*meta.Product, *source.Provenance, error) {
+	if code != "demo" {
+		return nil, nil, source.ErrNotFound
+	}
+	return &meta.Product{
+		Code: "demo", Versions: []string{"2024-01-01"}, DefaultVersion: "2024-01-01",
+	}, &source.Provenance{Kind: source.KindBaseline}, nil
+}
+
+func (dispatchErrorTestSource) LoadAPIIndex(code, version string) (*meta.APIIndex, error) {
+	if code != "demo" || version != "2024-01-01" {
+		return nil, source.ErrNotFound
+	}
+	index := &meta.APIIndex{
+		ProductCode: code,
+		Version:     version,
+		Entries: map[string]meta.APIIndexEntry{
+			"RunThing": {APIName: "RunThing", CmdName: "run-thing"},
+		},
+	}
+	index.BuildCmdIndex()
+	return index, nil
+}
+
+func (dispatchErrorTestSource) LoadAPI(code, version, name string) (*meta.API, error) {
+	if code != "demo" || version != "2024-01-01" || name != "RunThing" {
+		return nil, source.ErrNotFound
+	}
+	return &meta.API{
+		Name: "RunThing", CmdName: "run-thing", ProductCode: "demo",
+		Version: "2024-01-01", Method: "POST", Protocol: "HTTPS", Style: meta.StyleRPC,
+		Endpoints: meta.Endpoints{Global: "demo.example.com"},
+		Parameters: []meta.Parameter{{
+			Name: "instance_type", RawName: "InstanceType", Type: meta.TypeString,
+			Position: meta.PosQuery, Required: true, Options: []string{"--instance-type"},
+		}},
+	}, nil
+}
+
+func newDispatchErrorTestEngine() *Engine {
+	return NewEngine(func() (loader.Loader, error) {
+		return loader.New(dispatchErrorTestSource{}), nil
+	}, nil)
+}
+
+func TestDispatchPreservesUnknownFlagDetails(t *testing.T) {
+	err := newDispatchErrorTestEngine().Dispatch(Request{
+		Args: []string{"demo", "run-thing", "--instnace-type", "ecs.g6"},
+		Out:  io.Discard,
+	})
+
+	var unknownFlag *argparser.UnknownFlagError
+	if !errors.As(err, &unknownFlag) {
+		t.Fatalf("Dispatch error %T does not preserve UnknownFlagError: %v", err, err)
+	}
+	if unknownFlag.Flag != "instnace-type" || !reflect.DeepEqual(unknownFlag.Known, []string{"instance-type"}) {
+		t.Fatalf("UnknownFlagError = %#v", unknownFlag)
+	}
+}
+
+func TestDispatchPreservesMissingRequiredDetails(t *testing.T) {
+	err := newDispatchErrorTestEngine().Dispatch(Request{
+		Args: []string{"demo", "run-thing"},
+		Out:  io.Discard,
+	})
+
+	var usage *UsageError
+	if !errors.As(err, &usage) || usage.Code != "MISSING_REQUIRED_PARAMETER" {
+		t.Fatalf("Dispatch error = %#v, want MISSING_REQUIRED_PARAMETER UsageError", err)
+	}
+	var missing *runtime.MissingRequiredError
+	if !errors.As(err, &missing) || !reflect.DeepEqual(missing.Flags, []string{"--instance-type"}) {
+		t.Fatalf("Dispatch error does not preserve MissingRequiredError: %v", err)
+	}
+}
+
+func TestDispatchPreservesCredentialFailure(t *testing.T) {
+	cause := errors.New("credential unavailable")
+	err := newDispatchErrorTestEngine().Dispatch(Request{
+		Args: []string{"demo", "run-thing", "--instance-type", "ecs.g6"},
+		Out:  io.Discard,
+		Host: runtime.StaticHost{CredErr: cause},
+	})
+
+	var credential *CredentialError
+	if !errors.As(err, &credential) {
+		t.Fatalf("Dispatch error %T does not preserve CredentialError: %v", err, err)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("Dispatch error does not preserve credential cause: %v", err)
+	}
+}
 
 func TestBuildExecContextRawBodyPrecedesBodyFile(t *testing.T) {
 	res := &argparser.Result{Reserved: argparser.Reserved{

--- a/aliyun-openapi-runtime/engine/errors.go
+++ b/aliyun-openapi-runtime/engine/errors.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+// UsageError preserves a machine-readable reason while keeping the exact
+// existing error text for human-mode callers.
+type UsageError struct {
+	Code string
+	Err  error
+}
+
+func (e *UsageError) Error() string { return e.Err.Error() }
+
+func (e *UsageError) Unwrap() error { return e.Err }
+
+// CredentialError identifies failures that occur before an API call while
+// resolving the credential source configured by the embedding host.
+type CredentialError struct {
+	Err error
+}
+
+func (e *CredentialError) Error() string { return e.Err.Error() }
+
+func (e *CredentialError) Unwrap() error { return e.Err }

--- a/cli/agent_error.go
+++ b/cli/agent_error.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+type AgentErrorCategory string
+
+const (
+	InternalErrorCategory       AgentErrorCategory = "INTERNAL_ERROR"
+	UsageErrorCategory          AgentErrorCategory = "USAGE_ERROR"
+	AuthenticationErrorCategory AgentErrorCategory = "AUTHENTICATION_ERROR"
+	PermissionErrorCategory     AgentErrorCategory = "PERMISSION_ERROR"
+	ThrottlingErrorCategory     AgentErrorCategory = "THROTTLING_ERROR"
+	NetworkErrorCategory        AgentErrorCategory = "NETWORK_ERROR"
+	ServiceErrorCategory        AgentErrorCategory = "SERVICE_ERROR"
+)
+
+type AgentErrorRecovery struct {
+	Command string `json:"command"`
+}
+
+type AgentErrorEnvelope struct {
+	OK          bool               `json:"ok"`
+	Category    AgentErrorCategory `json:"category"`
+	Code        string             `json:"code"`
+	Message     string             `json:"message"`
+	Suggestions []string           `json:"suggestions"`
+	Retryable   bool               `json:"retryable"`
+	RequestID   string             `json:"requestId"`
+	Recovery    AgentErrorRecovery `json:"recovery"`
+}
+
+type AgentError struct {
+	envelope AgentErrorEnvelope
+	cause    error
+}
+
+func NewAgentError(envelope AgentErrorEnvelope, cause error) *AgentError {
+	envelope.Suggestions = copySuggestions(envelope.Suggestions)
+	return &AgentError{envelope: envelope, cause: cause}
+}
+
+func (e *AgentError) Error() string {
+	if e.envelope.Message != "" {
+		return e.envelope.Message
+	}
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	return e.envelope.Code
+}
+
+func (e *AgentError) Unwrap() error {
+	return e.cause
+}
+
+func (e *AgentError) Envelope() AgentErrorEnvelope {
+	envelope := e.envelope
+	envelope.Suggestions = copySuggestions(envelope.Suggestions)
+	return envelope
+}
+
+func (e *AgentError) ExitCode() int {
+	switch e.envelope.Category {
+	case UsageErrorCategory:
+		return 2
+	case AuthenticationErrorCategory:
+		return 3
+	case PermissionErrorCategory:
+		return 4
+	case ThrottlingErrorCategory:
+		return 5
+	case NetworkErrorCategory:
+		return 6
+	case ServiceErrorCategory:
+		return 7
+	default:
+		return 1
+	}
+}
+
+func copySuggestions(suggestions []string) []string {
+	copyOfSuggestions := make([]string, len(suggestions))
+	copy(copyOfSuggestions, suggestions)
+	return copyOfSuggestions
+}

--- a/cli/agent_error_test.go
+++ b/cli/agent_error_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentErrorPreservesStableEnvelope(t *testing.T) {
+	cause := errors.New("unknown flag --instnace-type")
+	suggestions := []string{"--instance-type"}
+	envelope := AgentErrorEnvelope{
+		OK:          false,
+		Category:    UsageErrorCategory,
+		Code:        "UNKNOWN_FLAG",
+		Message:     cause.Error(),
+		Suggestions: suggestions,
+		Retryable:   false,
+		RequestID:   "",
+		Recovery:    AgentErrorRecovery{Command: "aliyun ecs describe-instances --help"},
+	}
+
+	err := NewAgentError(envelope, cause)
+	suggestions[0] = "--mutated"
+
+	assert.Equal(t, cause.Error(), err.Error())
+	assert.ErrorIs(t, err, cause)
+	assert.Equal(t, []string{"--instance-type"}, err.Envelope().Suggestions)
+	assert.Equal(t, 2, err.ExitCode())
+}
+
+func TestAgentErrorNormalizesNilSuggestions(t *testing.T) {
+	err := NewAgentError(AgentErrorEnvelope{
+		Category: InternalErrorCategory,
+		Code:     "INTERNAL_ERROR",
+		Message:  "opaque",
+	}, errors.New("opaque"))
+
+	require.NotNil(t, err.Envelope().Suggestions)
+	assert.Empty(t, err.Envelope().Suggestions)
+}
+
+func TestAgentErrorExitCodes(t *testing.T) {
+	tests := []struct {
+		category AgentErrorCategory
+		want     int
+	}{
+		{InternalErrorCategory, 1},
+		{UsageErrorCategory, 2},
+		{AuthenticationErrorCategory, 3},
+		{PermissionErrorCategory, 4},
+		{ThrottlingErrorCategory, 5},
+		{NetworkErrorCategory, 6},
+		{ServiceErrorCategory, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.category), func(t *testing.T) {
+			err := NewAgentError(AgentErrorEnvelope{Category: tt.category}, errors.New("test"))
+			assert.Equal(t, tt.want, err.ExitCode())
+		})
+	}
+}

--- a/cli/command.go
+++ b/cli/command.go
@@ -15,6 +15,8 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -345,6 +347,13 @@ func (c *Command) executeInner(ctx *Context, args []string) error {
 }
 
 func (c *Command) processError(ctx *Context, err error) {
+	var agentErr *AgentError
+	if errors.As(err, &agentErr) {
+		_ = json.NewEncoder(ctx.Stderr()).Encode(agentErr.Envelope())
+		Exit(agentErr.ExitCode())
+		return
+	}
+
 	Errorf(ctx.Stderr(), "ERROR: %s\n", err.Error())
 	exitCode := 1
 	if e, ok := err.(SuggestibleError); ok {

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -222,6 +222,31 @@ func TestProcessError(t *testing.T) {
 	assert.Equal(t, "\x1b[1;31mERROR: test error tip\n\x1b[0m\x1b[1;33m\n\n\x1b[0m", buf2.String())
 }
 
+func TestProcessAgentErrorWritesOneJSONLineToStderr(t *testing.T) {
+	DisableExitCode()
+	defer EnableExitCode()
+
+	cmd := newAliyunCmd()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(stdout, stderr)
+	err := NewAgentError(AgentErrorEnvelope{
+		OK:          false,
+		Category:    UsageErrorCategory,
+		Code:        "UNKNOWN_FLAG",
+		Message:     "unknown flag --instnace-type",
+		Suggestions: []string{"--instance-type"},
+		Retryable:   false,
+		RequestID:   "",
+		Recovery:    AgentErrorRecovery{Command: "aliyun ecs describe-instances --help"},
+	}, errors.New("unknown flag --instnace-type"))
+
+	cmd.processError(ctx, err)
+
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, "{\"ok\":false,\"category\":\"USAGE_ERROR\",\"code\":\"UNKNOWN_FLAG\",\"message\":\"unknown flag --instnace-type\",\"suggestions\":[\"--instance-type\"],\"retryable\":false,\"requestId\":\"\",\"recovery\":{\"command\":\"aliyun ecs describe-instances --help\"}}\n", stderr.String())
+}
+
 func TestExecuteHelp(t *testing.T) {
 	cmd := newAliyunCmd()
 	buf := new(bytes.Buffer)

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -39,6 +39,10 @@ func (e *errorWithTip) Error() string {
 	return e.err.Error()
 }
 
+func (e *errorWithTip) Unwrap() error {
+	return e.err
+}
+
 func (e *errorWithTip) GetTip(lang string) string {
 	return e.tip
 }

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,12 +23,14 @@ import (
 )
 
 func TestErrorWithTip(t *testing.T) {
-	err := NewErrorWithTip(errors.New("err test"), "%s-%d", "nicai", 1)
+	cause := errors.New("err test")
+	err := NewErrorWithTip(cause, "%s-%d", "nicai", 1)
 	e, ok := err.(*errorWithTip)
 	assert.True(t, ok)
 	assert.Equal(t, &errorWithTip{err: errors.New("err test"), tip: fmt.Sprintf("%s-%d", "nicai", 1)}, e)
 	assert.Equal(t, e.Error(), "err test")
 	assert.Equal(t, "nicai-1", e.GetTip("ch"))
+	assert.ErrorIs(t, err, cause)
 }
 
 func TestInvalidCommandError(t *testing.T) {

--- a/openapi/agent_error.go
+++ b/openapi/agent_error.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/alibabacloud-go/tea/tea"
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-openapi-runtime/argparser"
+	"github.com/aliyun/aliyun-openapi-runtime/engine"
+	runtime "github.com/aliyun/aliyun-openapi-runtime/runtime"
+)
+
+type credentialConfigurationError struct {
+	Err error
+}
+
+func (e *credentialConfigurationError) Error() string { return e.Err.Error() }
+
+func (e *credentialConfigurationError) Unwrap() error { return e.Err }
+
+func normalizeAgentError(err error, args []string) error {
+	if err == nil {
+		return nil
+	}
+
+	var existing *cli.AgentError
+	if errors.As(err, &existing) {
+		return existing
+	}
+
+	var unknownFlag *argparser.UnknownFlagError
+	if errors.As(err, &unknownFlag) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_FLAG", unknownFlag.Error(),
+			flagSuggestions(unknownFlag.Flag, unknownFlag.Known), false, "", commandHelp(args))
+	}
+
+	var missing *runtime.MissingRequiredError
+	if errors.As(err, &missing) {
+		return newAgentError(err, cli.UsageErrorCategory, "MISSING_REQUIRED_PARAMETER", missing.Error(),
+			stableStrings(missing.Flags), false, "", commandHelp(args))
+	}
+
+	var invalidParameter *InvalidParameterError
+	if errors.As(err, &invalidParameter) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_FLAG", invalidParameter.Error(),
+			invalidParameter.AgentSuggestions(), false, "", commandHelp(args))
+	}
+
+	var invalidAPI *InvalidApiError
+	if errors.As(err, &invalidAPI) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_API", invalidAPI.Error(),
+			invalidAPI.AgentSuggestions(), false, "", productHelp(args))
+	}
+
+	var invalidUnifiedAPI *InvalidUnifiedApiError
+	if errors.As(err, &invalidUnifiedAPI) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_API", invalidUnifiedAPI.Error(),
+			invalidUnifiedAPI.AgentSuggestions(), false, "", productHelp(args))
+	}
+
+	var invalidProduct *InvalidProductError
+	if errors.As(err, &invalidProduct) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_PRODUCT", invalidProduct.Error(),
+			invalidProduct.AgentSuggestions(), false, "", "aliyun --help")
+	}
+
+	var invalidProductOrPlugin *InvalidProductOrPluginError
+	if errors.As(err, &invalidProductOrPlugin) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_PRODUCT", invalidProductOrPlugin.Error(),
+			invalidProductOrPlugin.AgentSuggestions(), false, "", "aliyun --help")
+	}
+
+	var invalidFlag *cli.InvalidFlagError
+	if errors.As(err, &invalidFlag) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_FLAG", invalidFlag.Error(),
+			nil, false, "", commandHelp(args))
+	}
+
+	var invalidCommand *cli.InvalidCommandError
+	if errors.As(err, &invalidCommand) {
+		return newAgentError(err, cli.UsageErrorCategory, "UNKNOWN_COMMAND", invalidCommand.Error(),
+			invalidCommand.GetSuggestions(), false, "", commandHelp(args))
+	}
+
+	var runtimeCredential *engine.CredentialError
+	var configuredCredential *credentialConfigurationError
+	if errors.As(err, &runtimeCredential) || errors.As(err, &configuredCredential) {
+		return newAgentError(err, cli.AuthenticationErrorCategory, "CREDENTIAL_NOT_CONFIGURED", err.Error(),
+			nil, false, "", "aliyun configure")
+	}
+
+	var usage *engine.UsageError
+	if errors.As(err, &usage) {
+		code := strings.TrimSpace(usage.Code)
+		if code == "" {
+			code = "INVALID_ARGUMENT"
+		}
+		return newAgentError(err, cli.UsageErrorCategory, code, err.Error(), nil, false, "", commandHelp(args))
+	}
+
+	var serverError *sdkerrors.ServerError
+	if errors.As(err, &serverError) {
+		category, retryable := classifySDKFailure(serverError.HttpStatus(), serverError.ErrorCode())
+		code := nonEmptyCode(serverError.ErrorCode(), "SERVICE_ERROR")
+		message := nonEmptyMessage(serverError.Message(), err.Error())
+		return newAgentError(err, category, code, message, nil, retryable, serverError.RequestId(), "")
+	}
+
+	var teaError *tea.SDKError
+	if errors.As(err, &teaError) {
+		status := tea.IntValue(teaError.StatusCode)
+		code := tea.StringValue(teaError.Code)
+		category, retryable := classifySDKFailure(status, code)
+		return newAgentError(err, category, nonEmptyCode(code, "SERVICE_ERROR"),
+			nonEmptyMessage(tea.StringValue(teaError.Message), err.Error()), nil, retryable,
+			requestIDFromTeaData(tea.StringValue(teaError.Data)), "")
+	}
+
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		retryable := networkError.Timeout()
+		if temporary, ok := networkError.(interface{ Temporary() bool }); ok {
+			retryable = retryable || temporary.Temporary()
+		}
+		return newAgentError(err, cli.NetworkErrorCategory, "NETWORK_FAILURE", err.Error(), nil, retryable, "", "")
+	}
+
+	return newAgentError(err, cli.InternalErrorCategory, "INTERNAL_ERROR", err.Error(), nil, false, "", "")
+}
+
+func newAgentError(cause error, category cli.AgentErrorCategory, code, message string, suggestions []string,
+	retryable bool, requestID, recoveryCommand string) error {
+	return cli.NewAgentError(cli.AgentErrorEnvelope{
+		OK:          false,
+		Category:    category,
+		Code:        code,
+		Message:     message,
+		Suggestions: suggestions,
+		Retryable:   retryable,
+		RequestID:   requestID,
+		Recovery:    cli.AgentErrorRecovery{Command: recoveryCommand},
+	}, cause)
+}
+
+func classifySDKFailure(status int, code string) (cli.AgentErrorCategory, bool) {
+	normalized := normalizeErrorCode(code)
+	switch {
+	case status == 401 || isAuthenticationCode(normalized):
+		return cli.AuthenticationErrorCategory, false
+	case status == 403 || isPermissionCode(normalized):
+		return cli.PermissionErrorCategory, false
+	case status == 429 || isThrottlingCode(normalized):
+		return cli.ThrottlingErrorCategory, true
+	case status >= 500 && status <= 599:
+		return cli.ServiceErrorCategory, true
+	default:
+		return cli.ServiceErrorCategory, false
+	}
+}
+
+func normalizeErrorCode(code string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(code) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func isAuthenticationCode(code string) bool {
+	if code == "unauthorized" {
+		return true
+	}
+	return hasAnyPrefix(code,
+		"invalidaccesskey", "invalidsecuritytoken", "missingsecuritytoken",
+		"expiredsecuritytoken", "tokenexpired", "signaturedoesnotmatch",
+		"incompletesignature", "authentication", "authfailure", "invalidcredential")
+}
+
+func isPermissionCode(code string) bool {
+	return hasAnyPrefix(code,
+		"forbidden", "accessdenied", "unauthorizedoperation", "permissiondenied",
+		"nopermission", "operationdenied")
+}
+
+func isThrottlingCode(code string) bool {
+	return hasAnyPrefix(code, "throttling", "toomanyrequests", "requestlimitexceeded", "flowcontrol")
+}
+
+func hasAnyPrefix(value string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func requestIDFromTeaData(data string) string {
+	if strings.TrimSpace(data) == "" {
+		return ""
+	}
+	var decoded interface{}
+	if json.Unmarshal([]byte(data), &decoded) != nil {
+		return ""
+	}
+	return findRequestID(decoded)
+}
+
+func findRequestID(value interface{}) string {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for key, item := range typed {
+			if strings.EqualFold(key, "requestId") {
+				if requestID, ok := item.(string); ok {
+					return requestID
+				}
+			}
+		}
+		for _, item := range typed {
+			if requestID := findRequestID(item); requestID != "" {
+				return requestID
+			}
+		}
+	case []interface{}:
+		for _, item := range typed {
+			if requestID := findRequestID(item); requestID != "" {
+				return requestID
+			}
+		}
+	}
+	return ""
+}
+
+func commandHelp(args []string) string {
+	if len(args) >= 2 && strings.TrimSpace(args[0]) != "" && strings.TrimSpace(args[1]) != "" {
+		return "aliyun " + args[0] + " " + args[1] + " --help"
+	}
+	return productHelp(args)
+}
+
+func productHelp(args []string) string {
+	if len(args) >= 1 && strings.TrimSpace(args[0]) != "" {
+		return "aliyun " + args[0] + " --help"
+	}
+	return "aliyun --help"
+}
+
+func nonEmptyCode(code, fallback string) string {
+	if strings.TrimSpace(code) == "" {
+		return fallback
+	}
+	return code
+}
+
+func nonEmptyMessage(message, fallback string) string {
+	if strings.TrimSpace(message) == "" {
+		return fallback
+	}
+	return message
+}
+
+func flagSuggestions(input string, candidates []string) []string {
+	return closeSuggestions(input, candidates, true)
+}
+
+func apiSuggestions(input string, candidates []string) []string {
+	return closeSuggestions(input, candidates, false)
+}
+
+func closeSuggestions(input string, candidates []string, flags bool) []string {
+	input = strings.TrimLeft(input, "-")
+	suggester := cli.NewSuggester(input, cli.DefaultSuggestDistance)
+	for _, candidate := range candidates {
+		candidate = strings.TrimLeft(strings.TrimSpace(candidate), "-")
+		if candidate != "" {
+			suggester.UnifyApply(candidate)
+		}
+	}
+	results := suggester.GetResults()
+	if flags {
+		for i := range results {
+			results[i] = "--" + strings.TrimLeft(results[i], "-")
+		}
+	}
+	return stableStrings(results)
+}
+
+func stableStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/alibabacloud-go/tea/tea"
+	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-openapi-runtime/argparser"
+	"github.com/aliyun/aliyun-openapi-runtime/engine"
+	runtime "github.com/aliyun/aliyun-openapi-runtime/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func agentEnvelope(t *testing.T, err error, args ...string) cli.AgentErrorEnvelope {
+	t.Helper()
+	normalized := normalizeAgentError(err, args)
+	var agentErr *cli.AgentError
+	require.ErrorAs(t, normalized, &agentErr)
+	return agentErr.Envelope()
+}
+
+func TestNormalizeAgentErrorLocalUsageErrors(t *testing.T) {
+	t.Run("kebab unknown flag", func(t *testing.T) {
+		cause := &argparser.UnknownFlagError{
+			Flag:  "instnace-type",
+			Known: []string{"image-id", "instance-type"},
+		}
+		err := &engine.UsageError{Code: "UNKNOWN_FLAG", Err: fmt.Errorf("%w (help)", cause)}
+
+		envelope := agentEnvelope(t, err, "ecs", "describe-instances")
+		assert.Equal(t, cli.UsageErrorCategory, envelope.Category)
+		assert.Equal(t, "UNKNOWN_FLAG", envelope.Code)
+		assert.Equal(t, cause.Error(), envelope.Message)
+		assert.Equal(t, []string{"--instance-type"}, envelope.Suggestions)
+		assert.Equal(t, "aliyun ecs describe-instances --help", envelope.Recovery.Command)
+		assert.False(t, envelope.Retryable)
+	})
+
+	t.Run("missing required parameters", func(t *testing.T) {
+		cause := &runtime.MissingRequiredError{Flags: []string{"--image-id", "--instance-type"}}
+		err := &engine.UsageError{Code: "MISSING_REQUIRED_PARAMETER", Err: cause}
+
+		envelope := agentEnvelope(t, err, "ecs", "run-instances")
+		assert.Equal(t, cli.UsageErrorCategory, envelope.Category)
+		assert.Equal(t, "MISSING_REQUIRED_PARAMETER", envelope.Code)
+		assert.Equal(t, cause.Error(), envelope.Message)
+		assert.Equal(t, []string{"--image-id", "--instance-type"}, envelope.Suggestions)
+		assert.Equal(t, "aliyun ecs run-instances --help", envelope.Recovery.Command)
+	})
+
+	t.Run("PascalCase invalid parameter", func(t *testing.T) {
+		err := &InvalidParameterError{
+			Name:              "InstnaceType",
+			ProductCode:       "ecs",
+			ApiName:           "RunInstances",
+			ParameterNames:    []string{"ImageId", "InstanceType"},
+			ParameterExamples: map[string]string{"InstanceType": "ecs.g6.large"},
+		}
+
+		envelope := agentEnvelope(t, err, "ecs", "RunInstances")
+		assert.Equal(t, cli.UsageErrorCategory, envelope.Category)
+		assert.Equal(t, "UNKNOWN_FLAG", envelope.Code)
+		assert.Equal(t, []string{"--InstanceType"}, envelope.Suggestions)
+		assert.NotContains(t, envelope.Suggestions[0], "example")
+		assert.Equal(t, "aliyun ecs RunInstances --help", envelope.Recovery.Command)
+	})
+
+	t.Run("PascalCase invalid API", func(t *testing.T) {
+		err := &InvalidApiError{
+			Name: "DescribeInstnaces",
+			product: &meta.Product{
+				Code:     "ecs",
+				ApiNames: []string{"DescribeImages", "DescribeInstances"},
+			},
+		}
+
+		envelope := agentEnvelope(t, err, "ecs", "DescribeInstnaces")
+		assert.Equal(t, cli.UsageErrorCategory, envelope.Category)
+		assert.Equal(t, "UNKNOWN_API", envelope.Code)
+		assert.Equal(t, []string{"DescribeInstances"}, envelope.Suggestions)
+		assert.Equal(t, "aliyun ecs --help", envelope.Recovery.Command)
+	})
+}
+
+func TestNormalizeAgentErrorCredentialFailure(t *testing.T) {
+	cause := errors.New("profile is not configured")
+	tests := []error{
+		&engine.CredentialError{Err: cause},
+		&credentialConfigurationError{Err: cause},
+	}
+
+	for _, err := range tests {
+		envelope := agentEnvelope(t, err, "ecs", "DescribeInstances")
+		assert.Equal(t, cli.AuthenticationErrorCategory, envelope.Category)
+		assert.Equal(t, "CREDENTIAL_NOT_CONFIGURED", envelope.Code)
+		assert.Equal(t, "aliyun configure", envelope.Recovery.Command)
+		assert.False(t, envelope.Retryable)
+	}
+}
+
+func TestNormalizeAgentErrorOldSDKFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		code      string
+		category  cli.AgentErrorCategory
+		retryable bool
+	}{
+		{name: "authentication", status: 401, code: "InvalidAccessKeyId.NotFound", category: cli.AuthenticationErrorCategory},
+		{name: "permission", status: 403, code: "Forbidden.RAM", category: cli.PermissionErrorCategory},
+		{name: "throttling", status: 429, code: "Throttling.User", category: cli.ThrottlingErrorCategory, retryable: true},
+		{name: "service", status: 500, code: "InternalError", category: cli.ServiceErrorCategory, retryable: true},
+		{name: "authentication code on 400", status: 400, code: "InvalidSecurityToken.Expired", category: cli.AuthenticationErrorCategory},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"RequestId":"old-%d","Code":%q,"Message":"structured message"}`, tt.status, tt.code)
+			err := sdkerrors.NewServerError(tt.status, body, "")
+			envelope := agentEnvelope(t, fmt.Errorf("call failed: %w", err), "ecs", "DescribeInstances")
+
+			assert.Equal(t, tt.category, envelope.Category)
+			assert.Equal(t, tt.code, envelope.Code)
+			assert.Equal(t, fmt.Sprintf("old-%d", tt.status), envelope.RequestID)
+			assert.Equal(t, "structured message", envelope.Message)
+			assert.Equal(t, tt.retryable, envelope.Retryable)
+			assert.Empty(t, envelope.Suggestions)
+		})
+	}
+}
+
+func TestNormalizeAgentErrorTeaSDKFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		code      string
+		category  cli.AgentErrorCategory
+		retryable bool
+	}{
+		{name: "authentication", status: 401, code: "Unauthorized", category: cli.AuthenticationErrorCategory},
+		{name: "permission", status: 403, code: "AccessDenied", category: cli.PermissionErrorCategory},
+		{name: "throttling", status: 429, code: "Throttling.Api", category: cli.ThrottlingErrorCategory, retryable: true},
+		{name: "service", status: 503, code: "ServiceUnavailable", category: cli.ServiceErrorCategory, retryable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tea.NewSDKError(map[string]interface{}{
+				"statusCode": tt.status,
+				"code":       tt.code,
+				"message":    "structured tea message",
+				"data":       map[string]interface{}{"requestId": fmt.Sprintf("tea-%d", tt.status)},
+			})
+			envelope := agentEnvelope(t, fmt.Errorf("runtime: %w", err), "ecs", "describe-instances")
+
+			assert.Equal(t, tt.category, envelope.Category)
+			assert.Equal(t, tt.code, envelope.Code)
+			assert.Equal(t, fmt.Sprintf("tea-%d", tt.status), envelope.RequestID)
+			assert.Equal(t, "structured tea message", envelope.Message)
+			assert.Equal(t, tt.retryable, envelope.Retryable)
+		})
+	}
+}
+
+func TestNormalizeAgentErrorNetworkAndUnknownFallback(t *testing.T) {
+	t.Run("temporary DNS failure", func(t *testing.T) {
+		err := &net.DNSError{Err: "temporary failure", Name: "ecs.aliyuncs.com", IsTemporary: true}
+		envelope := agentEnvelope(t, err, "ecs", "DescribeInstances")
+		assert.Equal(t, cli.NetworkErrorCategory, envelope.Category)
+		assert.Equal(t, "NETWORK_FAILURE", envelope.Code)
+		assert.True(t, envelope.Retryable)
+	})
+
+	t.Run("unknown text is never guessed", func(t *testing.T) {
+		err := errors.New("AccessDenied Throttling InvalidAccessKeyId")
+		envelope := agentEnvelope(t, err, "ecs", "DescribeInstances")
+		assert.Equal(t, cli.InternalErrorCategory, envelope.Category)
+		assert.Equal(t, "INTERNAL_ERROR", envelope.Code)
+		assert.Equal(t, err.Error(), envelope.Message)
+		assert.False(t, envelope.Retryable)
+	})
+}

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -15,15 +15,22 @@
 package openapi
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alibabacloud-go/tea/tea"
 	sdkerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
 	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
 	"github.com/aliyun/aliyun-openapi-runtime/argparser"
 	"github.com/aliyun/aliyun-openapi-runtime/engine"
 	runtime "github.com/aliyun/aliyun-openapi-runtime/runtime"
@@ -199,4 +206,139 @@ func TestNormalizeAgentErrorNetworkAndUnknownFallback(t *testing.T) {
 		assert.Equal(t, err.Error(), envelope.Message)
 		assert.False(t, envelope.Retryable)
 	})
+}
+
+func TestAgentErrorEnvelopeEndToEndForBothCommandStyles(t *testing.T) {
+	testHome := t.TempDir()
+	cleanupHome := setTestHomeDir(t, testHome)
+	defer cleanupHome()
+	writeMinimalConfigJSON(t, testHome)
+	require.NoError(t, os.MkdirAll(filepath.Join(testHome, ".aliyun", "plugins"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(testHome, ".aliyun", "plugins", "manifest.json"), []byte(`{"plugins":{}}`), 0644))
+	require.NoError(t, aimode.Save(filepath.Join(testHome, ".aliyun"), &aimode.AiConfig{Enabled: false}))
+
+	cli.DisableExitCode()
+	defer cli.EnableExitCode()
+
+	assertEnvelopeShape := func(t *testing.T, stderr string) map[string]interface{} {
+		t.Helper()
+		assert.Equal(t, 1, strings.Count(stderr, "\n"), "agent error must be one JSON line")
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(stderr), &decoded))
+		assert.ElementsMatch(t,
+			[]string{"ok", "category", "code", "message", "suggestions", "retryable", "requestId", "recovery"},
+			mapKeys(decoded))
+		return decoded
+	}
+
+	t.Run("kebab-case runtime", func(t *testing.T) {
+		originalDispatch := runtimeTryDispatch
+		runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+			unknown := &argparser.UnknownFlagError{Flag: "instnace-type", Known: []string{"image-id", "instance-type"}}
+			return true, &engine.UsageError{Code: "UNKNOWN_FLAG", Err: unknown}
+		}
+		defer func() { runtimeTryDispatch = originalDispatch }()
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd := &cli.Command{Name: "aliyun", EnableUnknownFlag: true}
+		config.AddFlags(cmd.Flags())
+		AddFlags(cmd.Flags())
+		commando := NewCommando(stdout, config.Profile{Language: "en"})
+		commando.InitWithCommand(cmd)
+		ctx := cli.NewCommandContext(stdout, stderr)
+		ctx.EnterCommand(cmd)
+
+		originalArgs := os.Args
+		os.Args = []string{"aliyun", "ecs", "describe-instances", "--instnace-type", "ecs.g6.large", "--cli-ai-mode"}
+		defer func() { os.Args = originalArgs }()
+		cmd.Execute(ctx, os.Args[1:])
+
+		assert.Empty(t, stdout.String())
+		decoded := assertEnvelopeShape(t, stderr.String())
+		assert.Equal(t, "USAGE_ERROR", decoded["category"])
+		assert.Equal(t, "UNKNOWN_FLAG", decoded["code"])
+		assert.Equal(t, []interface{}{"--instance-type"}, decoded["suggestions"])
+	})
+
+	t.Run("PascalCase legacy view", func(t *testing.T) {
+		product := meta.Product{
+			Code: "Ecs", Version: "2014-05-26", ApiStyle: "rpc", ApiNames: []string{"RunInstances"},
+		}
+		builtinRepo, err := meta.MockLoadRepository([]meta.Product{product})
+		require.NoError(t, err)
+		canonicalRepo := newFakeCanonicalRepo()
+		canonicalRepo.AddAPI("ecs", "2014-05-26", canonicalTestAPI(&testLegacyAPI{
+			Name: "RunInstances", Protocol: "HTTPS", Method: "POST",
+			Parameters: []testLegacyParameter{{Name: "InstanceType", Position: "Query", Type: "String"}},
+		}))
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		cmd := &cli.Command{Name: "aliyun", EnableUnknownFlag: true}
+		config.AddFlags(cmd.Flags())
+		AddFlags(cmd.Flags())
+		commando := NewCommando(stdout, config.Profile{Language: "en"})
+		commando.library = &Library{builtinRepo: builtinRepo, canonicalRepo: canonicalRepo}
+		commando.InitWithCommand(cmd)
+		ctx := cli.NewCommandContext(stdout, stderr)
+		ctx.EnterCommand(cmd)
+
+		originalArgs := os.Args
+		os.Args = []string{"aliyun", "ecs", "RunInstances", "--InstnaceType", "ecs.g6.large", "--endpoint", "ecs.aliyuncs.com", "--cli-ai-mode"}
+		defer func() { os.Args = originalArgs }()
+		cmd.Execute(ctx, os.Args[1:])
+
+		assert.Empty(t, stdout.String())
+		decoded := assertEnvelopeShape(t, stderr.String())
+		assert.Equal(t, "USAGE_ERROR", decoded["category"])
+		assert.Equal(t, "UNKNOWN_FLAG", decoded["code"])
+		assert.Equal(t, []interface{}{"--InstanceType"}, decoded["suggestions"])
+	})
+}
+
+func TestAgentErrorEnvelopeForcedOffKeepsHumanOutput(t *testing.T) {
+	testHome := t.TempDir()
+	cleanupHome := setTestHomeDir(t, testHome)
+	defer cleanupHome()
+	writeMinimalConfigJSON(t, testHome)
+	require.NoError(t, os.MkdirAll(filepath.Join(testHome, ".aliyun", "plugins"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(testHome, ".aliyun", "plugins", "manifest.json"), []byte(`{"plugins":{}}`), 0644))
+	require.NoError(t, aimode.Save(filepath.Join(testHome, ".aliyun"), &aimode.AiConfig{Enabled: true}))
+
+	originalDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		unknown := &argparser.UnknownFlagError{Flag: "instnace-type", Known: []string{"instance-type"}}
+		return true, &engine.UsageError{Code: "UNKNOWN_FLAG", Err: unknown}
+	}
+	defer func() { runtimeTryDispatch = originalDispatch }()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := &cli.Command{Name: "aliyun", EnableUnknownFlag: true}
+	config.AddFlags(cmd.Flags())
+	AddFlags(cmd.Flags())
+	commando := NewCommando(stdout, config.Profile{Language: "en"})
+	commando.InitWithCommand(cmd)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	cli.DisableExitCode()
+	defer cli.EnableExitCode()
+	originalArgs := os.Args
+	os.Args = []string{"aliyun", "ecs", "describe-instances", "--instnace-type", "ecs.g6.large", "--no-cli-ai-mode"}
+	defer func() { os.Args = originalArgs }()
+	cmd.Execute(ctx, os.Args[1:])
+
+	assert.Empty(t, stdout.String())
+	assert.Contains(t, stderr.String(), "ERROR: unknown flag --instnace-type")
+	assert.False(t, strings.HasPrefix(strings.TrimSpace(stderr.String()), "{"))
+}
+
+func mapKeys(values map[string]interface{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -16,6 +16,7 @@ package openapi
 import (
 	"bufio"
 	"bytes"
+	"errors"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
@@ -56,6 +57,22 @@ var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*respons
 
 var runtimeTryDispatch = runtimehost.TryDispatch
 
+var agentErrorNormalizer = func(err error, _ []string) error {
+	return err
+}
+
+type externalPluginError struct {
+	err error
+}
+
+func (e *externalPluginError) Error() string {
+	return e.err.Error()
+}
+
+func (e *externalPluginError) Unwrap() error {
+	return e.err
+}
+
 func NewCommando(w io.Writer, profile config.Profile) *Commando {
 	r := &Commando{
 		profile: profile,
@@ -89,9 +106,34 @@ func (c *Commando) printPluginIndexLoadFailureNote(ctx *cli.Context) {
 }
 
 func (c *Commando) InitWithCommand(cmd *cli.Command) {
-	cmd.Run = c.main
+	cmd.Run = c.run
 	cmd.Help = c.help
 	cmd.AutoComplete = c.complete
+}
+
+func (c *Commando) run(ctx *cli.Context, args []string) error {
+	return c.finishCommandRun(ctx, args, c.main(ctx, args))
+}
+
+func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var pluginErr *externalPluginError
+	if errors.As(err, &pluginErr) {
+		return pluginErr.err
+	}
+
+	cfg, loadErr := aimode.Load(config.GetConfigDir(ctx))
+	if loadErr != nil {
+		cfg = aimode.DefaultAiConfig()
+	}
+	forceOn, forceOff := CliAIOverrides(ctx.Flags())
+	if !aimode.EnabledForCommand(cfg, forceOn, forceOff) {
+		return err
+	}
+	return agentErrorNormalizer(err, args)
 }
 
 func DetectInConfigureMode(flags *cli.FlagSet) bool {
@@ -364,7 +406,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 
 			ok, err := plugin.ExecutePlugin(args[0], pluginArgs, ctx)
 			if err != nil {
-				return err
+				return &externalPluginError{err: err}
 			}
 			if !ok {
 				return fmt.Errorf("plugin %s not found", pluginName)

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -57,9 +57,7 @@ var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*respons
 
 var runtimeTryDispatch = runtimehost.TryDispatch
 
-var agentErrorNormalizer = func(err error, _ []string) error {
-	return err
-}
+var agentErrorNormalizer = normalizeAgentError
 
 type externalPluginError struct {
 	err error
@@ -307,7 +305,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				// profile 加载 / 校验失败必须 fail-fast，不要 silent 吞错。否则会停留在main.go 启动时的默认 profile，--profile xxx 的语义丢失，用户毫无感知。
 				profile, err := config.LoadProfileWithContext(ctx)
 				if err != nil {
-					return cli.NewErrorWithTip(err, "Configuration failed, use `aliyun configure` to configure it")
+					return cli.NewErrorWithTip(&credentialConfigurationError{Err: err}, "Configuration failed, use `aliyun configure` to configure it")
 				}
 				c.profile = profile
 				// 需要判断是否plugin auto install enabled, 且支持环境变量
@@ -362,7 +360,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 					envs, rtErr = c.profile.GetRuntimeEnv(ctx)
 					if rtErr != nil {
 						if profileRequired {
-							return cli.NewErrorWithTip(rtErr,
+							return cli.NewErrorWithTip(&credentialConfigurationError{Err: rtErr},
 								fmt.Sprintf("profile %q: failed to resolve credentials", c.profile.Name))
 						}
 						envs = config.BuildBaselineEnv(ctx)
@@ -370,9 +368,9 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				} else {
 					if profileRequired {
 						if profileErr != nil {
-							return cli.NewErrorWithTip(profileErr, "Configuration failed, use `aliyun configure` to configure it")
+							return cli.NewErrorWithTip(&credentialConfigurationError{Err: profileErr}, "Configuration failed, use `aliyun configure` to configure it")
 						}
-						return fmt.Errorf("profile not found, use `aliyun configure` to configure it")
+						return &credentialConfigurationError{Err: fmt.Errorf("profile not found, use `aliyun configure` to configure it")}
 					}
 					envs = config.BuildBaselineEnv(ctx)
 				}
@@ -426,11 +424,11 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 	var err error
 	c.profile, err = config.LoadProfileWithContext(ctx)
 	if err != nil {
-		return cli.NewErrorWithTip(err, "Configuration failed, use `aliyun configure` to configure it")
+		return cli.NewErrorWithTip(&credentialConfigurationError{Err: err}, "Configuration failed, use `aliyun configure` to configure it")
 	}
 	err = c.profile.Validate()
 	if err != nil {
-		return cli.NewErrorWithTip(err, "Configuration failed, use `aliyun configure` to configure it.")
+		return cli.NewErrorWithTip(&credentialConfigurationError{Err: err}, "Configuration failed, use `aliyun configure` to configure it.")
 	}
 	i18n.SetLanguage(c.profile.Language)
 

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -34,9 +34,72 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/config"
 	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/pluginsettings"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/safety"
 )
+
+func TestCommandoAgentModeNormalizesOnlyInProcessErrors(t *testing.T) {
+	sourceErr := errors.New("source")
+	normalizedErr := errors.New("normalized")
+	originalNormalizer := agentErrorNormalizer
+	agentErrorNormalizer = func(err error, args []string) error {
+		assert.ErrorIs(t, err, sourceErr)
+		assert.Equal(t, []string{"ecs", "describe-instances"}, args)
+		return normalizedErr
+	}
+	t.Cleanup(func() { agentErrorNormalizer = originalNormalizer })
+
+	newContext := func(t *testing.T, configured bool, forceOn bool, forceOff bool) *cli.Context {
+		t.Helper()
+		configDir := t.TempDir()
+		assert.NoError(t, aimode.Save(configDir, &aimode.AiConfig{Enabled: configured}))
+		ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+		configPath := config.NewConfigurePathFlag()
+		configPath.SetAssigned(true)
+		configPath.SetValue(filepath.Join(configDir, "config.json"))
+		ctx.Flags().Add(configPath)
+		if forceOn {
+			flag := NewCliAIModeFlag()
+			flag.SetAssigned(true)
+			ctx.Flags().Add(flag)
+		}
+		if forceOff {
+			flag := NewCliNoAIModeFlag()
+			flag.SetAssigned(true)
+			ctx.Flags().Add(flag)
+		}
+		return ctx
+	}
+
+	tests := []struct {
+		name       string
+		configured bool
+		forceOn    bool
+		forceOff   bool
+		want       error
+	}{
+		{name: "configured off", want: sourceErr},
+		{name: "configured on", configured: true, want: normalizedErr},
+		{name: "force on", forceOn: true, want: normalizedErr},
+		{name: "force off", configured: true, forceOff: true, want: sourceErr},
+		{name: "force off wins", configured: true, forceOn: true, forceOff: true, want: sourceErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newContext(t, tt.configured, tt.forceOn, tt.forceOff)
+			got := (&Commando{}).finishCommandRun(ctx, []string{"ecs", "describe-instances"}, sourceErr)
+			assert.ErrorIs(t, got, tt.want)
+		})
+	}
+
+	t.Run("external plugin bypasses normalization", func(t *testing.T) {
+		ctx := newContext(t, true, false, false)
+		got := (&Commando{}).finishCommandRun(ctx, []string{"fc", "invoke"}, &externalPluginError{err: sourceErr})
+		assert.Equal(t, sourceErr, got)
+	})
+}
 
 // setTestHomeDir sets the test home directory for cross-platform testing.
 // Returns a cleanup function that restores the original environment variables.

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -41,6 +41,17 @@ func (e *InvalidProductError) GetSuggestions() []string {
 	return sr.GetResults()
 }
 
+func (e *InvalidProductError) AgentSuggestions() []string {
+	if e.library == nil {
+		return nil
+	}
+	candidates := make([]string, 0)
+	for _, product := range e.library.GetProducts() {
+		candidates = append(candidates, strings.ToLower(product.Code))
+	}
+	return apiSuggestions(strings.ToLower(e.Code), candidates)
+}
+
 // return when use unknown api
 type InvalidApiError struct {
 	Name    string
@@ -57,6 +68,13 @@ func (e *InvalidApiError) GetSuggestions() []string {
 		sr.Apply(s)
 	}
 	return sr.GetResults()
+}
+
+func (e *InvalidApiError) AgentSuggestions() []string {
+	if e.product == nil {
+		return nil
+	}
+	return apiSuggestions(e.Name, e.product.ApiNames)
 }
 
 // return when use unknown parameter
@@ -92,6 +110,16 @@ func (e *InvalidParameterError) GetSuggestions() []string {
 		}
 	}
 	return results
+}
+
+func (e *InvalidParameterError) AgentSuggestions() []string {
+	candidates := append([]string(nil), e.ParameterNames...)
+	if e.flags != nil {
+		for _, flag := range e.flags.Flags() {
+			candidates = append(candidates, flag.Name)
+		}
+	}
+	return flagSuggestions(e.Name, candidates)
 }
 
 // NewInvalidParameterErrorFromCanonical creates error from canonical API
@@ -151,6 +179,14 @@ func (e *InvalidProductOrPluginError) GetSuggestions() []string {
 	return sr.GetResults()
 }
 
+func (e *InvalidProductOrPluginError) AgentSuggestions() []string {
+	candidates := make([]string, 0, len(e.plugins))
+	for _, product := range e.plugins {
+		candidates = append(candidates, strings.ToLower(product.ProductCode))
+	}
+	return apiSuggestions(strings.ToLower(e.Code), candidates)
+}
+
 type InvalidUnifiedApiError struct {
 	Name    string
 	product *meta.Product
@@ -171,6 +207,15 @@ func (e *InvalidUnifiedApiError) GetSuggestions() []string {
 	}
 	results := removeDuplicates(sr.GetResults())
 	return results
+}
+
+func (e *InvalidUnifiedApiError) AgentSuggestions() []string {
+	if e.product == nil {
+		return nil
+	}
+	candidates := append([]string(nil), e.product.ApiNames...)
+	candidates = append(candidates, e.lPlugin.CmdNames...)
+	return apiSuggestions(e.Name, candidates)
 }
 
 func removeDuplicates(slice []string) []string {

--- a/sysconfig/aimode/config.go
+++ b/sysconfig/aimode/config.go
@@ -150,21 +150,27 @@ func MergeAiModeIntoOssutilPayload(configDir string, envMap map[string]any, forc
 
 // RequestUserAgentSuffixForCommand applies per-invocation overrides from the root CLI
 func RequestUserAgentSuffixForCommand(cfg *AiConfig, forceOn, forceOff bool) string {
-	if forceOff {
+	if !EnabledForCommand(cfg, forceOn, forceOff) {
 		return ""
+	}
+	effective := DefaultAiConfig()
+	if cfg != nil {
+		effective.UserAgent = cfg.UserAgent
+	}
+	effective.Enabled = true
+	return RequestUserAgentSuffix(effective)
+}
+
+// EnabledForCommand resolves the effective AI mode for one command. A
+// command-level opt-out always wins, followed by opt-in and then configuration.
+func EnabledForCommand(cfg *AiConfig, forceOn, forceOff bool) bool {
+	if forceOff {
+		return false
 	}
 	if forceOn {
-		effective := DefaultAiConfig()
-		if cfg != nil {
-			effective.UserAgent = cfg.UserAgent
-		}
-		effective.Enabled = true
-		return RequestUserAgentSuffix(effective)
+		return true
 	}
-	if cfg == nil {
-		return ""
-	}
-	return RequestUserAgentSuffix(cfg)
+	return cfg != nil && cfg.Enabled
 }
 
 func MergeUserAgentIntoPluginEnvs(configDir string, envs map[string]string, forceOn, forceOff bool) {

--- a/sysconfig/aimode/config_test.go
+++ b/sysconfig/aimode/config_test.go
@@ -147,3 +147,26 @@ func TestRequestUserAgentSuffixForCommand(t *testing.T) {
 	assert.Contains(t, RequestUserAgentSuffixForCommand(&AiConfig{Enabled: false, UserAgent: "s"}, true, false), "s")
 	assert.Equal(t, "", RequestUserAgentSuffixForCommand(&AiConfig{Enabled: false}, false, false))
 }
+
+func TestEnabledForCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *AiConfig
+		forceOn  bool
+		forceOff bool
+		want     bool
+	}{
+		{name: "nil config", cfg: nil, want: false},
+		{name: "configured off", cfg: &AiConfig{Enabled: false}, want: false},
+		{name: "configured on", cfg: &AiConfig{Enabled: true}, want: true},
+		{name: "force on", cfg: &AiConfig{Enabled: false}, forceOn: true, want: true},
+		{name: "force off", cfg: &AiConfig{Enabled: true}, forceOff: true, want: false},
+		{name: "force off wins", cfg: &AiConfig{Enabled: true}, forceOn: true, forceOff: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EnabledForCommand(tt.cfg, tt.forceOn, tt.forceOff))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- emit one stable JSON error envelope on stderr for effective AI Mode, with semantic categories, exit codes, retryability, RequestId, suggestions, and recovery commands
- cover both in-process PascalCase and kebab-case OpenAPI commands while preserving structured runtime and SDK error facts
- keep normal human output unchanged; `--no-cli-ai-mode` wins and independent Go plugin process errors bypass host normalization

## Verification

- `go test -vet=off ./cli ./openapi/runtimehost ./sysconfig/aimode -count=1`
- `NO_COLOR=1 go test -vet=off ./openapi -skip '^TestPrintApiUsage_UnknownApi_PluginAvailableNotInstalled_Lowercase$' -count=1`
- `(cd aliyun-openapi-runtime && go test ./...)`
- `go build -o /private/tmp/aliyun-cli-agent-error ./main`

The skipped OpenAPI test is the documented pre-existing failure on `unify-meta-test`; all other OpenAPI package tests pass.
