### PR TITLE
fix: preserve original API help layout in AI mode

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -1270,19 +1270,7 @@ func (c *Commando) help(ctx *cli.Context, args []string) error {
 			if buildErr != nil {
 				return buildErr
 			}
-			document.GlobalParameters = projectGlobalParameters(ctx.Flags())
-			applyRequestHelpOptions(document, helpOpts, aiMode)
-			if helpOpts.Search != "" {
-				if renderErr := renderCanonicalRequestSearchText(ctx.Stdout(), document, helpOpts.Search); renderErr != nil {
-					return renderErr
-				}
-				if renderErr := renderRequestQueryExampleText(ctx.Stdout(), document.ResponseQuery); renderErr != nil {
-					return renderErr
-				}
-			} else if renderErr := renderCanonicalRequestText(ctx.Stdout(), document); renderErr != nil {
-				return renderErr
-			}
-			return c.finishCanonicalTextHelp(ctx, aiMode)
+			return c.renderProjectedOriginalRequestHelp(ctx, args, document, helpOpts, aiMode)
 		}
 	}
 	c.loadPlugins()
@@ -1332,6 +1320,38 @@ func (c *Commando) help(ctx *cli.Context, args []string) error {
 		}
 		return fmt.Errorf("too many arguments: %d", len(args))
 	}
+}
+
+func (c *Commando) renderProjectedOriginalRequestHelp(
+	ctx *cli.Context,
+	args []string,
+	document *machineHelpAPIDocument,
+	options helpOptions,
+	aiMode bool,
+) error {
+	var original bytes.Buffer
+	captureCtx := cli.NewCommandContext(&original, ctx.Stderr())
+	captureCtx.SetAgentName(ctx.AgentName())
+	if cmd := ctx.Command(); cmd != nil {
+		captureCtx.EnterCommand(cmd)
+		cmd.PrintHead(captureCtx)
+	}
+	if err := c.printApiUsage(captureCtx, args[0], args[1]); err != nil {
+		_, _ = io.Copy(ctx.Stdout(), &original)
+		return err
+	}
+
+	projected, _ := projectOriginalRequestHelpText(original.String(), options, aiMode)
+	if _, err := io.WriteString(ctx.Stdout(), projected); err != nil {
+		return err
+	}
+	if err := renderRequestQueryExampleText(ctx.Stdout(), document.ResponseQuery); err != nil {
+		return err
+	}
+	if !aiMode {
+		return renderAIModeEnableHelpHint(ctx.Stdout())
+	}
+	return nil
 }
 
 func (c *Commando) complete(ctx *cli.Context, args []string) []string {

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -439,6 +439,111 @@ func renderCanonicalRequestText(w io.Writer, document *machineHelpAPIDocument) e
 	return renderRequestQueryExampleText(w, document.ResponseQuery)
 }
 
+// projectOriginalRequestHelpText keeps the established runtime/legacy Help
+// renderer intact and changes only the API parameter blocks. Global parameters,
+// examples, wrapping, labels, and every other section remain byte-for-byte as
+// rendered by the original provider.
+func projectOriginalRequestHelpText(text string, options helpOptions, aiMode bool) (string, *HelpListingMetadata) {
+	lines := strings.SplitAfter(text, "\n")
+	parametersLine := -1
+	globalParametersLine := -1
+	for index, line := range lines {
+		switch strings.TrimSpace(line) {
+		case "Parameters:", "参数:":
+			parametersLine = index
+		case "Global Parameters:", "全局参数:":
+			if parametersLine >= 0 {
+				globalParametersLine = index
+			}
+		}
+	}
+	if parametersLine < 0 || globalParametersLine <= parametersLine {
+		return text, nil
+	}
+
+	type parameterBlock struct {
+		text string
+	}
+	blocks := make([]parameterBlock, 0)
+	var current strings.Builder
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		blocks = append(blocks, parameterBlock{text: current.String()})
+		current.Reset()
+	}
+	for _, line := range lines[parametersLine+1 : globalParametersLine] {
+		if strings.HasPrefix(line, "  --") {
+			flush()
+		}
+		if len(blocks) == 0 && current.Len() == 0 && strings.TrimSpace(line) == "" {
+			continue
+		}
+		current.WriteString(line)
+	}
+	flush()
+	if len(blocks) == 0 {
+		return text, nil
+	}
+
+	selected := blocks
+	if options.Search != "" {
+		query := newHelpSearchText(options.Search)
+		selected = make([]parameterBlock, 0, len(blocks))
+		for _, block := range blocks {
+			if helpTextContains(stripHelpANSI(block.text), query) {
+				selected = append(selected, block)
+			}
+		}
+
+	}
+
+	var listing *HelpListingMetadata
+	if aiMode && options.Search == "" && !options.All && len(selected) > helpListingLimit {
+		listing = &HelpListingMetadata{Shown: helpListingLimit, Total: len(selected), Hint: helpListingHint}
+		selected = selected[:helpListingLimit]
+	}
+	if options.Search == "" && listing == nil {
+		return text, nil
+	}
+
+	var projected strings.Builder
+	for _, line := range lines[:parametersLine+1] {
+		projected.WriteString(line)
+	}
+	if len(selected) == 0 {
+		fmt.Fprintf(&projected, noHelpSearchMatchesFormat+"\n", options.Search)
+	} else {
+		for _, block := range selected {
+			projected.WriteString(strings.TrimRight(block.text, "\n"))
+			projected.WriteByte('\n')
+		}
+	}
+	if listing != nil {
+		fmt.Fprintf(&projected, "\nShowing %d of %d parameters.\n%s\n", listing.Shown, listing.Total, listing.Hint)
+	}
+	projected.WriteByte('\n')
+	for _, line := range lines[globalParametersLine:] {
+		projected.WriteString(line)
+	}
+	return projected.String(), listing
+}
+
+func stripHelpANSI(value string) string {
+	for {
+		start := strings.Index(value, "\x1b[")
+		if start < 0 {
+			return value
+		}
+		end := strings.IndexByte(value[start:], 'm')
+		if end < 0 {
+			return value
+		}
+		value = value[:start] + value[start+end+1:]
+	}
+}
+
 func renderMachineHelpParameters(w io.Writer, parameters []machineHelpParameter) error {
 	for _, parameter := range parameters {
 		name := parameter.Name

--- a/openapi/help_projection_test.go
+++ b/openapi/help_projection_test.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -9,7 +10,46 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestProjectOriginalRequestHelpTextPreservesLayoutWhileCappingAndSearching(t *testing.T) {
+	var source strings.Builder
+	source.WriteString("Description: original renderer\n\nParameters:\n")
+	for index := 1; index <= 23; index++ {
+		fmt.Fprintf(&source, "  --parameter-%02d              string, help %02d\n", index, index)
+		if index == 2 {
+			source.WriteString("                              continuation stays aligned\n")
+		}
+	}
+	source.WriteString("\nGlobal Parameters:\n  --region                      string, original global help\n\nExamples:\n  aliyun demo list-items\n")
+
+	t.Run("AI mode caps only API parameters", func(t *testing.T) {
+		projected, listing := projectOriginalRequestHelpText(source.String(), helpOptions{}, true)
+
+		require.NotNil(t, listing)
+		assert.Equal(t, 20, listing.Shown)
+		assert.Equal(t, 23, listing.Total)
+		assert.Contains(t, projected, "Description: original renderer")
+		assert.Contains(t, projected, "--parameter-20")
+		assert.NotContains(t, projected, "--parameter-21")
+		assert.Contains(t, projected, "--region                      string, original global help")
+		assert.Contains(t, projected, "Examples:\n  aliyun demo list-items")
+		assert.Contains(t, projected, "Showing 20 of 23 parameters.")
+	})
+
+	t.Run("search keeps original matching blocks and all globals", func(t *testing.T) {
+		projected, listing := projectOriginalRequestHelpText(source.String(), helpOptions{Search: "parameter-02"}, true)
+
+		assert.Nil(t, listing)
+		assert.Contains(t, projected, "--parameter-02")
+		assert.Contains(t, projected, "continuation stays aligned")
+		assert.NotContains(t, projected, "--parameter-01")
+		assert.NotContains(t, projected, "--parameter-03")
+		assert.Contains(t, projected, "--region                      string, original global help")
+		assert.NotContains(t, projected, "Showing ")
+	})
+}
 
 func TestValidateRecoverySearchUsesRealCanonicalHelpProvider(t *testing.T) {
 	c, ctx, _, _ := newCanonicalHelpTestContext(t)


### PR DESCRIPTION
## Summary
- retain the canonical metadata v12 submodule update
- reuse the established runtime and legacy API Help rendering in AI mode
- cap and search only API parameter blocks while preserving global flags and formatting
- keep response query guidance as an additive block

## Test Plan
- focused OpenAPI Help projection regression test