### PR TITLE
fix: accept --api-version on legacy commands

### DIFF
--- a/aliyun-openapi-runtime/argparser/argparser_test.go
+++ b/aliyun-openapi-runtime/argparser/argparser_test.go
@@ -109,6 +109,24 @@ func TestScalarByOption(t *testing.T) {
 	}
 }
 
+func TestBusinessVersionParameterRemainsAPIArgument(t *testing.T) {
+	params := []meta.Parameter{{
+		Name: "version", RawName: "Version", Type: meta.TypeString,
+		Options: []string{"--version"},
+	}}
+
+	res, err := Parse(params, []string{"--version", "1.0.0"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := res.Args["Version"]; got != "1.0.0" {
+		t.Fatalf("Version = %#v", got)
+	}
+	if res.Reserved.Version != "" {
+		t.Fatalf("reserved API version = %q", res.Reserved.Version)
+	}
+}
+
 func TestOnlyOptionsAcceptedAsFlag(t *testing.T) {
 	for _, flag := range []string{"RegionId", "region-id"} {
 		_, err := Parse(schema(), []string{"--" + flag, "cn-beijing"})

--- a/openapi/flags.go
+++ b/openapi/flags.go
@@ -203,6 +203,7 @@ func NewVersionFlag() *cli.Flag {
 	return &cli.Flag{
 		Category:     "caller",
 		Name:         VersionFlagName,
+		Aliases:      []string{"api-version"},
 		AssignedMode: cli.AssignedOnce,
 		Short: i18n.T(
 			"use `--version <YYYY-MM-DD>` to assign product api version",

--- a/openapi/flags_test.go
+++ b/openapi/flags_test.go
@@ -14,6 +14,7 @@
 package openapi
 
 import (
+	"io"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -107,4 +108,33 @@ func TestAFlags(t *testing.T) {
 	on, off = CliAIOverrides(fs2)
 	assert.False(t, on)
 	assert.True(t, off)
+}
+
+func TestVersionFlagSupportsAPIVersionAlias(t *testing.T) {
+	ctx := cli.NewCommandContext(io.Discard, io.Discard)
+	ctx.Flags().Add(NewVersionFlag())
+
+	versionflag := VersionFlag(ctx.Flags())
+	assert.Equal(t, []string{"api-version"}, versionflag.Aliases)
+	assert.Same(t, versionflag, ctx.Flags().Get("api-version"))
+
+	parser := cli.NewParser([]string{"--api-version", "2014-05-26"}, ctx)
+	args, err := parser.ReadAll()
+	assert.NoError(t, err)
+	assert.Empty(t, args)
+	value, assigned := versionflag.GetValue()
+	assert.True(t, assigned)
+	assert.Equal(t, "2014-05-26", value)
+}
+
+func TestVersionFlagRejectsBothSpellings(t *testing.T) {
+	ctx := cli.NewCommandContext(io.Discard, io.Discard)
+	ctx.Flags().Add(NewVersionFlag())
+
+	parser := cli.NewParser([]string{
+		"--version", "2014-05-26",
+		"--api-version", "2020-01-01",
+	}, ctx)
+	_, err := parser.ReadAll()
+	assert.EqualError(t, err, "--version duplicated")
 }


### PR DESCRIPTION
## Summary

- accept `--api-version` as an alias of the legacy `--version` product API version flag
- keep both spellings backed by the same flag value and reject using both together
- preserve Canonical API business parameters named `--version`

## Test plan

- `go test -race -vet=off ./openapi -run <version-and-invoker-tests> -count=1`
- `cd aliyun-openapi-runtime && go test -race ./... -count=1`
- `go build ./main/main.go`

## Baseline note

The full OpenAPI package suite currently has a pre-existing failure in `TestPrintApiUsage_UnknownApi_PluginAvailableNotInstalled_Lowercase`; the same failure reproduces at the target branch commit. The version, invoker, runtimehost, and embedded runtime suites affected by this change pass.