### PR TITLE
fix: reject invalid product flags and tighten canonical Help

### DIFF
--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -89,6 +89,18 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		}, requests)
 	})
 
+	t.Run("short unknown API still uses validated product search", func(t *testing.T) {
+		cause := &InvalidApiError{Name: "get", product: &meta.Product{Code: "sts"}}
+		envelope := requireAgentEnvelope(t, cause, []string{"sts", "get"}, func(request RecoverySearchRequest) bool {
+			assert.Equal(t, RecoverySearchRequest{Product: "sts", Style: "kebab", Keyword: "get"}, request)
+			return true
+		})
+
+		assert.Equal(t, "search_api", envelope.Recovery.Action)
+		assert.Equal(t, "aliyun sts --help-search get", envelope.Recovery.Command)
+		assert.Equal(t, "Search APIs related to get.", envelope.Recovery.Hint)
+	})
+
 	t.Run("legacy unknown parameter message excludes Help recovery text", func(t *testing.T) {
 		cause := &InvalidParameterError{
 			Name: "InstnaceType", ProductCode: "ecs", ApiName: "RunInstances", ParameterNames: []string{"InstanceType"},

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -401,6 +401,9 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 					return runtimehost.Dispatch(ctx, pluginArgs)
 				}
 			} else {
+				if validationErr := c.validateCanonicalRuntimeCommand(args, ctx); validationErr != nil {
+					return validationErr
+				}
 				if handled, derr := runtimeTryDispatch(ctx, pluginArgs); handled {
 					return derr
 				}

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -837,6 +837,52 @@ func TestCanonicalTextHelpOmitsEnableHintWhenAIModeIsOn(t *testing.T) {
 	assert.NotContains(t, stdout.String(), cli.AIModeEnableCommand)
 }
 
+func TestCanonicalCamelProductTextHelpIncludesKebabSwitchHint(t *testing.T) {
+	t.Setenv(baselineProductHelpEnv, "")
+	originalAvailable := productHelpAvailable
+	productHelpAvailable = func(product string) bool { return product == "demo" }
+	t.Cleanup(func() { productHelpAvailable = originalAvailable })
+	c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
+	target := HelpTarget{
+		Level:        HelpLevelProduct,
+		Product:      "demo",
+		CommandStyle: CommandStyleCamel,
+		Operation:    HelpOperationDefault,
+		Output:       HelpOutputText,
+		Provider:     HelpProviderHost,
+	}
+
+	require.NoError(t, c.renderHostHelpTarget(ctx, target, false))
+	assert.Empty(t, stderr.String())
+	assert.Contains(t, stdout.String(), "set "+baselineProductHelpEnv+"=true")
+}
+
+func TestCanonicalProductJSONHonorsRawLanguageFlagBeforeParsing(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
+	ctx.SetInvocationArgs([]string{"demo", "--help-search", "report", "--cli-output", "json", "--language", "zh"})
+	target := HelpTarget{
+		Level:        HelpLevelProduct,
+		Product:      "demo",
+		CommandStyle: CommandStyleCamel,
+		Operation:    HelpOperationSearch,
+		SearchQuery:  "report",
+		Output:       HelpOutputJSON,
+		Provider:     HelpProviderHost,
+	}
+
+	require.NoError(t, c.renderHostHelpTarget(ctx, target, false))
+	assert.Empty(t, stderr.String())
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	apis := output["apis"].([]any)
+	require.Len(t, apis, 1)
+	assert.Equal(t, "创建报表。", apis[0].(map[string]any)["description"])
+}
+
 func TestCanonicalTextHelpKeepsConfiguredAIModeDisableHint(t *testing.T) {
 	testHome := t.TempDir()
 	cleanup := setTestHomeDir(t, testHome)

--- a/openapi/help_dispatch.go
+++ b/openapi/help_dispatch.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/openapi/runtimehost"
 )
 
@@ -35,13 +37,13 @@ func (c *Commando) beforeParseHelpRoute(ctx *cli.Context, args []string) (bool, 
 	}
 	requested := rawHelpRequested(args)
 	positionals := rawHelpPositionals(args)
-	if len(positionals) == 0 {
+	if len(positionals) > 0 && positionals[0] != "utils" && ctx != nil && ctx.Command() != nil && ctx.Command().GetSubCommand(positionals[0]) != nil {
+		return false, nil
+	}
+	if len(positionals) <= 1 {
 		if unknown := unknownRootOption(ctx, args); unknown != "" {
 			return true, cli.NewInvalidFlagError(unknown, ctx)
 		}
-	}
-	if len(positionals) > 0 && positionals[0] != "utils" && ctx != nil && ctx.Command() != nil && ctx.Command().GetSubCommand(positionals[0]) != nil {
-		return false, nil
 	}
 	implicitProductHelp := !requested && len(positionals) == 1
 	if !requested && !implicitProductHelp {
@@ -425,6 +427,7 @@ func (c *Commando) renderHostHelpTarget(ctx *cli.Context, target HelpTarget, aiM
 	if err := target.Validate(); err != nil {
 		return err
 	}
+	c.applyHostHelpLanguage(ctx)
 	service := newMachineHelpService(c.library.helpRepo)
 	jsonOutput := aiMode || target.Output == HelpOutputJSON
 	opts := helpOptions{
@@ -511,7 +514,41 @@ func (c *Commando) renderHostHelpTarget(ctx *cli.Context, target HelpTarget, aiM
 	if err := renderHostHelpText(ctx, document, target.SearchQuery); err != nil {
 		return err
 	}
+	if target.Level == HelpLevelProduct && target.CommandStyle == CommandStyleCamel &&
+		!productHelpEnvEnabled(baselineProductHelpEnv) && productHelpAvailable(target.Product) {
+		printProductHelpSwitchHint(ctx,
+			"To view baseline kebab-case product help, set "+baselineProductHelpEnv+"=true.",
+			"如需查看 baseline 的 kebab-case 产品帮助，请设置 "+baselineProductHelpEnv+"=true。")
+	}
 	return c.finishCanonicalTextHelp(ctx, aiMode)
+}
+
+func (c *Commando) applyHostHelpLanguage(ctx *cli.Context) {
+	lang := strings.TrimSpace(c.profile.Language)
+	if ctx != nil {
+		if flag := config.LanguageFlag(ctx.Flags()); flag != nil && flag.IsAssigned() {
+			lang = strings.TrimSpace(flag.GetStringOrDefault(lang))
+		}
+		if raw := rawHelpLanguage(ctx.InvocationArgs()); raw != "" {
+			lang = raw
+		}
+	}
+	switch strings.ToLower(lang) {
+	case "zh", "en":
+		i18n.SetLanguage(strings.ToLower(lang))
+	}
+}
+
+func rawHelpLanguage(args []string) string {
+	for index, arg := range args {
+		if strings.HasPrefix(arg, "--language=") {
+			return strings.TrimSpace(strings.TrimPrefix(arg, "--language="))
+		}
+		if arg == "--language" && index+1 < len(args) {
+			return strings.TrimSpace(args[index+1])
+		}
+	}
+	return ""
 }
 
 func rewriteResponseQueryVersionFlag(example *machineHelpQueryExample, versionFlag APIVersionFlag) {

--- a/openapi/help_dispatch_test.go
+++ b/openapi/help_dispatch_test.go
@@ -2,6 +2,8 @@ package openapi
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
@@ -109,6 +111,16 @@ func TestBeforeParseHelpRouteRejectsUnknownRootFlag(t *testing.T) {
 	assert.Equal(t, "--regoin", invalid.Flag)
 }
 
+func TestBeforeParseHelpRouteRejectsUnknownProductFlag(t *testing.T) {
+	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	handled, err := c.beforeParseHelpRoute(ctx, []string{"demo", "--hekp"})
+
+	assert.True(t, handled)
+	var invalid *cli.InvalidFlagError
+	require.True(t, errors.As(err, &invalid))
+	assert.Equal(t, "--hekp", invalid.Flag)
+}
+
 func TestValidateCanonicalAPICommandPrecedesProfileResolution(t *testing.T) {
 	c, ctx, _, _ := newCanonicalHelpTestContext(t)
 	ctx.SetInvocationArgs([]string{"demo", "MissingAPI", "--version", "2026-01-01"})
@@ -129,4 +141,53 @@ func TestValidateCanonicalAPICommandPrecedesProfileResolution(t *testing.T) {
 	var invalidParameter *InvalidParameterError
 	require.True(t, errors.As(err, &invalidParameter))
 	assert.Equal(t, "ReprotId", invalidParameter.Name)
+}
+
+func TestLowercaseCanonicalCommandIsValidatedBeforeRuntimeProfileResolution(t *testing.T) {
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	t.Cleanup(cleanup)
+	require.NoError(t, os.MkdirAll(filepath.Join(testHome, ".aliyun", "plugins"), 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(testHome, ".aliyun", "plugins", "manifest.json"),
+		[]byte(`{"plugins":{}}`),
+		0644,
+	))
+
+	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	ctx.SetInvocationArgs([]string{"demo", "get-caller"})
+	originalArgs := os.Args
+	os.Args = []string{"aliyun", "demo", "get-caller"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	runtimeCalled := false
+	originalDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		runtimeCalled = true
+		return true, errors.New("profile default: failed to resolve credentials")
+	}
+	t.Cleanup(func() { runtimeTryDispatch = originalDispatch })
+
+	err := c.main(ctx, []string{"demo", "get-caller"})
+	var invalid *InvalidApiError
+	require.True(t, errors.As(err, &invalid), "err=%T %v", err, err)
+	assert.Equal(t, "get-caller", invalid.Name)
+	assert.False(t, runtimeCalled, "local command identity must be checked before runtime/profile setup")
+}
+
+func TestBundledSTSUnknownCommandIsLocallyIdentified(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	root := testMachineHelpRootCommand()
+	AddFlags(root.Flags())
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(root)
+	ctx.SetInvocationArgs([]string{"sts", "get"})
+	assert.False(t, EstimateCostFlag(ctx.Flags()).IsAssigned())
+	assert.False(t, ForceFlag(ctx.Flags()).IsAssigned())
+
+	err := c.validateCanonicalRuntimeCommand([]string{"sts", "get"}, ctx)
+	var invalid *InvalidApiError
+	require.True(t, errors.As(err, &invalid), "err=%T %v", err, err)
+	assert.Equal(t, "get", invalid.Name)
+	require.NoError(t, c.validateCanonicalAPICommand([]string{"sts", "GET"}, ctx), "uppercase REST method remains exempt")
 }

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -1021,11 +1021,18 @@ func (c *Commando) finishCanonicalTextHelp(ctx *cli.Context, aiMode bool) error 
 }
 
 func localizedMachineHelpText(text machineHelpLocalizedText) string {
-	if i18n.GetLanguage() == "zh" && text.ZH != "" {
+	if localizedMachineHelpLanguage() == "zh" && text.ZH != "" {
 		return text.ZH
 	}
 	if text.EN != "" {
 		return text.EN
 	}
 	return text.ZH
+}
+
+func localizedMachineHelpLanguage() string {
+	if i18n.GetLanguage() == "zh" {
+		return "zh"
+	}
+	return "en"
 }

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -104,8 +104,12 @@ func applyRootHelpOptions(document *machineHelpRootDocument, options helpOptions
 			}
 			if entry.kind == "command" {
 				document.Commands = append(document.Commands, entry.command)
+				aliases := entry.command.Aliases
+				if entry.command.Group == string(RootGroupUtils) {
+					aliases = nil
+				}
 				document.Matches = append(document.Matches, machineHelpRootMatch{
-					Kind: "command", Name: entry.command.Name, Aliases: entry.command.Aliases,
+					Kind: "command", Name: entry.command.Name, Aliases: aliases,
 					Command: strings.Join(entry.command.Path, " ") + " --help", Description: entry.command.Description,
 				})
 			} else if entry.kind == "flag" {

--- a/openapi/local_command_validation.go
+++ b/openapi/local_command_validation.go
@@ -14,7 +14,7 @@ func (c *Commando) validateCanonicalAPICommand(args []string, ctx *cli.Context) 
 	if len(args) != 2 || c.library == nil || c.library.helpRepo == nil {
 		return nil
 	}
-	method := strings.ToUpper(args[1])
+	method := args[1]
 	if method == "GET" || method == "POST" || method == "PUT" || method == "DELETE" {
 		return nil
 	}
@@ -56,4 +56,18 @@ func (c *Commando) validateCanonicalAPICommand(args []string, ctx *cli.Context) 
 	default:
 		return nil
 	}
+}
+
+// validateCanonicalRuntimeCommand validates a command for products already
+// present in Canonical metadata without preventing unknown/plugin-only
+// products from continuing through the established runtime and auto-install
+// routing paths.
+func (c *Commando) validateCanonicalRuntimeCommand(args []string, ctx *cli.Context) error {
+	err := c.validateCanonicalAPICommand(args, ctx)
+	var invalidProduct *InvalidProductError
+	var invalidParameter *InvalidParameterError
+	if errors.As(err, &invalidProduct) || errors.As(err, &invalidParameter) {
+		return nil
+	}
+	return err
 }

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -84,6 +84,24 @@ type machineHelpLocalizedText struct {
 	ZH string `json:"zh"`
 }
 
+func (text machineHelpLocalizedText) MarshalJSON() ([]byte, error) {
+	return json.Marshal(localizedMachineHelpText(text))
+}
+
+func (text *machineHelpLocalizedText) UnmarshalJSON(data []byte) error {
+	var selected string
+	if err := json.Unmarshal(data, &selected); err == nil {
+		if localizedMachineHelpLanguage() == "zh" {
+			text.ZH = selected
+		} else {
+			text.EN = selected
+		}
+		return nil
+	}
+	type localizedTextJSON machineHelpLocalizedText
+	return json.Unmarshal(data, (*localizedTextJSON)(text))
+}
+
 type machineHelpCommandSummary struct {
 	Group       string                   `json:"group"`
 	Path        []string                 `json:"path"`
@@ -157,6 +175,21 @@ type machineHelpAPISummary struct {
 	Title       machineHelpLocalizedText `json:"title"`
 	Description machineHelpLocalizedText `json:"description"`
 	Deprecated  bool                     `json:"deprecated"`
+}
+
+func (summary machineHelpAPISummary) MarshalJSON() ([]byte, error) {
+	type apiSummaryJSON struct {
+		Name        string                   `json:"name"`
+		Title       machineHelpLocalizedText `json:"title"`
+		Description machineHelpLocalizedText `json:"description"`
+		Deprecated  bool                     `json:"deprecated,omitempty"`
+	}
+	return json.Marshal(apiSummaryJSON{
+		Name:        firstNonEmptyMachineHelpString(summary.DisplayName, summary.CmdName, summary.Name),
+		Title:       summary.Title,
+		Description: summary.Description,
+		Deprecated:  summary.Deprecated,
+	})
 }
 
 type machineHelpProductDocument struct {

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -1055,6 +1055,10 @@ func (document *machineHelpRootDocument) prepareJSONGroups() {
 	for _, command := range document.Commands {
 		switch command.Group {
 		case string(RootGroupUtils):
+			// Root-level aliases keep the historical hidden utility entrypoints
+			// searchable and executable, but they are implementation details and
+			// must not be exposed as part of the public utilities Help document.
+			command.Aliases = nil
 			document.Utilities = append(document.Utilities, command)
 		case string(RootGroupExtension):
 			document.Extensions = append(document.Extensions, command)

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -223,6 +223,53 @@ func TestMachineHelpAPIResponseUsesCanonicalSchemaAndReachableComponents(t *test
 	assert.Empty(t, doc.Notice)
 }
 
+func TestMachineHelpAPIResponseJSONKeepsOneLocalizedResponseSchema(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+
+	tests := []struct {
+		language        string
+		wantDescription string
+		wantTitle       string
+	}{
+		{language: "en", wantDescription: "The request ID.", wantTitle: "Report ID"},
+		{language: "zh", wantDescription: "请求 ID。", wantTitle: "报表 ID"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.language, func(t *testing.T) {
+			i18n.SetLanguage(tt.language)
+			service := testMachineHelpService(t)
+			doc, err := service.buildAPIResponse("demo", "CreateReport", "2026-01-01")
+			require.NoError(t, err)
+
+			var encoded bytes.Buffer
+			require.NoError(t, encodeMachineHelpJSON(&encoded, doc))
+			output := encoded.String()
+			assert.Contains(t, output, `"responses"`)
+			assert.Contains(t, output, `"components"`)
+			assert.NotContains(t, output, `"outputSchema"`)
+			assert.NotContains(t, output, `"description_en"`)
+			assert.NotContains(t, output, `"description_zh"`)
+			assert.NotContains(t, output, `"title_en"`)
+			assert.NotContains(t, output, `"title_zh"`)
+			assert.Contains(t, output, fmt.Sprintf(`"description": %q`, tt.wantDescription))
+			assert.Contains(t, output, fmt.Sprintf(`"title": %q`, tt.wantTitle))
+		})
+	}
+}
+
+func TestLocalizeMachineHelpRawJSONOmitsEmptyLocalizedText(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	localized, err := localizeMachineHelpRawJSON(json.RawMessage(
+		`{"type":"object","description_en":"","description_zh":""}`,
+	))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"object"}`, string(localized))
+}
+
 func TestMachineHelpAPIResponseWithoutSchemaReturnsNotice(t *testing.T) {
 	service := testMachineHelpService(t)
 	doc, err := service.buildAPIResponse("demo", "DescribeRegions", "2026-01-01")
@@ -430,11 +477,12 @@ func TestCommandoHelpJSONResponseSection(t *testing.T) {
 	assert.False(t, c.pluginLoaded)
 	assert.Empty(t, stderr.String())
 
-	var doc machineHelpAPIResponseDocument
+	var doc map[string]any
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &doc))
-	assert.Equal(t, helpSectionResponse, doc.Section)
-	require.NotNil(t, doc.OutputSchema)
-	assert.Equal(t, "200", doc.OutputSchema.StatusCode)
+	assert.Equal(t, helpSectionResponse, doc["section"])
+	assert.Contains(t, doc, "responses")
+	assert.Contains(t, doc, "components")
+	assert.NotContains(t, doc, "outputSchema")
 	assert.NotContains(t, stdout.String(), `"parameterSets"`)
 }
 

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -88,6 +88,32 @@ func TestMachineHelpProductExplicitVersion(t *testing.T) {
 	assert.Equal(t, "describe-regions", doc.APIs[1].CmdName)
 }
 
+func TestMachineHelpProductJSONUsesSelectedLanguageAndActiveCommandName(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	service := testMachineHelpService(t)
+	doc, err := service.buildProductForStyle("demo", "2026-01-01", "camel")
+	require.NoError(t, err)
+	require.Len(t, doc.APIs, 2)
+	doc.APIs[1].Deprecated = true
+
+	var encoded bytes.Buffer
+	require.NoError(t, encodeMachineHelpJSON(&encoded, doc))
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(encoded.Bytes(), &output))
+	apis := output["apis"].([]any)
+	first := apis[0].(map[string]any)
+	assert.Equal(t, "CreateReport", first["name"])
+	assert.Equal(t, "Creates a report.", first["description"])
+	assert.ElementsMatch(t, []string{"name", "description"}, mapKeys(first))
+	second := apis[1].(map[string]any)
+	assert.Equal(t, true, second["deprecated"])
+	assert.NotContains(t, second, "cmdName")
+	assert.NotContains(t, second, "displayName")
+}
+
 func TestMachineHelpAPICamelAndKebabShareCanonicalIdentity(t *testing.T) {
 	service := testMachineHelpService(t)
 	camel, err := service.buildAPI("demo", "CreateReport", "2026-01-01")

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -60,6 +60,53 @@ func TestMachineHelpRootJSONUsesExplicitGroups(t *testing.T) {
 	assert.Contains(t, raw, "products")
 }
 
+func TestMachineHelpRootJSONOmitsUtilityAliases(t *testing.T) {
+	doc := &machineHelpRootDocument{Commands: []machineHelpCommandSummary{
+		{
+			Group:   string(RootGroupCore),
+			Name:    "configure",
+			Aliases: []string{"setup"},
+		},
+		{
+			Group:   string(RootGroupUtils),
+			Name:    "utils go-migrate",
+			Aliases: []string{"go-migrate"},
+		},
+	}}
+
+	var output bytes.Buffer
+	require.NoError(t, encodeMachineHelpJSON(&output, doc))
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+
+	utilities := raw["utilities"].([]any)
+	require.Len(t, utilities, 1)
+	assert.NotContains(t, utilities[0].(map[string]any), "aliases")
+
+	coreCommands := raw["coreCommands"].([]any)
+	require.Len(t, coreCommands, 1)
+	assert.Equal(t, []any{"setup"}, coreCommands[0].(map[string]any)["aliases"])
+}
+
+func TestMachineHelpRootSearchJSONOmitsUtilityAliases(t *testing.T) {
+	doc := &machineHelpRootDocument{Commands: []machineHelpCommandSummary{{
+		Group:   string(RootGroupUtils),
+		Path:    []string{"aliyun", "utils", "go-migrate"},
+		Name:    "utils go-migrate",
+		Aliases: []string{"go-migrate"},
+	}}}
+	applyRootHelpOptions(doc, helpOptions{Search: "go-migrate"}, false)
+
+	var output bytes.Buffer
+	require.NoError(t, encodeMachineHelpJSON(&output, doc))
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+
+	matches := raw["matches"].([]any)
+	require.Len(t, matches, 1)
+	assert.NotContains(t, matches[0].(map[string]any), "aliases")
+}
+
 func TestMachineHelpProduct(t *testing.T) {
 	service := testMachineHelpService(t)
 	doc, err := service.buildProduct("demo", "")

--- a/openapi/response_help.go
+++ b/openapi/response_help.go
@@ -18,7 +18,11 @@ func renderResponseHelpText(w io.Writer, document *machineHelpAPIResponseDocumen
 		if _, err := fmt.Fprintln(w, "Responses:"); err != nil {
 			return err
 		}
-		if err := writeIndentedJSON(w, document.Responses); err != nil {
+		responses, err := localizeMachineHelpRawJSON(document.Responses)
+		if err != nil {
+			return err
+		}
+		if err := writeIndentedJSON(w, responses); err != nil {
 			return err
 		}
 		if err := renderMachineHelpComponents(w, document.Components); err != nil {
@@ -62,7 +66,11 @@ func renderResponseHelpText(w io.Writer, document *machineHelpAPIResponseDocumen
 	if _, err := fmt.Fprintf(w, "%s):\n", heading); err != nil {
 		return err
 	}
-	if err := writeIndentedJSON(w, document.OutputSchema.Schema); err != nil {
+	schema, err := localizeMachineHelpRawJSON(document.OutputSchema.Schema)
+	if err != nil {
+		return err
+	}
+	if err := writeIndentedJSON(w, schema); err != nil {
 		return err
 	}
 
@@ -83,12 +91,16 @@ func renderMachineHelpComponents(w io.Writer, components *machineHelpComponents)
 	if components == nil || len(components.Schemas) == 0 {
 		return nil
 	}
+	localized, err := localizeMachineHelpComponents(components)
+	if err != nil {
+		return err
+	}
 	if _, err := fmt.Fprintln(w, "\nComponents:"); err != nil {
 		return err
 	}
 	encoded, err := json.Marshal(struct {
 		Schemas map[string]json.RawMessage `json:"schemas"`
-	}{Schemas: components.Schemas})
+	}{Schemas: localized.Schemas})
 	if err != nil {
 		return err
 	}

--- a/openapi/response_help_locale.go
+++ b/openapi/response_help_locale.go
@@ -1,0 +1,145 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// MarshalJSON keeps the lossless OpenAPI responses/components view as the
+// public response Help contract. OutputSchema is an internal convenience view
+// of the same successful response and is emitted only for search projections,
+// where the complete responses document has intentionally been removed.
+func (document machineHelpAPIResponseDocument) MarshalJSON() ([]byte, error) {
+	type responseDocumentJSON machineHelpAPIResponseDocument
+
+	responses, err := localizeMachineHelpRawJSON(document.Responses)
+	if err != nil {
+		return nil, err
+	}
+	components, err := localizeMachineHelpComponents(document.Components)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputSchema *machineHelpOutputSchema
+	if len(bytes.TrimSpace(document.Responses)) == 0 {
+		outputSchema, err = localizeMachineHelpOutputSchema(document.OutputSchema)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return json.Marshal(struct {
+		responseDocumentJSON
+		Responses    json.RawMessage          `json:"responses"`
+		Components   *machineHelpComponents   `json:"components"`
+		OutputSchema *machineHelpOutputSchema `json:"outputSchema"`
+	}{
+		responseDocumentJSON: responseDocumentJSON(document),
+		Responses:            responses,
+		Components:           components,
+		OutputSchema:         outputSchema,
+	})
+}
+
+func localizeMachineHelpOutputSchema(schema *machineHelpOutputSchema) (*machineHelpOutputSchema, error) {
+	if schema == nil {
+		return nil, nil
+	}
+	localizedSchema, err := localizeMachineHelpRawJSON(schema.Schema)
+	if err != nil {
+		return nil, err
+	}
+	components, err := localizeMachineHelpComponents(schema.Components)
+	if err != nil {
+		return nil, err
+	}
+	return &machineHelpOutputSchema{
+		StatusCode:  schema.StatusCode,
+		ContentType: schema.ContentType,
+		Schema:      localizedSchema,
+		Components:  components,
+	}, nil
+}
+
+func localizeMachineHelpComponents(components *machineHelpComponents) (*machineHelpComponents, error) {
+	if components == nil {
+		return nil, nil
+	}
+	localized := &machineHelpComponents{Schemas: make(map[string]json.RawMessage, len(components.Schemas))}
+	for name, schema := range components.Schemas {
+		value, err := localizeMachineHelpRawJSON(schema)
+		if err != nil {
+			return nil, err
+		}
+		localized.Schemas[name] = value
+	}
+	return localized, nil
+}
+
+func localizeMachineHelpRawJSON(raw json.RawMessage) (json.RawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	localized := localizeMachineHelpJSONValue(value, localizedMachineHelpLanguage())
+	return json.Marshal(localized)
+}
+
+func localizeMachineHelpJSONValue(value any, language string) any {
+	switch typed := value.(type) {
+	case []any:
+		result := make([]any, len(typed))
+		for index, item := range typed {
+			result[index] = localizeMachineHelpJSONValue(item, language)
+		}
+		return result
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, item := range typed {
+			result[key] = localizeMachineHelpJSONValue(item, language)
+		}
+		projectMachineHelpLocalizedJSONText(result, "description", language)
+		projectMachineHelpLocalizedJSONText(result, "title", language)
+		return result
+	default:
+		return value
+	}
+}
+
+func projectMachineHelpLocalizedJSONText(node map[string]any, field, language string) {
+	enValue, enExists := node[field+"_en"]
+	zhValue, zhExists := node[field+"_zh"]
+	if !enExists && !zhExists {
+		return
+	}
+	en, enIsText := enValue.(string)
+	zh, zhIsText := zhValue.(string)
+	if (enExists && !enIsText) || (zhExists && !zhIsText) {
+		return
+	}
+	baseValue, baseExists := node[field]
+	base, baseIsText := baseValue.(string)
+	if baseExists && !baseIsText {
+		return
+	}
+
+	delete(node, field+"_en")
+	delete(node, field+"_zh")
+	var localized string
+	if language == "zh" {
+		localized = firstNonEmptyMachineHelpString(zh, base, en)
+	} else {
+		localized = firstNonEmptyMachineHelpString(en, base, zh)
+	}
+	if localized == "" {
+		delete(node, field)
+		return
+	}
+	node[field] = localized
+}

--- a/openapi/response_help_test.go
+++ b/openapi/response_help_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,4 +53,23 @@ func TestRenderResponseHelpTextKeepsFullResponsesWhenSuccessHasNoBody(t *testing
 	assert.Contains(t, output.String(), "Responses:")
 	assert.Contains(t, output.String(), `"400": {`)
 	assert.Contains(t, output.String(), "Notice: No response schema is available for this API.")
+}
+
+func TestRenderResponseHelpTextUsesSelectedSchemaLanguage(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("zh")
+
+	service := testMachineHelpService(t)
+	document, err := service.buildAPIResponse("demo", "CreateReport", "2026-01-01")
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, renderResponseHelpText(&output, document))
+	assert.Contains(t, output.String(), `"description": "请求 ID。"`)
+	assert.Contains(t, output.String(), `"title": "报表 ID"`)
+	assert.NotContains(t, output.String(), `"description_en"`)
+	assert.NotContains(t, output.String(), `"description_zh"`)
+	assert.NotContains(t, output.String(), `"title_en"`)
+	assert.NotContains(t, output.String(), `"title_zh"`)
 }


### PR DESCRIPTION
## Summary

- reject unknown product-level flags before implicit product Help can swallow them, with consistent human and AI-mode errors
- validate unknown canonical commands before runtime/profile initialization and keep recovery commands aligned with command style
- remove redundant response-schema and utility alias fields, while selecting only the configured language in Help output

## Test plan

- `make test`
- `make test-runtime`
- `make test-release`
- packed Linux binary: `aliyun ecs --hekp` exits 2 and reports the invalid flag in non-AI mode
- packed Linux binary: `ALIBABA_CLOUD_CLI_AI_MODE=1 aliyun ecs --hekp` exits 2 with structured JSON and `did_you_mean`
- packed Linux binary: `aliyun ecs --help` still exits 0 and renders product Help
