### PR TITLE
feat: add machine-readable Help JSON v1

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -360,6 +360,19 @@ aliyun rds DescribeDBInstanceAttribute --DBInstanceId xxxxxx
 
   如获取 ECS 的 CreateInstance 的信息： `aliyun help ecs CreateInstance`
 
+#### 面向 Agent 的结构化帮助
+
+使用 `--help=json`，或者等价的 `help ... --format json`，可以把本地内置的 Canonical 元数据读取为稳定的 JSON：
+
+```sh
+aliyun --help=json
+aliyun help ecs --format json
+aliyun help ecs DescribeInstances --format json
+aliyun ecs describe-instances --help=json
+```
+
+根命令、产品、传统大驼峰 API 和烤串风 API 均受支持。当前协议版本为 `schemaVersion: "v1"`，无需凭证，也不会访问网络。API 文档会同时返回两种命令风格的参数树；当前来源中没有的 `outputSchema`、`pagination`、`risk`、`recovery` 固定输出为 `null`。
+
 ### 使用`--force`参数
 
 阿里云 CLI 集成了一部分云产品的元数据，在调用时会对参数的合法性进行检查。如果使用了一个元数据中未包含的API或参数会导致`unknown api`或`unknown parameter`错误。可以使用`--force`参数跳过API和参数检查，强制调用元数据列表外的API和参数，如:

--- a/README.md
+++ b/README.md
@@ -392,6 +392,19 @@ Alibaba Cloud CLI integrates API descriptions for some products, you can get hel
 
  For example, get the help information of the CreateInstance API: `aliyun help ecs CreateInstance`
 
+#### Machine-readable help for Agents
+
+Pass `--help=json`, or use the equivalent `help ... --format json` form, to read the locally bundled Canonical metadata as stable JSON:
+
+```sh
+aliyun --help=json
+aliyun help ecs --format json
+aliyun help ecs DescribeInstances --format json
+aliyun ecs describe-instances --help=json
+```
+
+Root, product, legacy PascalCase API, and kebab-case API help are supported. The current contract uses `schemaVersion: "v1"` and does not require credentials or network access. API documents expose both command-style parameter trees; source data not currently available for `outputSchema`, `pagination`, `risk`, and `recovery` is emitted as `null`.
+
 ### Use the `--force` option
 
 Alibaba Cloud CLI integrates the product metadata of some products. It will validate API parameters when calling the API. If an API or a parameter that is not included in the metadata is used, an error `unknown api` or `unknown parameter` will be returned. You can use the `--force` option to skip the validation and call the API by force as shown in the following example:

--- a/canonicalmeta/canonical_test.go
+++ b/canonicalmeta/canonical_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/fs"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -70,6 +71,66 @@ func TestReadAPI_CreateReport(t *testing.T) {
 	bodyParam := (*api.V1BodyParameters)[0]
 	if bodyParam.Name != "body" {
 		t.Errorf("expected body param name=body, got %s", bodyParam.Name)
+	}
+}
+
+func TestReadProducts(t *testing.T) {
+	catalog, err := testFS().GetProducts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Products) != 1 {
+		t.Fatalf("expected 1 product, got %d", len(catalog.Products))
+	}
+	product := catalog.Products[0]
+	if product.Code != "demo" {
+		t.Fatalf("expected code demo, got %s", product.Code)
+	}
+	if product.Version != "2026-01-01" {
+		t.Fatalf("expected legacy default 2026-01-01, got %s", product.Version)
+	}
+	if product.PluginDefaultVersion != "2025-01-01" {
+		t.Fatalf("expected plugin default 2025-01-01, got %s", product.PluginDefaultVersion)
+	}
+	wantVersions := []string{"2025-01-01", "2026-01-01"}
+	if !slices.Equal(product.Versions, wantVersions) {
+		t.Fatalf("versions = %#v, want %#v", product.Versions, wantVersions)
+	}
+}
+
+func TestReadVersionIndex(t *testing.T) {
+	index, err := testFS().GetVersionIndex("demo", "2026-01-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if index.Version != "2026-01-01" {
+		t.Fatalf("version = %s", index.Version)
+	}
+	entry, ok := index.APIs["DescribeRegions"]
+	if !ok {
+		t.Fatal("DescribeRegions is missing")
+	}
+	if entry.CmdName != "describe-regions" {
+		t.Fatalf("cmd_name = %s", entry.CmdName)
+	}
+}
+
+func TestReadAPICompleteHelpFields(t *testing.T) {
+	api, err := testFS().GetAPI("demo", "2026-01-01", "CreateReport")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if api.CmdName != "create-report" {
+		t.Fatalf("cmd_name = %s", api.CmdName)
+	}
+	if api.Operation == nil {
+		t.Fatal("operation is nil")
+	}
+	if api.Operation.APIVersion != "2026-01-01" {
+		t.Fatalf("api_version = %s", api.Operation.APIVersion)
+	}
+	if len(api.Parameters) == 0 || !slices.Equal(api.Parameters[0].Options, []string{"--report-id"}) {
+		t.Fatalf("options = %#v", api.Parameters[0].Options)
 	}
 }
 

--- a/canonicalmeta/reader.go
+++ b/canonicalmeta/reader.go
@@ -18,6 +18,57 @@ func NewReader(fsys fs.FS) *Reader {
 	return &Reader{fs: fsys}
 }
 
+// ReadProducts reads the Canonical product catalog.
+func (r *Reader) ReadProducts() (*ProductsIndex, error) {
+	paths := []string{
+		"metadatas/products.json",
+		"canonical/metadatas/products.json",
+	}
+	var lastErr error
+	for _, candidate := range paths {
+		data, err := fs.ReadFile(r.fs, candidate)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				lastErr = err
+				continue
+			}
+			return nil, fmt.Errorf("read canonical products %s failed: %w", candidate, err)
+		}
+		var products ProductsIndex
+		if err := json.Unmarshal(data, &products); err != nil {
+			return nil, fmt.Errorf("parse canonical products %s failed: %w", candidate, err)
+		}
+		return &products, nil
+	}
+	return nil, fmt.Errorf("read canonical products failed: %w", lastErr)
+}
+
+// ReadVersionIndex reads one product/version index.
+func (r *Reader) ReadVersionIndex(product, version string) (*VersionIndex, error) {
+	lower := strings.ToLower(product)
+	paths := []string{
+		fmt.Sprintf("canonical/%s/%s/version.json", lower, version),
+		fmt.Sprintf("canonical/%s/canonical/%s/%s/version.json", lower, lower, version),
+	}
+	var lastErr error
+	for _, candidate := range paths {
+		data, err := fs.ReadFile(r.fs, candidate)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				lastErr = err
+				continue
+			}
+			return nil, fmt.Errorf("read canonical version index %s failed: %w", candidate, err)
+		}
+		var index VersionIndex
+		if err := json.Unmarshal(data, &index); err != nil {
+			return nil, fmt.Errorf("parse canonical version index %s failed: %w", candidate, err)
+		}
+		return &index, nil
+	}
+	return nil, fmt.Errorf("read canonical version index for %s/%s failed: %w", lower, version, lastErr)
+}
+
 // ReadAPI reads a single Canonical API JSON file.
 // Product directory names are always lowercase.
 func (r *Reader) ReadAPI(product, version, apiName string) (*API, error) {

--- a/canonicalmeta/repository.go
+++ b/canonicalmeta/repository.go
@@ -24,6 +24,16 @@ func (r *Repository) GetAPI(product, version, apiName string) (*API, error) {
 	return r.reader.ReadAPI(product, version, apiName)
 }
 
+// GetProducts returns the Canonical product catalog.
+func (r *Repository) GetProducts() (*ProductsIndex, error) {
+	return r.reader.ReadProducts()
+}
+
+// GetVersionIndex returns the lightweight API index for one product version.
+func (r *Repository) GetVersionIndex(product, version string) (*VersionIndex, error) {
+	return r.reader.ReadVersionIndex(product, version)
+}
+
 // GetAPIByPath finds a Canonical API by matching method and path pattern.
 // Used for ROA-style APIs where the API is identified by HTTP method + URL path.
 func (r *Repository) GetAPIByPath(product, version, method, path string, apiNames []string) (*API, error) {

--- a/canonicalmeta/testdata/canonical/demo/2025-01-01/version.json
+++ b/canonicalmeta/testdata/canonical/demo/2025-01-01/version.json
@@ -1,0 +1,12 @@
+{
+  "apis": {
+    "DescribeRegions": {
+      "cmd_name": "describe-regions",
+      "deprecated": false,
+      "description_zh": "查询地域列表。",
+      "description_en": "Queries regions."
+    }
+  },
+  "style": "ROA",
+  "version": "2025-01-01"
+}

--- a/canonicalmeta/testdata/canonical/demo/2026-01-01/version.json
+++ b/canonicalmeta/testdata/canonical/demo/2026-01-01/version.json
@@ -1,0 +1,18 @@
+{
+  "apis": {
+    "CreateReport": {
+      "cmd_name": "create-report",
+      "deprecated": false,
+      "description_zh": "创建报表。",
+      "description_en": "Creates a report."
+    },
+    "DescribeRegions": {
+      "cmd_name": "describe-regions",
+      "deprecated": false,
+      "description_zh": "查询地域列表。",
+      "description_en": "Queries regions."
+    }
+  },
+  "style": "ROA",
+  "version": "2026-01-01"
+}

--- a/canonicalmeta/testdata/metadatas/products.json
+++ b/canonicalmeta/testdata/metadatas/products.json
@@ -1,0 +1,23 @@
+{
+  "products": [
+    {
+      "code": "demo",
+      "name": {
+        "en": "Demo Service",
+        "zh": "演示服务"
+      },
+      "api_style": "restful",
+      "version": "2026-01-01",
+      "plugin_default_version": "2025-01-01",
+      "versions": [
+        "2025-01-01",
+        "2026-01-01"
+      ],
+      "apis": [
+        "CreateReport",
+        "DescribeRegions"
+      ],
+      "distribution": "meta"
+    }
+  ]
+}

--- a/canonicalmeta/types.go
+++ b/canonicalmeta/types.go
@@ -3,24 +3,80 @@ package canonicalmeta
 // API represents a Canonical API JSON file.
 // Fields not needed by the old CLI are omitted from deserialization.
 type API struct {
-	Name        string `json:"name"`
-	Deprecated  bool   `json:"deprecated,omitempty"`
-	Protocol    string `json:"protocol"`
-	Method      string `json:"method"`
-	PathPattern string `json:"pathPattern"`
+	Name         string `json:"name"`
+	CmdName      string `json:"cmd_name,omitempty"`
+	CmdFullName  string `json:"cmd_full_name,omitempty"`
+	ProductCode  string `json:"product_code,omitempty"`
+	MultiVersion bool   `json:"multi_version,omitempty"`
+	Deprecated   bool   `json:"deprecated,omitempty"`
+	Protocol     string `json:"protocol"`
+	Method       string `json:"method"`
+	PathPattern  string `json:"pathPattern"`
 
 	Security []string `json:"security,omitempty"`
 
 	DescriptionZh string `json:"description_zh,omitempty"`
 	DescriptionEn string `json:"description_en,omitempty"`
 
-	CamelExample string `json:"camel_example,omitempty"`
-	KebabExample string `json:"kebab_example,omitempty"`
+	CamelExample string     `json:"camel_example,omitempty"`
+	KebabExample string     `json:"kebab_example,omitempty"`
+	Operation    *Operation `json:"operation,omitempty"`
 
 	Parameters []Parameter `json:"parameters"`
 
 	V1Parameters     *[]V1Parameter `json:"v1_parameters,omitempty"`
 	V1BodyParameters *[]V1Parameter `json:"v1_body_parameters,omitempty"`
+}
+
+// Operation describes the selected HTTP operation for the Canonical command.
+type Operation struct {
+	Action          string            `json:"action,omitempty"`
+	APIStyle        string            `json:"api_style,omitempty"`
+	APIVersion      string            `json:"api_version,omitempty"`
+	Method          string            `json:"method,omitempty"`
+	Protocol        string            `json:"protocol,omitempty"`
+	URL             string            `json:"url,omitempty"`
+	IsSSE           bool              `json:"is_sse,omitempty"`
+	ReqBodyType     string            `json:"req_body_type,omitempty"`
+	ContentType     string            `json:"content_type,omitempty"`
+	HasWildcardPath bool              `json:"has_wildcard_path,omitempty"`
+	BodyMapping     map[string]string `json:"body_mapping,omitempty"`
+}
+
+// ProductsIndex is the product catalog stored in metadatas/products.json.
+type ProductsIndex struct {
+	Products []ProductEntry `json:"products"`
+}
+
+// ProductEntry contains product identity, versions, endpoints, and distribution.
+type ProductEntry struct {
+	Code                 string            `json:"code"`
+	Name                 map[string]string `json:"name"`
+	APIStyle             string            `json:"api_style"`
+	GlobalEndpoint       string            `json:"global_endpoint"`
+	RegionalEndpoints    map[string]string `json:"regional_endpoints"`
+	RegionalVPCEndpoints map[string]string `json:"regional_vpc_endpoints"`
+	LocationServiceCode  string            `json:"location_service_code"`
+	PluginDefaultVersion string            `json:"plugin_default_version"`
+	Version              string            `json:"version"`
+	Versions             []string          `json:"versions"`
+	APIs                 []string          `json:"apis"`
+	Distribution         string            `json:"distribution,omitempty"`
+}
+
+// VersionIndex is the lightweight API index stored beside per-API JSON files.
+type VersionIndex struct {
+	APIs    map[string]VersionAPIEntry `json:"apis"`
+	Style   string                     `json:"style"`
+	Version string                     `json:"version"`
+}
+
+// VersionAPIEntry is one API entry in version.json.
+type VersionAPIEntry struct {
+	CmdName       string `json:"cmd_name"`
+	Deprecated    bool   `json:"deprecated"`
+	DescriptionZh string `json:"description_zh"`
+	DescriptionEn string `json:"description_en"`
 }
 
 // Description returns the API-level description for the given language.
@@ -52,15 +108,16 @@ type TypeShape struct {
 
 // Parameter represents a Canonical API parameter.
 type Parameter struct {
-	Name       string `json:"name"`
-	RawName    string `json:"raw_name"`
-	Type       string `json:"type"`
-	Required   bool   `json:"required"`
-	Location   string `json:"location"`
-	ParamStyle string `json:"param_style,omitempty"`
-	IsWildcard bool   `json:"is_wildcard,omitempty"`
-	Format     string `json:"format,omitempty"`
-	Example    string `json:"example,omitempty"`
+	Name       string   `json:"name"`
+	RawName    string   `json:"raw_name"`
+	Type       string   `json:"type"`
+	Required   bool     `json:"required"`
+	Location   string   `json:"location"`
+	ParamStyle string   `json:"param_style,omitempty"`
+	IsWildcard bool     `json:"is_wildcard,omitempty"`
+	Format     string   `json:"format,omitempty"`
+	Example    string   `json:"example,omitempty"`
+	Options    []string `json:"options,omitempty"`
 
 	DescriptionZh string `json:"description_zh,omitempty"`
 	DescriptionEn string `json:"description_en,omitempty"`

--- a/cli/command.go
+++ b/cli/command.go
@@ -345,6 +345,12 @@ func (c *Command) executeInner(ctx *Context, args []string) error {
 }
 
 func (c *Command) processError(ctx *Context, err error) {
+	if e, ok := err.(StructuredError); ok {
+		_ = e.RenderError(ctx.Stderr())
+		Exit(e.ExitCode())
+		return
+	}
+
 	Errorf(ctx.Stderr(), "ERROR: %s\n", err.Error())
 	exitCode := 1
 	if e, ok := err.(SuggestibleError); ok {

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -17,11 +17,23 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/stretchr/testify/assert"
 )
+
+type structuredTestError struct{}
+
+func (structuredTestError) Error() string { return "fallback" }
+
+func (structuredTestError) RenderError(w io.Writer) error {
+	_, err := io.WriteString(w, "{\"schemaVersion\":\"v1\",\"error\":{\"code\":\"TEST\"}}\n")
+	return err
+}
+
+func (structuredTestError) ExitCode() int { return 2 }
 
 func TestCommand(t *testing.T) {
 	cmd := &Command{
@@ -220,6 +232,20 @@ func TestProcessError(t *testing.T) {
 	err := NewErrorWithTip(e, "")
 	cmd.processError(ctx, err)
 	assert.Equal(t, "\x1b[1;31mERROR: test error tip\n\x1b[0m\x1b[1;33m\n\n\x1b[0m", buf2.String())
+}
+
+func TestProcessStructuredError(t *testing.T) {
+	DisableExitCode()
+	defer EnableExitCode()
+	cmd := newAliyunCmd()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := NewCommandContext(stdout, stderr)
+
+	cmd.processError(ctx, structuredTestError{})
+
+	assert.Equal(t, "{\"schemaVersion\":\"v1\",\"error\":{\"code\":\"TEST\"}}\n", stderr.String())
+	assert.Empty(t, stdout.String())
 }
 
 func TestExecuteHelp(t *testing.T) {

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -15,8 +15,17 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"strings"
 )
+
+// StructuredError renders a machine-readable error without the decorations
+// used by the interactive error path.
+type StructuredError interface {
+	error
+	RenderError(io.Writer) error
+	ExitCode() int
+}
 
 // If command.Execute return Noticeable error, print i18n Notice under error information
 type ErrorWithTip interface {

--- a/docs/superpowers/plans/2026-08-18-agentic-help-json-v1.md
+++ b/docs/superpowers/plans/2026-08-18-agentic-help-json-v1.md
@@ -1,0 +1,417 @@
+# Agentic Help JSON v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add stable, offline, machine-readable root/product/API help through both `--help=json` and `aliyun help ... --format json` on top of the unified Canonical metadata branch.
+
+**Architecture:** Normalize both public syntaxes into the existing help path with a hidden internal format flag. Project Canonical catalog, version index, API, legacy parameter view, and static command metadata into dedicated Help v1 DTOs; do not serialize internal structs directly. Structured machine-help errors are rendered as JSON on stderr with non-zero exit codes.
+
+**Tech Stack:** Go 1.25, aliyun CLI command framework, `encoding/json`, `io/fs`, Canonical JSON metadata, Go tests with `testing` and `testify`.
+
+---
+
+## File map
+
+- Create `openapi/machine_help_args.go`: recognize and normalize the two public machine-help syntaxes.
+- Create `openapi/machine_help_args_test.go`: parser compatibility and normalization tests.
+- Create `openapi/machine_help.go`: Help v1 DTOs, root/product/API projection, deterministic JSON rendering, and structured errors.
+- Create `openapi/machine_help_test.go`: contract, parameter-tree, version, error, and offline tests.
+- Modify `openapi/flags.go`: register the hidden internal help-format flag.
+- Modify `openapi/commando.go`: dispatch machine help before text-help/plugin loading.
+- Modify `main/main.go`: normalize raw argv before the root parser.
+- Modify `main/main_test.go`: command-level coverage for both public syntaxes.
+- Modify `canonicalmeta/types.go`: expose the Canonical fields needed by Help v1 without changing legacy projections.
+- Modify `canonicalmeta/reader.go`: read the product catalog and version indexes.
+- Modify `canonicalmeta/repository.go`: provide query methods used by the Help service.
+- Modify `canonicalmeta/canonical_test.go`: validate the new readers and complete API decoding.
+- Modify `canonicalmeta/testdata/metadatas/products.json`: deterministic product fixture.
+- Modify `canonicalmeta/testdata/canonical/demo/2026-01-01/version.json`: deterministic version-index fixture.
+- Modify `meta/product.go`: retain `plugin_default_version`, `versions`, and `distribution` already present in `products.json`.
+- Modify `cli/errors.go` and `cli/command.go`: allow a command error to render its own machine-readable payload.
+- Modify `cli/command_test.go`: prove existing text errors remain unchanged and JSON errors use the structured path.
+- Modify `README.md` and `README-CN.md`: document the public Help v1 entry points.
+
+### Task 1: Normalize the two public command syntaxes
+
+**Files:**
+- Create: `openapi/machine_help_args.go`
+- Create: `openapi/machine_help_args_test.go`
+- Modify: `openapi/flags.go`
+- Modify: `main/main.go`
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Cover these exact cases:
+
+```go
+func TestNormalizeMachineHelpArgs(t *testing.T) {
+    tests := []struct {
+        name string
+        in   []string
+        want []string
+    }{
+        {"root equals", []string{"--help=json"}, []string{"--help", "--help-format", "json"}},
+        {"api equals", []string{"ecs", "describe-instances", "--help=json"}, []string{"ecs", "describe-instances", "--help", "--help-format", "json"}},
+        {"help command", []string{"help", "ecs", "DescribeInstances", "--format", "json"}, []string{"ecs", "DescribeInstances", "--help", "--help-format", "json"}},
+        {"text unchanged", []string{"help", "ecs"}, []string{"help", "ecs"}},
+        {"ordinary format unchanged", []string{"ecs", "Call", "--format", "json"}, []string{"ecs", "Call", "--format", "json"}},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.want, NormalizeMachineHelpArgs(tt.in))
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `go test ./openapi -run TestNormalizeMachineHelpArgs -count=1`
+
+Expected: compile failure because `NormalizeMachineHelpArgs` does not exist.
+
+- [ ] **Step 3: Implement minimal normalization and hidden flag**
+
+Add `MachineHelpFormatFlagName = "help-format"`, a hidden persistent `AssignedOnce` flag, and a normalizer that:
+
+```go
+func NormalizeMachineHelpArgs(args []string) []string {
+    // Copy input, rewrite only exact --help=<value>, or a leading
+    // `help` command containing --format=<value>/--format <value>.
+    // Plain text-help argv and ordinary API --format parameters remain untouched.
+}
+```
+
+Call it in `main.Main` immediately before `rootCmd.Execute(ctx, args)`.
+
+- [ ] **Step 4: Run targeted tests and verify GREEN**
+
+Run: `go test ./openapi ./main -run 'TestNormalizeMachineHelpArgs|TestMainWithNoArgs' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openapi/machine_help_args.go openapi/machine_help_args_test.go openapi/flags.go main/main.go
+git commit -m "feat: normalize machine help arguments"
+```
+
+### Task 2: Expose complete Canonical read models
+
+**Files:**
+- Modify: `canonicalmeta/types.go`
+- Modify: `canonicalmeta/reader.go`
+- Modify: `canonicalmeta/repository.go`
+- Modify: `canonicalmeta/canonical_test.go`
+- Create: `canonicalmeta/testdata/metadatas/products.json`
+- Create: `canonicalmeta/testdata/canonical/demo/2026-01-01/version.json`
+- Modify: `meta/product.go`
+
+- [ ] **Step 1: Write failing catalog, index, and API decoding tests**
+
+Tests assert:
+
+```go
+catalog, err := testFS().GetProducts()
+require.NoError(t, err)
+assert.Equal(t, "2025-01-01", catalog.Products[0].PluginDefaultVersion)
+assert.Equal(t, []string{"2025-01-01", "2026-01-01"}, catalog.Products[0].Versions)
+
+index, err := testFS().GetVersionIndex("demo", "2026-01-01")
+require.NoError(t, err)
+assert.Equal(t, "describe-regions", index.APIs["DescribeRegions"].CmdName)
+
+api, err := testFS().GetAPI("demo", "2026-01-01", "CreateReport")
+require.NoError(t, err)
+assert.Equal(t, "create-report", api.CmdName)
+assert.Equal(t, "2026-01-01", api.Operation.APIVersion)
+assert.Equal(t, []string{"--report-id"}, api.Parameters[0].Options)
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `go test ./canonicalmeta -run 'TestReadProducts|TestReadVersionIndex|TestReadAPICompleteHelpFields' -count=1`
+
+Expected: compile failures for missing catalog/index methods and fields.
+
+- [ ] **Step 3: Add read models and readers**
+
+Add explicit structs for `ProductsIndex`, `ProductEntry`, `VersionIndex`, `VersionAPIEntry`, and `Operation`, plus complete Help-facing fields on `API` and `Parameter`. Add:
+
+```go
+func (r *Reader) ReadProducts() (*ProductsIndex, error)
+func (r *Reader) ReadVersionIndex(product, version string) (*VersionIndex, error)
+func (r *Repository) GetProducts() (*ProductsIndex, error)
+func (r *Repository) GetVersionIndex(product, version string) (*VersionIndex, error)
+```
+
+Use the existing spec path first and retain the current nested-layout fallback. Extend legacy `meta.Product` only with JSON-backed fields:
+
+```go
+PluginDefaultVersion string   `json:"plugin_default_version"`
+Versions             []string `json:"versions"`
+Distribution         string   `json:"distribution,omitempty"`
+```
+
+- [ ] **Step 4: Run canonical and meta tests**
+
+Run: `go test ./canonicalmeta ./meta -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add canonicalmeta meta/product.go
+git commit -m "feat: expose canonical help metadata"
+```
+
+### Task 3: Implement the stable Help v1 projection
+
+**Files:**
+- Create: `openapi/machine_help.go`
+- Create: `openapi/machine_help_test.go`
+
+- [ ] **Step 1: Write failing root and product contract tests**
+
+Use an in-memory/fstest Canonical repository and a small static root command. Decode JSON into maps only at the assertion boundary and verify stable DTO fields:
+
+```go
+assert.Equal(t, "v1", doc.SchemaVersion)
+assert.Equal(t, "root", doc.Kind)
+assert.Equal(t, []string{"aliyun"}, doc.Target.Path)
+assert.Equal(t, []string{"configure", "plugin"}, commandNames(doc.Commands))
+
+assert.Equal(t, "product", productDoc.Kind)
+assert.Equal(t, "2026-01-01", productDoc.Product.LegacyDefaultVersion)
+assert.Equal(t, "2025-01-01", productDoc.Product.PluginDefaultVersion)
+assert.Equal(t, "2025-01-01", productDoc.Product.SelectedVersion)
+assert.Equal(t, "describe-regions", productDoc.APIs[0].CmdName)
+```
+
+- [ ] **Step 2: Run root/product tests and verify RED**
+
+Run: `go test ./openapi -run 'TestMachineHelpRoot|TestMachineHelpProduct' -count=1`
+
+Expected: compile failure because the Help v1 service and DTOs do not exist.
+
+- [ ] **Step 3: Implement root and product DTO projection**
+
+Define explicit JSON structs headed by:
+
+```go
+type machineHelpEnvelope struct {
+    SchemaVersion string            `json:"schemaVersion"`
+    Kind          string            `json:"kind"`
+    Target        machineHelpTarget `json:"target"`
+}
+```
+
+Sort command names, products, versions, and API index entries before marshaling. Product help selects explicit version first, otherwise `plugin_default_version`, then legacy `version`, then the first sorted supported version.
+
+- [ ] **Step 4: Run root/product tests and verify GREEN**
+
+Run: `go test ./openapi -run 'TestMachineHelpRoot|TestMachineHelpProduct' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing API and parameter-tree tests**
+
+Assert both command styles resolve the same Canonical identity at the same selected version while retaining their active projection:
+
+```go
+assert.Equal(t, "CreateReport", camelDoc.API.Name)
+assert.Equal(t, "CreateReport", kebabDoc.API.Name)
+assert.Equal(t, "camel", camelDoc.ActiveParameterSet)
+assert.Equal(t, "kebab", kebabDoc.ActiveParameterSet)
+assert.Equal(t, "--body", camelDoc.ParameterSets.Camel[0].Option)
+assert.Equal(t, "--report-id", kebabDoc.ParameterSets.Kebab[0].Options[0])
+assert.Nil(t, kebabDoc.OutputSchema)
+assert.Nil(t, kebabDoc.Pagination)
+assert.Nil(t, kebabDoc.Risk)
+assert.Nil(t, kebabDoc.Recovery)
+```
+
+Add recursive fixtures/assertions for repeat-list object fields, array element shapes, map values, body compatibility parameters, descriptions, and both examples.
+
+- [ ] **Step 6: Run API tests and verify RED**
+
+Run: `go test ./openapi -run 'TestMachineHelpAPI|TestMachineHelpNestedParameters' -count=1`
+
+Expected: failures because API projection is not implemented.
+
+- [ ] **Step 7: Implement API resolution and recursive projection**
+
+Resolve PascalCase by API index key and kebab-case by `cmd_name`. Build both parameter sets for every API:
+
+```go
+type machineHelpParameterSets struct {
+    Camel []machineHelpParameter `json:"camel"`
+    Kebab []machineHelpParameter `json:"kebab"`
+}
+```
+
+Use `LegacyTopLevelParameters()` recursively for camel and Canonical `Parameters`/`Fields`/`Element`/`Value` recursively for kebab. Emit both examples and explicit null fields without `omitempty`.
+
+- [ ] **Step 8: Run all machine-help tests and verify GREEN**
+
+Run: `go test ./openapi -run TestMachineHelp -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add openapi/machine_help.go openapi/machine_help_test.go
+git commit -m "feat: add help json v1 projection"
+```
+
+### Task 4: Wire machine help and structured JSON errors
+
+**Files:**
+- Modify: `cli/errors.go`
+- Modify: `cli/command.go`
+- Modify: `cli/command_test.go`
+- Modify: `openapi/commando.go`
+- Modify: `openapi/machine_help.go`
+- Modify: `openapi/machine_help_test.go`
+- Modify: `main/main_test.go`
+
+- [ ] **Step 1: Write failing structured-error tests**
+
+Define the desired seam in tests:
+
+```go
+type structuredTestError struct{}
+func (structuredTestError) Error() string { return "fallback" }
+func (structuredTestError) RenderError(w io.Writer) error {
+    _, err := io.WriteString(w, `{"schemaVersion":"v1","error":{"code":"TEST"}}`+"\n")
+    return err
+}
+func (structuredTestError) ExitCode() int { return 2 }
+```
+
+Verify `processError` writes only the JSON payload for this interface, while the existing `errors.New("test")` output remains byte-for-byte unchanged.
+
+- [ ] **Step 2: Run CLI test and verify RED**
+
+Run: `go test ./cli -run 'TestProcessStructuredError|TestProcessError' -count=1`
+
+Expected: structured error receives the old `ERROR:` prefix until the new interface is handled.
+
+- [ ] **Step 3: Implement the structured error seam**
+
+Add:
+
+```go
+type StructuredError interface {
+    error
+    RenderError(io.Writer) error
+    ExitCode() int
+}
+```
+
+At the top of `Command.processError`, render a `StructuredError` directly to stderr, call `Exit` with its code, and return. Leave the existing path untouched.
+
+- [ ] **Step 4: Write failing wiring and end-to-end tests**
+
+Tests must prove:
+
+- machine help is handled before `Commando.loadPlugins`, so no remote catalog call is attempted;
+- `aliyun --help=json`, root help command syntax, product help, PascalCase API help, and kebab API help produce JSON;
+- unknown product/API and invalid format produce JSON on stderr with non-zero exit;
+- plain text help snapshots remain unchanged;
+- no API execution hook, credential load, or plugin install hook is invoked.
+
+- [ ] **Step 5: Run wiring tests and verify RED**
+
+Run: `go test ./openapi ./main -run 'TestMachineHelp|TestMainMachineHelp' -count=1`
+
+Expected: failures because `Commando.help` still enters text help.
+
+- [ ] **Step 6: Wire the machine-help renderer**
+
+At the start of `Commando.help`, before `loadPlugins`, read the hidden format flag and call the Help v1 service. Convert lookup/validation failures to a structured machine-help error containing `schemaVersion`, stable code, message, target, and sorted suggestions.
+
+- [ ] **Step 7: Run targeted package tests and verify GREEN**
+
+Run: `go test ./cli ./canonicalmeta ./meta ./openapi ./main -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli openapi main
+git commit -m "feat: wire machine readable help"
+```
+
+### Task 5: Documentation and full verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README-CN.md`
+
+- [ ] **Step 1: Document the public interface**
+
+Add concise English and Chinese sections showing root, product, PascalCase API, and kebab API examples. State that `schemaVersion` is `v1`, data is local/offline, and currently unavailable output/pagination/risk/recovery fields are null.
+
+- [ ] **Step 2: Format and run static checks**
+
+Run:
+
+```bash
+gofmt -w cli/errors.go cli/command.go canonicalmeta/types.go canonicalmeta/reader.go canonicalmeta/repository.go canonicalmeta/canonical_test.go meta/product.go openapi/flags.go openapi/commando.go openapi/machine_help_args.go openapi/machine_help_args_test.go openapi/machine_help.go openapi/machine_help_test.go main/main.go main/main_test.go
+git diff --check
+```
+
+Expected: no output from `git diff --check`.
+
+- [ ] **Step 3: Run all tests**
+
+Run:
+
+```bash
+go test ./...
+(cd aliyun-openapi-runtime && go test ./...)
+```
+
+Expected: both suites PASS with zero failures.
+
+- [ ] **Step 4: Build and smoke-test the binary**
+
+Run:
+
+```bash
+go build -o /tmp/aliyun-help-json-v1 ./main
+/tmp/aliyun-help-json-v1 --help=json
+/tmp/aliyun-help-json-v1 help ecs --format json
+/tmp/aliyun-help-json-v1 help ecs DescribeInstances --format json
+/tmp/aliyun-help-json-v1 ecs describe-instances --help=json
+```
+
+Expected: each command emits valid JSON with `schemaVersion: "v1"`; API invocations are not executed.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add README.md README-CN.md
+git commit -m "docs: document help json v1"
+```
+
+- [ ] **Step 6: Verify branch diff and history**
+
+Run:
+
+```bash
+git status --short
+git log --oneline origin/unify-meta-test..HEAD
+git diff --stat origin/unify-meta-test...HEAD
+```
+
+Expected: clean worktree and only Help v1/design changes.
+
+- [ ] **Step 7: Push and create the pull request**
+
+Push `codex/agentic-help-json-v1` to the `fork` remote, then create a GitHub PR with base repository `aliyun/aliyun-cli`, base branch `unify-meta-test`, and Aone work item `85538412` in the description. Verify the PR URL, base/head branches, and CI state.

--- a/docs/superpowers/specs/2026-08-18-agentic-help-json-v1-design.md
+++ b/docs/superpowers/specs/2026-08-18-agentic-help-json-v1-design.md
@@ -1,0 +1,210 @@
+# Agentic Help JSON v1 Design
+
+## Context
+
+Aone requirement 85538412 asks aliyun CLI to expose the Canonical OpenAPI help data through a stable, public, machine-readable interface. Today `--help` is a value-less flag, so `--help=json` fails parsing, while `GENERATE_METADATA=YES` exports only the static `cli.Command` tree and does not describe APIs served by the unified Canonical runtime.
+
+This change is based on `origin/unify-meta-test`. Both legacy PascalCase OpenAPI commands and kebab-case commands are Canonical-backed on that branch, but they retain different command-line projections and may retain different default API versions.
+
+## Goals
+
+- Support equivalent machine-readable entry points:
+  - `aliyun ... --help=json`
+  - `aliyun help ... --format json`
+- Support root, product, and API help.
+- Support both PascalCase and kebab-case API names.
+- Publish a stable `schemaVersion: "v1"` contract rather than serializing internal Go structs or raw Canonical files.
+- Describe the actual command contract, including both legacy and kebab parameter projections.
+- Operate entirely from local static/Canonical metadata without credentials, network access, API execution, or plugin installation.
+- Preserve all existing text-help and command-execution behavior.
+
+## Non-goals
+
+- Changing Canonical generation or adding new source fields.
+- Changing API execution, command routing, parameter serialization, or default-version selection.
+- Inferring output schemas, pagination, risk, or recovery information when metadata does not provide it.
+- Making the existing hidden `GENERATE_METADATA=YES` export part of the public contract.
+
+## Command surface
+
+The following pairs are equivalent:
+
+```text
+aliyun --help=json
+aliyun help --format json
+
+aliyun ecs --help=json
+aliyun help ecs --format json
+
+aliyun ecs DescribeInstances --help=json
+aliyun help ecs DescribeInstances --format json
+
+aliyun ecs describe-instances --help=json
+aliyun help ecs describe-instances --format json
+```
+
+Plain `--help`, `-h`, and `aliyun help ...` without `--format json` keep their current text output.
+
+Only `json` is accepted as the value of `--help` and `--format` in the machine-help forms. Unsupported values fail without falling through to API execution.
+
+## Architecture
+
+### Entry normalization
+
+The CLI parser recognizes the two machine-help syntaxes and normalizes them into one request containing:
+
+- target path after `aliyun`;
+- requested output format;
+- requested API version, when supplied;
+- the requested command spelling, used to determine PascalCase versus kebab-case behavior.
+
+The normalizer must not reinterpret ordinary API parameters named `format` or change the behavior of the existing value-less help flag.
+
+### Stable help service
+
+A dedicated Help v1 service owns the public DTOs and JSON rendering. It accepts a normalized request and returns one of three document kinds:
+
+- `root`
+- `product`
+- `api`
+
+It does not marshal `cli.Command`, runtime `meta.*`, `canonicalmeta.*`, or on-disk Canonical structs directly. Internal data is explicitly projected into the v1 DTO so future internal refactors do not silently change the external contract.
+
+### Metadata resolution
+
+- Root documents combine the static top-level command tree with the locally available product catalog.
+- Product documents use product metadata plus the selected version index. They do not load every API JSON.
+- API documents resolve the requested command to a Canonical `(product, version, APIName)` and then load that one API definition.
+- PascalCase requests preserve the legacy default version and legacy parameter view.
+- Kebab-case requests preserve the plugin/runtime default version and Canonical parameter view.
+- An explicitly supplied version overrides only through the existing command-style rules; machine help does not introduce a new version-selection policy.
+
+## JSON contract
+
+### Common envelope
+
+Every successful document contains:
+
+```json
+{
+  "schemaVersion": "v1",
+  "kind": "root",
+  "target": {
+    "path": ["aliyun"],
+    "requestedStyle": "root"
+  }
+}
+```
+
+`kind` is `root`, `product`, or `api`. `requestedStyle` is `root`, `product`, `camel`, or `kebab`.
+
+No timestamps, random identifiers, local paths, or other invocation-specific unstable values are emitted. Objects use deterministic field order through DTO definition order; maps and discovered lists are sorted before marshaling.
+
+### Root document
+
+The root document adds:
+
+- `commands`: public top-level built-in commands with names and localized descriptions;
+- `products`: product code, localized names, supported command styles, and whether Canonical machine help is available.
+
+The root document is a discovery index. It does not inline every product or API schema.
+
+### Product document
+
+The product document adds:
+
+- product code and localized names;
+- API style;
+- `legacyDefaultVersion`;
+- `pluginDefaultVersion`;
+- sorted `supportedVersions`;
+- `selectedVersion`;
+- APIs from the selected version index, with `name`, `cmdName`, localized descriptions, and deprecation state.
+
+The version index keeps product help cheap and avoids opening every per-API JSON file.
+
+### API document
+
+The API document adds:
+
+- Canonical API name and kebab command name;
+- selected version and supported versions;
+- localized descriptions and deprecation state;
+- HTTP operation information;
+- `activeParameterSet`, set to `camel` or `kebab`;
+- `parameterSets.camel`, reflecting the legacy CLI projection actually accepted by PascalCase execution;
+- `parameterSets.kebab`, reflecting the Canonical/runtime projection actually accepted by kebab execution;
+- applicable global parameters;
+- `examples.camel` and `examples.kebab`;
+- the following stable nullable fields:
+
+```json
+{
+  "outputSchema": null,
+  "pagination": null,
+  "risk": null,
+  "recovery": null
+}
+```
+
+Each parameter node contains the available subset of:
+
+- logical name;
+- wire/raw name;
+- CLI options;
+- type;
+- location;
+- required state;
+- serialization style;
+- localized help;
+- example;
+- recursive object fields, array element, or map value;
+- source-backed constraints.
+
+Missing constraints are represented explicitly as null values rather than guessed from API names, HTTP methods, descriptions, or examples.
+
+## Error contract
+
+Machine-help failures produce a JSON error document on stderr and a non-zero exit status. Stdout stays empty. The error document contains:
+
+- `schemaVersion: "v1"`;
+- a stable error code;
+- a human-readable message;
+- the requested target path;
+- deterministic suggestions when available.
+
+Initial stable codes cover invalid format, invalid target depth, unknown product, unknown version, unknown API/command, and unavailable machine help. Errors must never fall through into API execution or plugin auto-install.
+
+## Compatibility
+
+- Existing text help is byte-for-byte unchanged outside tests that intentionally exercise the new forms.
+- Existing `--help` remains value-less for normal parsing; support for the exact `--help=json` form must not make `--help` consume a following positional argument.
+- Root command, plugin routing, legacy OpenAPI routing, and unified runtime execution are unchanged.
+- Default versions are reported, not unified: PascalCase and kebab requests may resolve different default versions by design.
+- The service reads the same effective metadata source as the corresponding execution path and reports its selected version.
+
+## Testing strategy
+
+Implementation follows red-green-refactor. Tests cover:
+
+1. parser recognition of both machine-help syntaxes and rejection of unsupported formats;
+2. regression coverage proving plain `--help`, `-h`, and text `aliyun help ...` are unchanged;
+3. deterministic root discovery output;
+4. product output with multiple versions and distinct legacy/plugin defaults;
+5. PascalCase and kebab resolution to Canonical API metadata;
+6. correct active parameter set and both parameter trees;
+7. RPC and ROA operations;
+8. nested object, array, map, repeat-list, and body compatibility projections;
+9. camel and kebab examples;
+10. explicit nulls for unsupported output schema, pagination, risk, and recovery data;
+11. stable JSON errors and non-zero exits;
+12. proof that machine help does not load credentials, access the network, install plugins, or execute an API.
+
+Targeted package tests run after each TDD cycle, followed by the repository's full Go test suite and build checks before push and PR creation.
+
+## Delivery
+
+- Base: latest `origin/unify-meta-test`.
+- Source branch: `codex/agentic-help-json-v1` on the user's GitHub fork.
+- Pull request target: `aliyun/aliyun-cli:unify-meta-test`.
+- The PR is associated with Aone work item `85538412` where the available review tooling supports work-item linkage.

--- a/main/main.go
+++ b/main/main.go
@@ -101,6 +101,7 @@ func Main(args []string) {
 	if os.Getenv("GENERATE_METADATA") == "YES" {
 		generateMetadata(rootCmd)
 	} else {
+		args = openapi.NormalizeMachineHelpArgs(args)
 		rootCmd.Execute(ctx, args)
 	}
 }

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,6 +18,48 @@ func TestMainWithNoArgs(t *testing.T) {
 	resetMainHooks(t, nil, nil, nil)
 
 	Main([]string{})
+}
+
+func TestMainMachineHelpJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantKind  string
+		wantStyle string
+	}{
+		{name: "root equals form", args: []string{"--help=json"}, wantKind: "root"},
+		{name: "product help command", args: []string{"help", "ecs", "--format", "json"}, wantKind: "product"},
+		{name: "camel API", args: []string{"help", "ecs", "DescribeInstances", "--version", "2014-05-26", "--format", "json"}, wantKind: "api", wantStyle: "camel"},
+		{name: "kebab API", args: []string{"ecs", "describe-instances", "--api-version", "2014-05-26", "--help=json"}, wantKind: "api", wantStyle: "kebab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			var stdout, stderr bytes.Buffer
+			resetMainHooks(t, &stdout, &stderr, nil)
+
+			Main(tt.args)
+
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			var document struct {
+				SchemaVersion      string `json:"schemaVersion"`
+				Kind               string `json:"kind"`
+				ActiveParameterSet string `json:"activeParameterSet"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &document); err != nil {
+				t.Fatalf("machine help is not JSON: %v\n%s", err, stdout.String())
+			}
+			if document.SchemaVersion != "v1" || document.Kind != tt.wantKind {
+				t.Fatalf("document = %#v, want schema v1 kind %s", document, tt.wantKind)
+			}
+			if document.ActiveParameterSet != tt.wantStyle {
+				t.Fatalf("activeParameterSet = %q, want %q", document.ActiveParameterSet, tt.wantStyle)
+			}
+		})
+	}
 }
 
 func TestMainInterceptsMockBeforeLoadingProfile(t *testing.T) {

--- a/meta/product.go
+++ b/meta/product.go
@@ -36,6 +36,9 @@ type Product struct {
 	RegionalEndpointPattern string            `json:"regional_endpoint_patterns"`
 	ApiStyle                string            `json:"api_style"`
 	ApiNames                []string          `json:"apis"`
+	PluginDefaultVersion    string            `json:"plugin_default_version"`
+	Versions                []string          `json:"versions"`
+	Distribution            string            `json:"distribution,omitempty"`
 }
 
 func (a *Product) GetLowerCode() string {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -1043,6 +1043,11 @@ func (c *Commando) createHttpContext(ctx *cli.Context, product *meta.Product, ap
 
 func (c *Commando) help(ctx *cli.Context, args []string) error {
 	// fmt.Println("commando help", args)
+	if formatFlag := MachineHelpFormatFlag(ctx.Flags()); formatFlag != nil && formatFlag.IsAssigned() {
+		format, _ := formatFlag.GetValue()
+		return c.printMachineHelp(ctx, args, format)
+	}
+
 	c.loadPlugins()
 	cmd := ctx.Command()
 	if len(args) == 0 {

--- a/openapi/flags.go
+++ b/openapi/flags.go
@@ -44,6 +44,7 @@ func AddFlags(fs *cli.FlagSet) {
 	fs.Add(NewUserAgentFlag())
 	fs.Add(NewCliAIModeFlag())
 	fs.Add(NewCliNoAIModeFlag())
+	fs.Add(NewMachineHelpFormatFlag())
 }
 
 const (
@@ -70,7 +71,21 @@ const (
 	UserAgentFlagName           = "user-agent"
 	CliAIModeFlagName           = "cli-ai-mode"
 	CliNoAIModeFlagName         = "no-cli-ai-mode"
+	MachineHelpFormatFlagName   = "help-format"
 )
+
+func MachineHelpFormatFlag(fs *cli.FlagSet) *cli.Flag {
+	return fs.Get(MachineHelpFormatFlagName)
+}
+
+func NewMachineHelpFormatFlag() *cli.Flag {
+	return &cli.Flag{
+		Name:         MachineHelpFormatFlagName,
+		AssignedMode: cli.AssignedOnce,
+		Persistent:   true,
+		Hidden:       true,
+	}
+}
 
 func OutputFlag(fs *cli.FlagSet) *cli.Flag {
 	return fs.Get(OutputFlagName)

--- a/openapi/library.go
+++ b/openapi/library.go
@@ -30,6 +30,7 @@ import (
 type Library struct {
 	builtinRepo   *meta.Repository
 	canonicalRepo canonicalAPIRepository
+	helpRepo      machineHelpRepository
 	writer        io.Writer
 }
 
@@ -39,11 +40,13 @@ type canonicalAPIRepository interface {
 }
 
 func NewLibrary(w io.Writer, lang string) *Library {
+	repo := canonicalmeta.NewRepository(bundledmeta.Metadatas)
 	lib := &Library{
 		builtinRepo: meta.LoadRepository(),
+		helpRepo:    repo,
 		writer:      w,
 	}
-	lib.canonicalRepo = canonicalmeta.NewRepository(bundledmeta.Metadatas)
+	lib.canonicalRepo = repo
 	return lib
 }
 

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -1,0 +1,514 @@
+package openapi
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+)
+
+const machineHelpSchemaVersion = "v1"
+
+type machineHelpRepository interface {
+	GetProducts() (*canonicalmeta.ProductsIndex, error)
+	GetVersionIndex(product, version string) (*canonicalmeta.VersionIndex, error)
+	GetAPI(product, version, apiName string) (*canonicalmeta.API, error)
+}
+
+type machineHelpService struct {
+	repository machineHelpRepository
+}
+
+func newMachineHelpService(repository machineHelpRepository) *machineHelpService {
+	return &machineHelpService{repository: repository}
+}
+
+type machineHelpTarget struct {
+	Path           []string `json:"path"`
+	RequestedStyle string   `json:"requestedStyle"`
+}
+
+type machineHelpLocalizedText struct {
+	EN string `json:"en"`
+	ZH string `json:"zh"`
+}
+
+type machineHelpCommandSummary struct {
+	Name        string                   `json:"name"`
+	Description machineHelpLocalizedText `json:"description"`
+}
+
+type machineHelpProductSummary struct {
+	Code          string                   `json:"code"`
+	Name          machineHelpLocalizedText `json:"name"`
+	CommandStyles []string                 `json:"commandStyles"`
+	CanonicalHelp bool                     `json:"canonicalHelp"`
+	Distribution  string                   `json:"distribution,omitempty"`
+}
+
+type machineHelpRootDocument struct {
+	SchemaVersion string                      `json:"schemaVersion"`
+	Kind          string                      `json:"kind"`
+	Target        machineHelpTarget           `json:"target"`
+	Commands      []machineHelpCommandSummary `json:"commands"`
+	Products      []machineHelpProductSummary `json:"products"`
+}
+
+type machineHelpProduct struct {
+	Code                 string                   `json:"code"`
+	Name                 machineHelpLocalizedText `json:"name"`
+	APIStyle             string                   `json:"apiStyle"`
+	LegacyDefaultVersion string                   `json:"legacyDefaultVersion"`
+	PluginDefaultVersion string                   `json:"pluginDefaultVersion"`
+	SupportedVersions    []string                 `json:"supportedVersions"`
+	SelectedVersion      string                   `json:"selectedVersion"`
+	Distribution         string                   `json:"distribution,omitempty"`
+}
+
+type machineHelpAPISummary struct {
+	Name        string                   `json:"name"`
+	CmdName     string                   `json:"cmdName"`
+	Description machineHelpLocalizedText `json:"description"`
+	Deprecated  bool                     `json:"deprecated"`
+}
+
+type machineHelpProductDocument struct {
+	SchemaVersion string                  `json:"schemaVersion"`
+	Kind          string                  `json:"kind"`
+	Target        machineHelpTarget       `json:"target"`
+	Product       machineHelpProduct      `json:"product"`
+	APIs          []machineHelpAPISummary `json:"apis"`
+}
+
+type machineHelpOperation struct {
+	Action          string `json:"action"`
+	APIStyle        string `json:"apiStyle"`
+	APIVersion      string `json:"apiVersion"`
+	Method          string `json:"method"`
+	Protocol        string `json:"protocol"`
+	URL             string `json:"url"`
+	IsSSE           bool   `json:"isSSE"`
+	ReqBodyType     string `json:"requestBodyType"`
+	ContentType     string `json:"contentType"`
+	HasWildcardPath bool   `json:"hasWildcardPath"`
+}
+
+type machineHelpAPI struct {
+	Name         string                   `json:"name"`
+	CmdName      string                   `json:"cmdName"`
+	CmdFullName  string                   `json:"cmdFullName"`
+	Description  machineHelpLocalizedText `json:"description"`
+	Deprecated   bool                     `json:"deprecated"`
+	MultiVersion bool                     `json:"multiVersion"`
+	Operation    machineHelpOperation     `json:"operation"`
+}
+
+type machineHelpConstraints struct {
+	Enum    any `json:"enum"`
+	Pattern any `json:"pattern"`
+	Minimum any `json:"minimum"`
+	Maximum any `json:"maximum"`
+}
+
+type machineHelpShape struct {
+	Type    string                 `json:"type"`
+	Fields  []machineHelpParameter `json:"fields,omitempty"`
+	Element *machineHelpShape      `json:"element,omitempty"`
+	Value   *machineHelpShape      `json:"value,omitempty"`
+}
+
+type machineHelpParameter struct {
+	Name          string                   `json:"name"`
+	RawName       string                   `json:"rawName"`
+	Options       []string                 `json:"options"`
+	Type          string                   `json:"type"`
+	Location      string                   `json:"location"`
+	Required      bool                     `json:"required"`
+	Serialization string                   `json:"serialization"`
+	Help          machineHelpLocalizedText `json:"help"`
+	Example       string                   `json:"example"`
+	Constraints   machineHelpConstraints   `json:"constraints"`
+	Fields        []machineHelpParameter   `json:"fields,omitempty"`
+	Element       *machineHelpShape        `json:"element,omitempty"`
+	Value         *machineHelpShape        `json:"value,omitempty"`
+}
+
+type machineHelpParameterSets struct {
+	Camel []machineHelpParameter `json:"camel"`
+	Kebab []machineHelpParameter `json:"kebab"`
+}
+
+type machineHelpExamples struct {
+	Camel string `json:"camel"`
+	Kebab string `json:"kebab"`
+}
+
+type machineHelpAPIDocument struct {
+	SchemaVersion      string                   `json:"schemaVersion"`
+	Kind               string                   `json:"kind"`
+	Target             machineHelpTarget        `json:"target"`
+	Product            machineHelpProduct       `json:"product"`
+	API                machineHelpAPI           `json:"api"`
+	ActiveParameterSet string                   `json:"activeParameterSet"`
+	ParameterSets      machineHelpParameterSets `json:"parameterSets"`
+	GlobalParameters   []machineHelpParameter   `json:"globalParameters"`
+	Examples           machineHelpExamples      `json:"examples"`
+	OutputSchema       any                      `json:"outputSchema"`
+	Pagination         any                      `json:"pagination"`
+	Risk               any                      `json:"risk"`
+	Recovery           any                      `json:"recovery"`
+}
+
+func (s *machineHelpService) buildRoot(root *cli.Command) (*machineHelpRootDocument, error) {
+	if root == nil {
+		return nil, fmt.Errorf("root command is nil")
+	}
+	catalog, err := s.repository.GetProducts()
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := map[string]*cli.Metadata{}
+	root.GetMetadata(metadata)
+	commands := make([]machineHelpCommandSummary, 0, len(root.SubCommandNames()))
+	for _, name := range root.SubCommandNames() {
+		entry := metadata[root.Name+" "+name]
+		if entry == nil || entry.Hidden {
+			continue
+		}
+		commands = append(commands, machineHelpCommandSummary{
+			Name:        name,
+			Description: localizedText(entry.Short),
+		})
+	}
+	sort.Slice(commands, func(i, j int) bool { return commands[i].Name < commands[j].Name })
+
+	products := make([]machineHelpProductSummary, 0, len(catalog.Products))
+	for _, product := range catalog.Products {
+		versions := normalizedVersions(product)
+		styles := []string(nil)
+		if len(versions) > 0 {
+			styles = []string{"camel", "kebab"}
+		}
+		products = append(products, machineHelpProductSummary{
+			Code:          strings.ToLower(product.Code),
+			Name:          localizedText(product.Name),
+			CommandStyles: styles,
+			CanonicalHelp: len(versions) > 0,
+			Distribution:  product.Distribution,
+		})
+	}
+	sort.Slice(products, func(i, j int) bool { return products[i].Code < products[j].Code })
+
+	return &machineHelpRootDocument{
+		SchemaVersion: machineHelpSchemaVersion,
+		Kind:          "root",
+		Target:        machineHelpTarget{Path: []string{"aliyun"}, RequestedStyle: "root"},
+		Commands:      commands,
+		Products:      products,
+	}, nil
+}
+
+func (s *machineHelpService) buildProduct(code, requestedVersion string) (*machineHelpProductDocument, error) {
+	product, err := s.findProduct(code)
+	if err != nil {
+		return nil, err
+	}
+	versions := normalizedVersions(*product)
+	selected, err := selectProductVersion(*product, versions, requestedVersion)
+	if err != nil {
+		return nil, err
+	}
+	index, err := s.repository.GetVersionIndex(product.Code, selected)
+	if err != nil {
+		return nil, err
+	}
+
+	apis := make([]machineHelpAPISummary, 0, len(index.APIs))
+	for name, entry := range index.APIs {
+		apis = append(apis, machineHelpAPISummary{
+			Name:        name,
+			CmdName:     entry.CmdName,
+			Description: machineHelpLocalizedText{EN: entry.DescriptionEn, ZH: entry.DescriptionZh},
+			Deprecated:  entry.Deprecated,
+		})
+	}
+	sort.Slice(apis, func(i, j int) bool {
+		if apis[i].CmdName == apis[j].CmdName {
+			return apis[i].Name < apis[j].Name
+		}
+		return apis[i].CmdName < apis[j].CmdName
+	})
+
+	productDoc := buildMachineHelpProduct(*product, versions, selected)
+	code = productDoc.Code
+	return &machineHelpProductDocument{
+		SchemaVersion: machineHelpSchemaVersion,
+		Kind:          "product",
+		Target:        machineHelpTarget{Path: []string{"aliyun", code}, RequestedStyle: "product"},
+		Product:       productDoc,
+		APIs:          apis,
+	}, nil
+}
+
+func (s *machineHelpService) buildAPI(code, command, requestedVersion string) (*machineHelpAPIDocument, error) {
+	product, err := s.findProduct(code)
+	if err != nil {
+		return nil, err
+	}
+	style := "camel"
+	if strings.ToLower(command) == command {
+		style = "kebab"
+	}
+	versions := normalizedVersions(*product)
+	selected, err := selectAPIVersion(*product, versions, requestedVersion, style)
+	if err != nil {
+		return nil, err
+	}
+	index, err := s.repository.GetVersionIndex(product.Code, selected)
+	if err != nil {
+		return nil, err
+	}
+	apiName := resolveAPIName(index, command, style)
+	if apiName == "" {
+		return nil, fmt.Errorf("unknown API command %q for product %q version %q", command, product.Code, selected)
+	}
+	api, err := s.repository.GetAPI(product.Code, selected, apiName)
+	if err != nil {
+		return nil, err
+	}
+
+	operation := machineHelpOperation{Method: api.Method, Protocol: api.Protocol, URL: api.PathPattern}
+	if api.Operation != nil {
+		operation = machineHelpOperation{
+			Action:          api.Operation.Action,
+			APIStyle:        api.Operation.APIStyle,
+			APIVersion:      api.Operation.APIVersion,
+			Method:          api.Operation.Method,
+			Protocol:        api.Operation.Protocol,
+			URL:             api.Operation.URL,
+			IsSSE:           api.Operation.IsSSE,
+			ReqBodyType:     api.Operation.ReqBodyType,
+			ContentType:     api.Operation.ContentType,
+			HasWildcardPath: api.Operation.HasWildcardPath,
+		}
+	}
+	camelParameters := make([]machineHelpParameter, 0)
+	for _, view := range api.LegacyTopLevelParameters() {
+		camelParameters = append(camelParameters, projectLegacyParameter(view, ""))
+	}
+	kebabParameters := make([]machineHelpParameter, 0, len(api.Parameters))
+	for i := range api.Parameters {
+		kebabParameters = append(kebabParameters, projectCanonicalParameter(&api.Parameters[i]))
+	}
+
+	productDoc := buildMachineHelpProduct(*product, versions, selected)
+	return &machineHelpAPIDocument{
+		SchemaVersion: machineHelpSchemaVersion,
+		Kind:          "api",
+		Target: machineHelpTarget{
+			Path:           []string{"aliyun", productDoc.Code, command},
+			RequestedStyle: style,
+		},
+		Product: productDoc,
+		API: machineHelpAPI{
+			Name:         api.Name,
+			CmdName:      api.CmdName,
+			CmdFullName:  api.CmdFullName,
+			Description:  machineHelpLocalizedText{EN: api.DescriptionEn, ZH: api.DescriptionZh},
+			Deprecated:   api.Deprecated,
+			MultiVersion: api.MultiVersion,
+			Operation:    operation,
+		},
+		ActiveParameterSet: style,
+		ParameterSets: machineHelpParameterSets{
+			Camel: camelParameters,
+			Kebab: kebabParameters,
+		},
+		GlobalParameters: make([]machineHelpParameter, 0),
+		Examples: machineHelpExamples{
+			Camel: api.CamelExample,
+			Kebab: api.KebabExample,
+		},
+		OutputSchema: nil,
+		Pagination:   nil,
+		Risk:         nil,
+		Recovery:     nil,
+	}, nil
+}
+
+func buildMachineHelpProduct(product canonicalmeta.ProductEntry, versions []string, selected string) machineHelpProduct {
+	return machineHelpProduct{
+		Code:                 strings.ToLower(product.Code),
+		Name:                 localizedText(product.Name),
+		APIStyle:             product.APIStyle,
+		LegacyDefaultVersion: product.Version,
+		PluginDefaultVersion: product.PluginDefaultVersion,
+		SupportedVersions:    versions,
+		SelectedVersion:      selected,
+		Distribution:         product.Distribution,
+	}
+}
+
+func selectAPIVersion(product canonicalmeta.ProductEntry, versions []string, requested, style string) (string, error) {
+	if requested != "" {
+		return selectProductVersion(product, versions, requested)
+	}
+	if style == "camel" && product.Version != "" {
+		return product.Version, nil
+	}
+	return selectProductVersion(product, versions, "")
+}
+
+func resolveAPIName(index *canonicalmeta.VersionIndex, command, style string) string {
+	for name, entry := range index.APIs {
+		if style == "camel" && strings.EqualFold(name, command) {
+			return name
+		}
+		if style == "kebab" && entry.CmdName == command {
+			return name
+		}
+	}
+	return ""
+}
+
+func projectCanonicalParameter(parameter *canonicalmeta.Parameter) machineHelpParameter {
+	if parameter == nil {
+		return machineHelpParameter{}
+	}
+	result := machineHelpParameter{
+		Name:          parameter.Name,
+		RawName:       parameter.RawName,
+		Options:       append([]string(nil), parameter.Options...),
+		Type:          parameter.Type,
+		Location:      strings.ToLower(parameter.Location),
+		Required:      parameter.Required,
+		Serialization: parameter.ParamStyle,
+		Help:          machineHelpLocalizedText{EN: parameter.HelpEn, ZH: parameter.HelpZh},
+		Example:       parameter.Example,
+	}
+	for i := range parameter.Fields {
+		result.Fields = append(result.Fields, projectCanonicalField(&parameter.Fields[i]))
+	}
+	result.Element = projectCanonicalShape(parameter.Element)
+	result.Value = projectCanonicalShape(parameter.Value)
+	return result
+}
+
+func projectCanonicalField(field *canonicalmeta.Field) machineHelpParameter {
+	if field == nil {
+		return machineHelpParameter{}
+	}
+	result := machineHelpParameter{
+		Name:        field.Name,
+		RawName:     field.RawName,
+		Options:     make([]string, 0),
+		Type:        field.Type,
+		Required:    field.Required,
+		Help:        machineHelpLocalizedText{EN: field.HelpEn, ZH: field.HelpZh},
+		Example:     field.Example,
+		Constraints: machineHelpConstraints{},
+	}
+	for i := range field.Fields {
+		result.Fields = append(result.Fields, projectCanonicalField(&field.Fields[i]))
+	}
+	result.Element = projectCanonicalShape(field.Element)
+	result.Value = projectCanonicalShape(field.Value)
+	return result
+}
+
+func projectCanonicalShape(shape *canonicalmeta.TypeShape) *machineHelpShape {
+	if shape == nil {
+		return nil
+	}
+	result := &machineHelpShape{Type: shape.Type}
+	for i := range shape.Fields {
+		result.Fields = append(result.Fields, projectCanonicalField(&shape.Fields[i]))
+	}
+	result.Element = projectCanonicalShape(shape.Element)
+	result.Value = projectCanonicalShape(shape.Value)
+	return result
+}
+
+func projectLegacyParameter(view *canonicalmeta.LegacyParameterView, prefix string) machineHelpParameter {
+	name := view.LegacyName()
+	optionPath := name
+	if prefix != "" {
+		optionPath = prefix + "." + name
+	}
+	result := machineHelpParameter{
+		Name:        name,
+		RawName:     name,
+		Options:     []string{"--" + optionPath},
+		Type:        view.LegacyType(),
+		Location:    strings.ToLower(view.LegacyPosition()),
+		Required:    view.LegacyRequired(),
+		Help:        machineHelpLocalizedText{EN: view.LegacyDescription("en"), ZH: view.LegacyDescription("zh")},
+		Example:     view.LegacyExample(),
+		Constraints: machineHelpConstraints{},
+	}
+	children := view.LegacyChildren()
+	if view.IsLegacyRepeatList() {
+		result.Serialization = "repeatList"
+		if len(children) > 0 {
+			result.Element = &machineHelpShape{Type: "object"}
+			for _, child := range children {
+				result.Element.Fields = append(result.Element.Fields, projectLegacyParameter(child, optionPath+".#"))
+			}
+		}
+	}
+	return result
+}
+
+func (s *machineHelpService) findProduct(code string) (*canonicalmeta.ProductEntry, error) {
+	catalog, err := s.repository.GetProducts()
+	if err != nil {
+		return nil, err
+	}
+	for i := range catalog.Products {
+		if strings.EqualFold(catalog.Products[i].Code, code) {
+			return &catalog.Products[i], nil
+		}
+	}
+	return nil, fmt.Errorf("unknown product %q", code)
+}
+
+func selectProductVersion(product canonicalmeta.ProductEntry, versions []string, requested string) (string, error) {
+	if requested != "" {
+		for _, version := range versions {
+			if version == requested {
+				return requested, nil
+			}
+		}
+		return "", fmt.Errorf("product %q does not expose version %q", product.Code, requested)
+	}
+	for _, candidate := range []string{product.PluginDefaultVersion, product.Version} {
+		if candidate != "" {
+			return candidate, nil
+		}
+	}
+	if len(versions) == 0 {
+		return "", fmt.Errorf("product %q has no API version", product.Code)
+	}
+	return versions[0], nil
+}
+
+func normalizedVersions(product canonicalmeta.ProductEntry) []string {
+	seen := map[string]bool{}
+	versions := make([]string, 0, len(product.Versions)+2)
+	for _, version := range append(append([]string(nil), product.Versions...), product.Version, product.PluginDefaultVersion) {
+		if version == "" || seen[version] {
+			continue
+		}
+		seen[version] = true
+		versions = append(versions, version)
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+func localizedText(values map[string]string) machineHelpLocalizedText {
+	return machineHelpLocalizedText{EN: values["en"], ZH: values["zh"]}
+}

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -1,7 +1,10 @@
 package openapi
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -20,6 +23,50 @@ type machineHelpRepository interface {
 type machineHelpService struct {
 	repository machineHelpRepository
 }
+
+type machineHelpErrorBody struct {
+	Code        string   `json:"code"`
+	Message     string   `json:"message"`
+	Target      []string `json:"target"`
+	Suggestions []string `json:"suggestions"`
+}
+
+type machineHelpErrorDocument struct {
+	SchemaVersion string               `json:"schemaVersion"`
+	Error         machineHelpErrorBody `json:"error"`
+}
+
+type machineHelpError struct {
+	document machineHelpErrorDocument
+	cause    error
+}
+
+func newMachineHelpError(code, message string, target, suggestions []string) *machineHelpError {
+	return &machineHelpError{document: machineHelpErrorDocument{
+		SchemaVersion: machineHelpSchemaVersion,
+		Error: machineHelpErrorBody{
+			Code:        code,
+			Message:     message,
+			Target:      append([]string(nil), target...),
+			Suggestions: append([]string(nil), suggestions...),
+		},
+	}}
+}
+
+func (e *machineHelpError) Error() string {
+	if e.cause != nil {
+		return e.document.Error.Message + ": " + e.cause.Error()
+	}
+	return e.document.Error.Message
+}
+
+func (e *machineHelpError) Unwrap() error { return e.cause }
+
+func (e *machineHelpError) RenderError(w io.Writer) error {
+	return encodeMachineHelpJSON(w, e.document)
+}
+
+func (e *machineHelpError) ExitCode() int { return 2 }
 
 func newMachineHelpService(repository machineHelpRepository) *machineHelpService {
 	return &machineHelpService{repository: repository}
@@ -273,7 +320,12 @@ func (s *machineHelpService) buildAPI(code, command, requestedVersion string) (*
 	}
 	apiName := resolveAPIName(index, command, style)
 	if apiName == "" {
-		return nil, fmt.Errorf("unknown API command %q for product %q version %q", command, product.Code, selected)
+		return nil, newMachineHelpError(
+			"UNKNOWN_API",
+			fmt.Sprintf("unknown API command %q for product %q version %q", command, product.Code, selected),
+			[]string{"aliyun", strings.ToLower(product.Code), command},
+			[]string{"inspect product help to list available APIs"},
+		)
 	}
 	api, err := s.repository.GetAPI(product.Code, selected, apiName)
 	if err != nil {
@@ -472,7 +524,12 @@ func (s *machineHelpService) findProduct(code string) (*canonicalmeta.ProductEnt
 			return &catalog.Products[i], nil
 		}
 	}
-	return nil, fmt.Errorf("unknown product %q", code)
+	return nil, newMachineHelpError(
+		"UNKNOWN_PRODUCT",
+		fmt.Sprintf("unknown product %q", code),
+		[]string{"aliyun", strings.ToLower(code)},
+		[]string{"inspect root help to list available products"},
+	)
 }
 
 func selectProductVersion(product canonicalmeta.ProductEntry, versions []string, requested string) (string, error) {
@@ -482,7 +539,12 @@ func selectProductVersion(product canonicalmeta.ProductEntry, versions []string,
 				return requested, nil
 			}
 		}
-		return "", fmt.Errorf("product %q does not expose version %q", product.Code, requested)
+		return "", newMachineHelpError(
+			"UNKNOWN_VERSION",
+			fmt.Sprintf("product %q does not expose version %q", product.Code, requested),
+			[]string{"aliyun", strings.ToLower(product.Code)},
+			[]string{"inspect supportedVersions in product help"},
+		)
 	}
 	for _, candidate := range []string{product.PluginDefaultVersion, product.Version} {
 		if candidate != "" {
@@ -490,7 +552,12 @@ func selectProductVersion(product canonicalmeta.ProductEntry, versions []string,
 		}
 	}
 	if len(versions) == 0 {
-		return "", fmt.Errorf("product %q has no API version", product.Code)
+		return "", newMachineHelpError(
+			"UNKNOWN_VERSION",
+			fmt.Sprintf("product %q has no API version", product.Code),
+			[]string{"aliyun", strings.ToLower(product.Code)},
+			nil,
+		)
 	}
 	return versions[0], nil
 }
@@ -511,4 +578,125 @@ func normalizedVersions(product canonicalmeta.ProductEntry) []string {
 
 func localizedText(values map[string]string) machineHelpLocalizedText {
 	return machineHelpLocalizedText{EN: values["en"], ZH: values["zh"]}
+}
+
+func (c *Commando) printMachineHelp(ctx *cli.Context, args []string, format string) error {
+	target := append([]string{"aliyun"}, args...)
+	if format != "json" {
+		return newMachineHelpError(
+			"INVALID_FORMAT",
+			fmt.Sprintf("unsupported help format %q", format),
+			target,
+			[]string{"use --help=json or help --format json"},
+		)
+	}
+	if len(args) > 2 {
+		return newMachineHelpError(
+			"INVALID_TARGET",
+			fmt.Sprintf("machine help accepts at most a product and an API, got %d arguments", len(args)),
+			target,
+			nil,
+		)
+	}
+	if c.library == nil || c.library.helpRepo == nil {
+		return newMachineHelpUnavailableError(target, errors.New("canonical metadata repository is unavailable"))
+	}
+
+	service := newMachineHelpService(c.library.helpRepo)
+	var (
+		document any
+		err      error
+	)
+	switch len(args) {
+	case 0:
+		document, err = service.buildRoot(ctx.Command())
+	case 1:
+		document, err = service.buildProduct(args[0], requestedMachineHelpVersion(ctx))
+	case 2:
+		document, err = service.buildAPI(args[0], args[1], requestedMachineHelpVersion(ctx))
+	}
+	if err != nil {
+		var structured *machineHelpError
+		if errors.As(err, &structured) {
+			return structured
+		}
+		return newMachineHelpUnavailableError(target, err)
+	}
+	if api, ok := document.(*machineHelpAPIDocument); ok {
+		api.GlobalParameters = projectGlobalParameters(ctx.Flags())
+	}
+	if err := encodeMachineHelpJSON(ctx.Stdout(), document); err != nil {
+		return newMachineHelpUnavailableError(target, err)
+	}
+	return nil
+}
+
+func newMachineHelpUnavailableError(target []string, cause error) *machineHelpError {
+	err := newMachineHelpError(
+		"MACHINE_HELP_UNAVAILABLE",
+		"machine-readable help is unavailable",
+		target,
+		nil,
+	)
+	err.cause = cause
+	return err
+}
+
+func encodeMachineHelpJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func requestedMachineHelpVersion(ctx *cli.Context) string {
+	if ctx != nil && ctx.UnknownFlags() != nil {
+		if value, ok := ctx.UnknownFlags().GetValue("api-version"); ok && value != "" {
+			return value
+		}
+	}
+	if ctx != nil {
+		if value, ok := VersionFlag(ctx.Flags()).GetValue(); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func projectGlobalParameters(flags *cli.FlagSet) []machineHelpParameter {
+	parameters := make([]machineHelpParameter, 0)
+	if flags == nil {
+		return parameters
+	}
+	for _, flag := range flags.Flags() {
+		if flag == nil || flag.Hidden || flag.Name == "help" {
+			continue
+		}
+		parameterType := "string"
+		serialization := "once"
+		switch flag.AssignedMode {
+		case cli.AssignedNone:
+			parameterType = "bool"
+			serialization = "flag"
+		case cli.AssignedRepeatable:
+			serialization = "repeatable"
+		}
+		parameter := machineHelpParameter{
+			Name:          flag.Name,
+			RawName:       flag.Name,
+			Options:       append([]string(nil), flag.GetFormations()...),
+			Type:          parameterType,
+			Location:      "global",
+			Required:      flag.Required,
+			Serialization: serialization,
+			Example:       flag.DefaultValue,
+			Constraints:   machineHelpConstraints{},
+		}
+		if flag.Short != nil {
+			parameter.Help = localizedText(flag.Short.GetData())
+		}
+		parameters = append(parameters, parameter)
+	}
+	sort.Slice(parameters, func(i, j int) bool { return parameters[i].Name < parameters[j].Name })
+	return parameters
 }

--- a/openapi/machine_help_args.go
+++ b/openapi/machine_help_args.go
@@ -1,0 +1,52 @@
+package openapi
+
+import "strings"
+
+// NormalizeMachineHelpArgs rewrites the two public machine-help syntaxes to
+// the existing help path plus an internal format flag. Ordinary text help and
+// API parameters named --format are left untouched.
+func NormalizeMachineHelpArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+
+	if args[0] == "help" {
+		if normalized, ok := normalizeHelpCommand(args[1:]); ok {
+			return normalized
+		}
+	}
+
+	out := make([]string, 0, len(args)+2)
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--help=") {
+			out = append(out, "--help", "--"+MachineHelpFormatFlagName, strings.TrimPrefix(arg, "--help="))
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+func normalizeHelpCommand(args []string) ([]string, bool) {
+	target := make([]string, 0, len(args)+2)
+	format := ""
+	found := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case strings.HasPrefix(arg, "--format="):
+			format = strings.TrimPrefix(arg, "--format=")
+			found = true
+		case arg == "--format" && i+1 < len(args):
+			format = args[i+1]
+			found = true
+			i++
+		default:
+			target = append(target, arg)
+		}
+	}
+	if !found {
+		return nil, false
+	}
+	return append(target, "--help", "--"+MachineHelpFormatFlagName, format), true
+}

--- a/openapi/machine_help_args_test.go
+++ b/openapi/machine_help_args_test.go
@@ -1,0 +1,64 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeMachineHelpArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "root equals",
+			in:   []string{"--help=json"},
+			want: []string{"--help", "--help-format", "json"},
+		},
+		{
+			name: "api equals",
+			in:   []string{"ecs", "describe-instances", "--help=json"},
+			want: []string{"ecs", "describe-instances", "--help", "--help-format", "json"},
+		},
+		{
+			name: "help command separated format",
+			in:   []string{"help", "ecs", "DescribeInstances", "--format", "json"},
+			want: []string{"ecs", "DescribeInstances", "--help", "--help-format", "json"},
+		},
+		{
+			name: "help command equals format",
+			in:   []string{"help", "ecs", "--format=json"},
+			want: []string{"ecs", "--help", "--help-format", "json"},
+		},
+		{
+			name: "invalid format still reaches machine error renderer",
+			in:   []string{"help", "ecs", "--format", "yaml"},
+			want: []string{"ecs", "--help", "--help-format", "yaml"},
+		},
+		{
+			name: "text unchanged",
+			in:   []string{"help", "ecs"},
+			want: []string{"help", "ecs"},
+		},
+		{
+			name: "ordinary format unchanged",
+			in:   []string{"ecs", "Call", "--format", "json"},
+			want: []string{"ecs", "Call", "--format", "json"},
+		},
+		{
+			name: "input is not mutated",
+			in:   []string{"ecs", "Call", "--help=json"},
+			want: []string{"ecs", "Call", "--help", "--help-format", "json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := append([]string(nil), tt.in...)
+			assert.Equal(t, tt.want, NormalizeMachineHelpArgs(tt.in))
+			assert.Equal(t, before, tt.in)
+		})
+	}
+}

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -1,0 +1,146 @@
+package openapi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testMachineHelpService(t *testing.T) *machineHelpService {
+	t.Helper()
+	repo := canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+	return newMachineHelpService(repo)
+}
+
+func testMachineHelpRootCommand() *cli.Command {
+	root := &cli.Command{Name: "aliyun", Short: i18n.T("Alibaba Cloud CLI", "阿里云 CLI")}
+	root.AddSubCommand(&cli.Command{Name: "plugin", Short: i18n.T("Manage plugins", "管理插件")})
+	root.AddSubCommand(&cli.Command{Name: "configure", Short: i18n.T("Configure credentials", "配置凭证")})
+	root.AddSubCommand(&cli.Command{Name: "internal", Hidden: true, Short: i18n.T("Internal", "内部")})
+	return root
+}
+
+func TestMachineHelpRoot(t *testing.T) {
+	service := testMachineHelpService(t)
+	doc, err := service.buildRoot(testMachineHelpRootCommand())
+	require.NoError(t, err)
+
+	assert.Equal(t, machineHelpSchemaVersion, doc.SchemaVersion)
+	assert.Equal(t, "root", doc.Kind)
+	assert.Equal(t, []string{"aliyun"}, doc.Target.Path)
+	require.Len(t, doc.Commands, 2)
+	assert.Equal(t, "configure", doc.Commands[0].Name)
+	assert.Equal(t, "plugin", doc.Commands[1].Name)
+	require.Len(t, doc.Products, 1)
+	assert.Equal(t, "demo", doc.Products[0].Code)
+	assert.Equal(t, []string{"camel", "kebab"}, doc.Products[0].CommandStyles)
+	assert.True(t, doc.Products[0].CanonicalHelp)
+}
+
+func TestMachineHelpProduct(t *testing.T) {
+	service := testMachineHelpService(t)
+	doc, err := service.buildProduct("demo", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, machineHelpSchemaVersion, doc.SchemaVersion)
+	assert.Equal(t, "product", doc.Kind)
+	assert.Equal(t, []string{"aliyun", "demo"}, doc.Target.Path)
+	assert.Equal(t, "2026-01-01", doc.Product.LegacyDefaultVersion)
+	assert.Equal(t, "2025-01-01", doc.Product.PluginDefaultVersion)
+	assert.Equal(t, []string{"2025-01-01", "2026-01-01"}, doc.Product.SupportedVersions)
+	assert.Equal(t, "2025-01-01", doc.Product.SelectedVersion)
+	require.Len(t, doc.APIs, 1)
+	assert.Equal(t, "DescribeRegions", doc.APIs[0].Name)
+	assert.Equal(t, "describe-regions", doc.APIs[0].CmdName)
+}
+
+func TestMachineHelpProductExplicitVersion(t *testing.T) {
+	service := testMachineHelpService(t)
+	doc, err := service.buildProduct("DEMO", "2026-01-01")
+	require.NoError(t, err)
+
+	assert.Equal(t, "2026-01-01", doc.Product.SelectedVersion)
+	require.Len(t, doc.APIs, 2)
+	assert.Equal(t, "create-report", doc.APIs[0].CmdName)
+	assert.Equal(t, "describe-regions", doc.APIs[1].CmdName)
+}
+
+func TestMachineHelpAPICamelAndKebabShareCanonicalIdentity(t *testing.T) {
+	service := testMachineHelpService(t)
+	camel, err := service.buildAPI("demo", "CreateReport", "2026-01-01")
+	require.NoError(t, err)
+	kebab, err := service.buildAPI("demo", "create-report", "2026-01-01")
+	require.NoError(t, err)
+
+	assert.Equal(t, machineHelpSchemaVersion, camel.SchemaVersion)
+	assert.Equal(t, "api", camel.Kind)
+	assert.Equal(t, "CreateReport", camel.API.Name)
+	assert.Equal(t, "CreateReport", kebab.API.Name)
+	assert.Equal(t, "create-report", camel.API.CmdName)
+	assert.Equal(t, "create-report", kebab.API.CmdName)
+	assert.Equal(t, "camel", camel.ActiveParameterSet)
+	assert.Equal(t, "kebab", kebab.ActiveParameterSet)
+	assert.Equal(t, []string{"aliyun", "demo", "CreateReport"}, camel.Target.Path)
+	assert.Equal(t, []string{"aliyun", "demo", "create-report"}, kebab.Target.Path)
+
+	assert.NotNil(t, findMachineHelpParameter(camel.ParameterSets.Camel, "--body"))
+	assert.NotNil(t, findMachineHelpParameter(camel.ParameterSets.Camel, "--ReportId"))
+	assert.NotNil(t, findMachineHelpParameter(kebab.ParameterSets.Kebab, "--report-id"))
+	assert.NotNil(t, findMachineHelpParameter(kebab.ParameterSets.Kebab, "--workspace-id"))
+	assert.Equal(t, "aliyun demo CreateReport ....", camel.Examples.Camel)
+	assert.Equal(t, "aliyun demo create-report ...", camel.Examples.Kebab)
+	assert.Nil(t, camel.OutputSchema)
+	assert.Nil(t, camel.Pagination)
+	assert.Nil(t, camel.Risk)
+	assert.Nil(t, camel.Recovery)
+}
+
+func TestMachineHelpAPIDefaultVersionFollowsCommandStyle(t *testing.T) {
+	service := testMachineHelpService(t)
+	camel, err := service.buildAPI("demo", "DescribeRegions", "")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-01-01", camel.Product.SelectedVersion)
+
+	// The plugin default is 2025-01-01. Its index resolves the kebab command
+	// even though the API fixture itself intentionally does not exist there.
+	_, err = service.buildAPI("demo", "describe-regions", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "2025-01-01")
+}
+
+func TestMachineHelpNestedParameters(t *testing.T) {
+	service := testMachineHelpService(t)
+	doc, err := service.buildAPI("demo", "DescribeRegions", "2026-01-01")
+	require.NoError(t, err)
+
+	tags := findMachineHelpParameter(doc.ParameterSets.Kebab, "--tags")
+	require.NotNil(t, tags)
+	assert.Equal(t, "array", tags.Type)
+	require.NotNil(t, tags.Element)
+	assert.Equal(t, "object", tags.Element.Type)
+	require.Len(t, tags.Element.Fields, 2)
+	assert.Equal(t, "Key", tags.Element.Fields[0].RawName)
+	assert.Equal(t, "Value", tags.Element.Fields[1].RawName)
+
+	legacyTags := findMachineHelpParameter(doc.ParameterSets.Camel, "--Tags")
+	require.NotNil(t, legacyTags)
+	require.NotNil(t, legacyTags.Element)
+	require.Len(t, legacyTags.Element.Fields, 2)
+	assert.Equal(t, []string{"--Tags.#.Key"}, legacyTags.Element.Fields[0].Options)
+}
+
+func findMachineHelpParameter(parameters []machineHelpParameter, option string) *machineHelpParameter {
+	for i := range parameters {
+		for _, candidate := range parameters[i].Options {
+			if candidate == option {
+				return &parameters[i]
+			}
+		}
+	}
+	return nil
+}

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -1,6 +1,8 @@
 package openapi
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -143,4 +145,73 @@ func findMachineHelpParameter(parameters []machineHelpParameter, option string) 
 		}
 	}
 	return nil
+}
+
+func TestCommandoHelpJSONUsesCanonicalMetadataWithoutLoadingPlugins(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	c.library.helpRepo = canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+	root := testMachineHelpRootCommand()
+	AddFlags(root.Flags())
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(root)
+	MachineHelpFormatFlag(ctx.Flags()).SetAssigned(true)
+	MachineHelpFormatFlag(ctx.Flags()).SetValue("json")
+	VersionFlag(ctx.Flags()).SetAssigned(true)
+	VersionFlag(ctx.Flags()).SetValue("2026-01-01")
+
+	err := c.help(ctx, []string{"demo", "CreateReport"})
+	require.NoError(t, err)
+	assert.False(t, c.pluginLoaded)
+	assert.Empty(t, stderr.String())
+
+	var doc machineHelpAPIDocument
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &doc))
+	assert.Equal(t, machineHelpSchemaVersion, doc.SchemaVersion)
+	assert.Equal(t, "api", doc.Kind)
+	assert.Equal(t, "CreateReport", doc.API.Name)
+	assert.NotEmpty(t, doc.GlobalParameters)
+}
+
+func TestCommandoHelpJSONAcceptsKebabAPIVersionFlag(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	c.library.helpRepo = canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+	root := testMachineHelpRootCommand()
+	AddFlags(root.Flags())
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(root)
+	MachineHelpFormatFlag(ctx.Flags()).SetAssigned(true)
+	MachineHelpFormatFlag(ctx.Flags()).SetValue("json")
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+	apiVersion, err := ctx.UnknownFlags().AddByName("api-version")
+	require.NoError(t, err)
+	apiVersion.SetAssigned(true)
+	apiVersion.SetValue("2026-01-01")
+
+	err = c.help(ctx, []string{"demo", "create-report"})
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	var doc machineHelpAPIDocument
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &doc))
+	assert.Equal(t, "kebab", doc.ActiveParameterSet)
+	assert.Equal(t, "2026-01-01", doc.Product.SelectedVersion)
+}
+
+func TestCommandoHelpJSONRejectsUnsupportedFormatStructurally(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	root := testMachineHelpRootCommand()
+	AddFlags(root.Flags())
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(root)
+	MachineHelpFormatFlag(ctx.Flags()).SetAssigned(true)
+	MachineHelpFormatFlag(ctx.Flags()).SetValue("yaml")
+
+	err := c.help(ctx, nil)
+	require.Error(t, err)
+	structured, ok := err.(cli.StructuredError)
+	require.True(t, ok)
+	var rendered bytes.Buffer
+	require.NoError(t, structured.RenderError(&rendered))
+	assert.JSONEq(t, `{"schemaVersion":"v1","error":{"code":"INVALID_FORMAT","message":"unsupported help format \"yaml\"","target":["aliyun"],"suggestions":["use --help=json or help --format json"]}}`, rendered.String())
+	assert.False(t, c.pluginLoaded)
 }


### PR DESCRIPTION
## Summary

- add public, offline machine-readable help through both `--help=json` and `help ... --format json`
- expose stable Help `v1` documents for root, product, PascalCase API, and kebab-case API targets from bundled Canonical metadata
- preserve command-style version/parameter behavior, return structured JSON errors, and document the interface

## Requirement

- 85538412

## Test plan

- `env -u NO_COLOR GOCACHE=/tmp/codex-go-cache go test -vet=off ./cli ./canonicalmeta ./meta ./main -count=1`
- `env NO_COLOR=1 GOCACHE=/tmp/codex-go-cache go test -vet=off ./openapi -skip '^TestPrintApiUsage_UnknownApi_PluginAvailableNotInstalled_Lowercase$' -count=1`
- `(cd aliyun-openapi-runtime && env -u NO_COLOR GOCACHE=/tmp/codex-go-cache go test -vet=off ./...)`
- `env GOCACHE=/tmp/codex-go-cache go build -o /tmp/aliyun-help-json-v1 ./main`
- smoke-tested root, product, PascalCase API, kebab-case API, and invalid-format JSON error output

## Baseline test note

The repository-wide `go test -vet=off ./...` still contains environment/live-integration failures in `cms2`, `cloudsso`, `config`, `oss/lib`, and a local-plugin-state test in `openapi`. The same representative failures were reproduced on an untouched `origin/unify-meta-test` worktree; the affected packages and the nested runtime suite pass as listed above.
