### PR TITLE
fix: honor --cli-output json for local errors

### DIFF
--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -934,6 +934,54 @@ func TestAgentErrorEnvelopeEndToEndIsOneCleanJSONDocument(t *testing.T) {
 	assert.Equal(t, "aliyun ecs describe-instances --help-search instance-type", recovery["command"])
 }
 
+func TestCLIOutputJSONStructuresLocalErrorWhenAIModeIsDisabled(t *testing.T) {
+	testHome := t.TempDir()
+	cleanupHome := setTestHomeDir(t, testHome)
+	defer cleanupHome()
+	writeMinimalConfigJSON(t, testHome)
+	require.NoError(t, os.MkdirAll(filepath.Join(testHome, ".aliyun", "plugins"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(testHome, ".aliyun", "plugins", "manifest.json"), []byte(`{"plugins":{}}`), 0644))
+	require.NoError(t, aimode.Save(filepath.Join(testHome, ".aliyun"), &aimode.AiConfig{Enabled: false}))
+	t.Setenv(aimode.EnvAIMode, "")
+	t.Setenv("NO_COLOR", "")
+
+	originalDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		unknown := &argparser.UnknownFlagError{Flag: "instnace-type", Known: []string{"image-id", "instance-type"}}
+		return true, &engine.UsageError{Code: "UNKNOWN_FLAG", Err: unknown}
+	}
+	defer func() { runtimeTryDispatch = originalDispatch }()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := &cli.Command{Name: "aliyun", EnableUnknownFlag: true}
+	config.AddFlags(cmd.Flags())
+	AddFlags(cmd.Flags())
+	commando := NewCommando(stdout, config.Profile{Language: "en"})
+	commando.InitWithCommand(cmd)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	cli.DisableExitCode()
+	defer cli.EnableExitCode()
+	originalArgs := os.Args
+	os.Args = []string{"aliyun", "ecs", "describe-instances", "--instnace-type", "ecs.g6.large", "--cli-output", "json", "--no-cli-ai-mode"}
+	defer func() { os.Args = originalArgs }()
+	cmd.Execute(ctx, os.Args[1:])
+
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "\n"))
+	assert.NotContains(t, stderr.String(), "\x1b[")
+	assert.NotContains(t, stderr.String(), cli.AIModeEnableTextHint)
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(stderr.Bytes(), &decoded))
+	assert.ElementsMatch(t, []string{"message", "did_you_mean", "recovery"}, mapKeys(decoded))
+	assert.Equal(t, []interface{}{"--instance-type"}, decoded["did_you_mean"])
+	recovery := decoded["recovery"].(map[string]interface{})
+	assert.Equal(t, "search_parameter", recovery["action"])
+	assert.Equal(t, "aliyun ecs describe-instances --help-search instance-type", recovery["command"])
+}
+
 func TestNonAIExplicitLocalErrorKeepsTextAndAppendsHintOnce(t *testing.T) {
 	testHome := t.TempDir()
 	cleanupHome := setTestHomeDir(t, testHome)

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -185,7 +185,7 @@ func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) 
 
 	enabled := c.applyEffectiveAIModeForArgs(ctx, args)
 
-	if !enabled {
+	if !enabled && !explicitLocalErrorJSONRequested(ctx, err) {
 		return err
 	}
 	normalizationArgs := recoveryNormalizationArgs(ctx, args)
@@ -198,6 +198,23 @@ func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) 
 		})
 	}
 	return agentErrorNormalizer(err, normalizationArgs)
+}
+
+// explicitLocalErrorJSONRequested reports whether the caller explicitly
+// selected JSON output for a CLI-local error. --cli-output is orthogonal to
+// Help, so this check belongs in the shared error-rendering gate rather than
+// the Help router. Remote server, network, and credential errors retain their
+// existing non-AI rendering.
+func explicitLocalErrorJSONRequested(ctx *cli.Context, err error) bool {
+	if ctx == nil || ctx.Flags() == nil || !cli.IsAIRecoveryEligible(err) {
+		return false
+	}
+	flag := CliOutputFlag(ctx.Flags())
+	if flag == nil || !flag.IsAssigned() {
+		return false
+	}
+	value, _ := flag.GetValue()
+	return strings.TrimSpace(value) == string(cli.HelpOutputJSON)
 }
 
 func (c *Commando) isExtensionInvocation(args []string) bool {


### PR DESCRIPTION
## Summary

- Honor explicit `--cli-output json` for supported host CLI local errors even when AI Mode is disabled.
- Preserve existing non-AI text output and avoid taking over external-plugin, server, network, or credential errors.
- Add an end-to-end regression test for the structured local-error path.

## Verification

- `make test`
- `make test-runtime`
- `make test-release`
- Packed-binary repro: `aliyun ecs DescribeInstances --bad-flag --cli-output json --no-cli-ai-mode`
- Packed-binary compatibility check: the same command without `--cli-output json` remains text plus the AI Mode hint.
- Packed-binary Help check: `aliyun ecs DescribeInstances --help --cli-section response --cli-output json`
