### PR TITLE
fix: respect product help command style in search

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -1256,7 +1256,13 @@ func (c *Commando) help(ctx *cli.Context, args []string) error {
 			}
 			return c.finishCanonicalTextHelp(ctx, aiMode)
 		case len(args) == 1 && (helpOpts.Search != "" || helpOpts.All || aiMode):
-			document, buildErr := service.buildProduct(args[0], requestedMachineHelpVersion(ctx))
+			style := ""
+			if productHelpEnvEnabled(originalProductHelpEnv) {
+				style = "camel"
+			} else if productHelpEnvEnabled(baselineProductHelpEnv) {
+				style = "kebab"
+			}
+			document, buildErr := service.buildProductForStyle(args[0], requestedMachineHelpVersion(ctx), style)
 			if buildErr != nil {
 				return buildErr
 			}

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -798,6 +798,8 @@ func TestCanonicalTextHelpSearchesRootProductAndRequestLocally(t *testing.T) {
 	})
 
 	t.Run("product api", func(t *testing.T) {
+		t.Setenv(originalProductHelpEnv, "")
+		t.Setenv(baselineProductHelpEnv, "")
 		c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
 		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
 		CliHelpSearchFlag(ctx.Flags()).SetValue("region")
@@ -805,7 +807,24 @@ func TestCanonicalTextHelpSearchesRootProductAndRequestLocally(t *testing.T) {
 		require.NoError(t, c.help(ctx, []string{"demo"}))
 		assert.False(t, c.pluginLoaded)
 		assert.Empty(t, stderr.String())
-		assert.Contains(t, stdout.String(), "describe-regions")
+		assert.Contains(t, stdout.String(), "Version: 2026-01-01")
+		assert.Contains(t, stdout.String(), "  DescribeRegions")
+		assert.NotContains(t, stdout.String(), "  describe-regions")
+	})
+
+	t.Run("product api baseline kebab style", func(t *testing.T) {
+		t.Setenv(originalProductHelpEnv, "")
+		t.Setenv(baselineProductHelpEnv, "true")
+		c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
+		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
+		CliHelpSearchFlag(ctx.Flags()).SetValue("region")
+
+		require.NoError(t, c.help(ctx, []string{"demo"}))
+		assert.False(t, c.pluginLoaded)
+		assert.Empty(t, stderr.String())
+		assert.Contains(t, stdout.String(), "Version: 2025-01-01")
+		assert.Contains(t, stdout.String(), "  describe-regions")
+		assert.NotContains(t, stdout.String(), "  DescribeRegions")
 	})
 
 	t.Run("request parameter", func(t *testing.T) {

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -351,7 +351,10 @@ func renderCanonicalProductText(w io.Writer, document *machineHelpProductDocumen
 		return err
 	}
 	for _, api := range document.APIs {
-		name := api.CmdName
+		name := api.Name
+		if document.commandStyle != "camel" && api.CmdName != "" {
+			name = api.CmdName
+		}
 		if name == "" {
 			name = api.Name
 		}

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -132,6 +132,7 @@ type machineHelpProductDocument struct {
 	APIs          []machineHelpAPISummary `json:"apis"`
 	Listing       *machineHelpListing     `json:"listing"`
 	AIModeHint    *machineHelpAIModeHint  `json:"aiModeHint"`
+	commandStyle  string
 }
 
 type machineHelpOperation struct {
@@ -320,12 +321,26 @@ func (s *machineHelpService) buildRoot(root *cli.Command) (*machineHelpRootDocum
 }
 
 func (s *machineHelpService) buildProduct(code, requestedVersion string) (*machineHelpProductDocument, error) {
+	document, err := s.buildProductForStyle(code, requestedVersion, "kebab")
+	if document != nil {
+		document.Target.RequestedStyle = "product"
+	}
+	return document, err
+}
+
+func (s *machineHelpService) buildProductForStyle(code, requestedVersion, requestedStyle string) (*machineHelpProductDocument, error) {
 	product, err := s.findProduct(code)
 	if err != nil {
 		return nil, err
 	}
+	if requestedStyle == "" {
+		requestedStyle = "kebab"
+		if product.Version != "" {
+			requestedStyle = "camel"
+		}
+	}
 	versions := normalizedVersions(*product)
-	selected, err := selectProductVersion(*product, versions, requestedVersion)
+	selected, err := selectAPIVersion(*product, versions, requestedVersion, requestedStyle)
 	if err != nil {
 		return nil, err
 	}
@@ -358,6 +373,7 @@ func (s *machineHelpService) buildProduct(code, requestedVersion string) (*machi
 		Target:        machineHelpTarget{Path: []string{"aliyun", code}, RequestedStyle: "product"},
 		Product:       productDoc,
 		APIs:          apis,
+		commandStyle:  requestedStyle,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- render product-level --cli-search results in PascalCase for the default legacy Help mode
- render kebab-case results when ALIBABA_CLOUD_BASELINE_PRODUCT_HELP is enabled
- select the matching legacy or plugin default API version without affecting installed plugin Help

## Test Plan
- added focused coverage for default PascalCase and baseline kebab-case search output