### PR TITLE
fix: consolidate canonical Help and local error behavior

### DIFF
--- a/openapi/agent_error.go
+++ b/openapi/agent_error.go
@@ -115,6 +115,14 @@ func normalizeAgentErrorWithSearch(err error, args []string, validate RecoverySe
 			invalidParameter.Name, parameterContext, validate)
 	}
 
+	var invalidBaseline *InvalidBaselineCommandError
+	if errors.As(err, &invalidBaseline) {
+		apiContext := context.withProductAPI(invalidBaseline.Product, invalidBaseline.Command)
+		message := fmt.Sprintf("%q is not a valid api.", invalidBaseline.Command)
+		return unknownAPIAgentError(err, message,
+			apiCandidateFormsForStyle(invalidBaseline.AgentSuggestions(), apiContext.style), apiContext, validate)
+	}
+
 	var invalidAPI *InvalidApiError
 	if errors.As(err, &invalidAPI) {
 		apiContext := context
@@ -131,14 +139,6 @@ func normalizeAgentErrorWithSearch(err error, args []string, validate RecoverySe
 			apiContext = context.withProductAPI(invalidUnifiedAPI.product.GetLowerCode(), invalidUnifiedAPI.Name)
 		}
 		return unknownAPIAgentError(err, invalidUnifiedAPI.AgentMessage(), apiCandidateFormsForStyle(invalidUnifiedAPI.AgentSuggestions(), apiContext.style), apiContext, validate)
-	}
-
-	var invalidBaseline *InvalidBaselineCommandError
-	if errors.As(err, &invalidBaseline) {
-		apiContext := context.withProductAPI(invalidBaseline.Product, invalidBaseline.Command)
-		message := fmt.Sprintf("%q is not a valid api.", invalidBaseline.Command)
-		return unknownAPIAgentError(err, message,
-			apiCandidateFormsForStyle(invalidBaseline.AgentSuggestions(), apiContext.style), apiContext, validate)
 	}
 
 	var unknownCommand *engine.UnknownCommandError

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -946,6 +946,54 @@ func TestAgentErrorEnvelopeEndToEndIsOneCleanJSONDocument(t *testing.T) {
 	assert.Equal(t, "aliyun ecs describe-instances --help-search instance-type", recovery["command"])
 }
 
+func TestCLIOutputJSONStructuresLocalErrorWhenAIModeIsDisabled(t *testing.T) {
+	testHome := t.TempDir()
+	cleanupHome := setTestHomeDir(t, testHome)
+	defer cleanupHome()
+	writeMinimalConfigJSON(t, testHome)
+	require.NoError(t, os.MkdirAll(filepath.Join(testHome, ".aliyun", "plugins"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(testHome, ".aliyun", "plugins", "manifest.json"), []byte(`{"plugins":{}}`), 0644))
+	require.NoError(t, aimode.Save(filepath.Join(testHome, ".aliyun"), &aimode.AiConfig{Enabled: false}))
+	t.Setenv(aimode.EnvAIMode, "")
+	t.Setenv("NO_COLOR", "")
+
+	originalDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		unknown := &argparser.UnknownFlagError{Flag: "instnace-type", Known: []string{"image-id", "instance-type"}}
+		return true, &engine.UsageError{Code: "UNKNOWN_FLAG", Err: unknown}
+	}
+	defer func() { runtimeTryDispatch = originalDispatch }()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := &cli.Command{Name: "aliyun", EnableUnknownFlag: true}
+	config.AddFlags(cmd.Flags())
+	AddFlags(cmd.Flags())
+	commando := NewCommando(stdout, config.Profile{Language: "en"})
+	commando.InitWithCommand(cmd)
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(cmd)
+
+	cli.DisableExitCode()
+	defer cli.EnableExitCode()
+	originalArgs := os.Args
+	os.Args = []string{"aliyun", "ecs", "describe-instances", "--instnace-type", "ecs.g6.large", "--cli-output", "json", "--no-cli-ai-mode"}
+	defer func() { os.Args = originalArgs }()
+	cmd.Execute(ctx, os.Args[1:])
+
+	assert.Empty(t, stdout.String())
+	assert.Equal(t, 1, strings.Count(stderr.String(), "\n"))
+	assert.NotContains(t, stderr.String(), "\x1b[")
+	assert.NotContains(t, stderr.String(), cli.AIModeEnableTextHint)
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(stderr.Bytes(), &decoded))
+	assert.ElementsMatch(t, []string{"message", "did_you_mean", "recovery"}, mapKeys(decoded))
+	assert.Equal(t, []interface{}{"--instance-type"}, decoded["did_you_mean"])
+	recovery := decoded["recovery"].(map[string]interface{})
+	assert.Equal(t, "search_parameter", recovery["action"])
+	assert.Equal(t, "aliyun ecs describe-instances --help-search instance-type", recovery["command"])
+}
+
 func TestNonAIExplicitLocalErrorKeepsTextAndAppendsHintOnce(t *testing.T) {
 	testHome := t.TempDir()
 	cleanupHome := setTestHomeDir(t, testHome)

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -90,6 +90,18 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		}, requests)
 	})
 
+	t.Run("short unknown API still uses validated product search", func(t *testing.T) {
+		cause := &InvalidApiError{Name: "get", product: &meta.Product{Code: "sts"}}
+		envelope := requireAgentEnvelope(t, cause, []string{"sts", "get"}, func(request RecoverySearchRequest) bool {
+			assert.Equal(t, RecoverySearchRequest{Product: "sts", Style: "kebab", Keyword: "get"}, request)
+			return true
+		})
+
+		assert.Equal(t, "search_api", envelope.Recovery.Action)
+		assert.Equal(t, "aliyun sts --help-search get", envelope.Recovery.Command)
+		assert.Equal(t, "Search APIs related to get.", envelope.Recovery.Hint)
+	})
+
 	t.Run("legacy unknown parameter message excludes Help recovery text", func(t *testing.T) {
 		cause := &InvalidParameterError{
 			Name: "InstnaceType", ProductCode: "ecs", ApiName: "RunInstances", ParameterNames: []string{"InstanceType"},

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -98,7 +98,7 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		})
 
 		assert.Equal(t, "search_api", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun sts --help-search get", envelope.Recovery.Command)
+		assert.Equal(t, "ALIBABA_CLOUD_BASELINE_PRODUCT_HELP=true aliyun sts --help-search get", envelope.Recovery.Command)
 		assert.Equal(t, "Search APIs related to get.", envelope.Recovery.Hint)
 	})
 
@@ -605,12 +605,12 @@ func TestNormalizeAgentErrorOAuthRefreshFailure(t *testing.T) {
 func TestNormalizeAgentErrorServerErrorsShareOneEnvelope(t *testing.T) {
 	serverBody := `{"RequestId":"req-1","Code":"Throttling.User","Message":"slow down"}`
 	tests := []struct {
-		name           string
-		err            error
-		wantMessage    string
-		wantCode       string
-		wantStatus     int
-		wantRequestID  string
+		name          string
+		err           error
+		wantMessage   string
+		wantCode      string
+		wantStatus    int
+		wantRequestID string
 	}{
 		{
 			name:          "old SDK server keeps request id",

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -353,6 +353,22 @@ func TestNormalizeAgentErrorRedactsHeaderValuesAndBodyFilePaths(t *testing.T) {
 }
 
 func TestNormalizeAgentErrorSearchValidationFallbackAndCommandStyle(t *testing.T) {
+	t.Run("baseline wrapper wins over its canonical unknown API cause", func(t *testing.T) {
+		cause := &InvalidBaselineCommandError{
+			Product:    "sts",
+			Command:    "get-caller",
+			Candidates: []string{"assume-role", "get-caller-identity"},
+			Err:        &InvalidApiError{Name: "get-caller"},
+		}
+		envelope := requireAgentEnvelope(t, cause, []string{"sts", "get-caller"}, func(got RecoverySearchRequest) bool {
+			return got.Style == "kebab" && got.Keyword == "caller-identity"
+		})
+
+		assert.Equal(t, []string{"get-caller-identity"}, envelope.DidYouMean)
+		assert.Equal(t, "search_api", envelope.Recovery.Action)
+		assert.Equal(t, "ALIBABA_CLOUD_BASELINE_PRODUCT_HELP=true aliyun sts --help-search caller-identity", envelope.Recovery.Command)
+	})
+
 	t.Run("baseline unknown API tokenizes the invalid name and uses a validated keyword", func(t *testing.T) {
 		cause := &InvalidBaselineCommandError{
 			Product: "bssopenapi",

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -1344,7 +1344,13 @@ func (c *Commando) legacyHelp(ctx *cli.Context, args []string) error {
 			}
 			return c.finishCanonicalTextHelp(ctx, aiMode)
 		case len(args) == 1 && (helpOpts.Search != "" || helpOpts.All || aiMode):
-			document, buildErr := service.buildProduct(args[0], requestedMachineHelpVersion(ctx))
+			style := ""
+			if productHelpEnvEnabled(originalProductHelpEnv) {
+				style = "camel"
+			} else if productHelpEnvEnabled(baselineProductHelpEnv) {
+				style = "kebab"
+			}
+			document, buildErr := service.buildProductForStyle(args[0], requestedMachineHelpVersion(ctx), style)
 			if buildErr != nil {
 				return buildErr
 			}

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -185,7 +185,7 @@ func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) 
 
 	enabled := c.applyEffectiveAIModeForArgs(ctx, args)
 
-	if !enabled {
+	if !enabled && !explicitLocalErrorJSONRequested(ctx, err) {
 		return err
 	}
 	normalizationArgs := recoveryNormalizationArgs(ctx, args)
@@ -198,6 +198,23 @@ func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) 
 		})
 	}
 	return agentErrorNormalizer(err, normalizationArgs)
+}
+
+// explicitLocalErrorJSONRequested reports whether the caller explicitly
+// selected JSON output for a CLI-local error. --cli-output is orthogonal to
+// Help, so this check belongs in the shared error-rendering gate rather than
+// the Help router. Remote server, network, and credential errors retain their
+// existing non-AI rendering.
+func explicitLocalErrorJSONRequested(ctx *cli.Context, err error) bool {
+	if ctx == nil || ctx.Flags() == nil || !cli.IsAIRecoveryEligible(err) {
+		return false
+	}
+	flag := CliOutputFlag(ctx.Flags())
+	if flag == nil || !flag.IsAssigned() {
+		return false
+	}
+	value, _ := flag.GetValue()
+	return strings.TrimSpace(value) == string(cli.HelpOutputJSON)
 }
 
 func (c *Commando) isExtensionInvocation(args []string) bool {

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -429,6 +429,9 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 					return c.adaptEngineUnknownCommand(runtimehost.Dispatch(ctx, pluginArgs))
 				}
 			} else {
+				if validationErr := c.validateCanonicalRuntimeCommand(args, ctx); validationErr != nil {
+					return validationErr
+				}
 				if handled, derr := runtimeTryDispatch(ctx, pluginArgs); handled {
 					return c.adaptEngineUnknownCommand(derr)
 				}

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -845,6 +845,52 @@ func TestCanonicalTextHelpOmitsEnableHintWhenAIModeIsOn(t *testing.T) {
 	assert.NotContains(t, stdout.String(), cli.AIModeEnableCommand)
 }
 
+func TestCanonicalCamelProductTextHelpIncludesKebabSwitchHint(t *testing.T) {
+	t.Setenv(baselineProductHelpEnv, "")
+	originalAvailable := productHelpAvailable
+	productHelpAvailable = func(product string) bool { return product == "demo" }
+	t.Cleanup(func() { productHelpAvailable = originalAvailable })
+	c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
+	target := HelpTarget{
+		Level:        HelpLevelProduct,
+		Product:      "demo",
+		CommandStyle: CommandStyleCamel,
+		Operation:    HelpOperationDefault,
+		Output:       HelpOutputText,
+		Provider:     HelpProviderHost,
+	}
+
+	require.NoError(t, c.renderHostHelpTarget(ctx, target, false))
+	assert.Empty(t, stderr.String())
+	assert.Contains(t, stdout.String(), "set "+baselineProductHelpEnv+"=true")
+}
+
+func TestCanonicalProductJSONHonorsRawLanguageFlagBeforeParsing(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
+	ctx.SetInvocationArgs([]string{"demo", "--help-search", "report", "--cli-output", "json", "--language", "zh"})
+	target := HelpTarget{
+		Level:        HelpLevelProduct,
+		Product:      "demo",
+		CommandStyle: CommandStyleCamel,
+		Operation:    HelpOperationSearch,
+		SearchQuery:  "report",
+		Output:       HelpOutputJSON,
+		Provider:     HelpProviderHost,
+	}
+
+	require.NoError(t, c.renderHostHelpTarget(ctx, target, false))
+	assert.Empty(t, stderr.String())
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	apis := output["apis"].([]any)
+	require.Len(t, apis, 1)
+	assert.Equal(t, "创建报表。", apis[0].(map[string]any)["description"])
+}
+
 func TestCanonicalTextHelpKeepsConfiguredAIModeDisableHint(t *testing.T) {
 	testHome := t.TempDir()
 	cleanup := setTestHomeDir(t, testHome)

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -808,6 +808,8 @@ func TestCanonicalTextHelpSearchesRootProductAndRequestLocally(t *testing.T) {
 	})
 
 	t.Run("product api", func(t *testing.T) {
+		t.Setenv(originalProductHelpEnv, "")
+		t.Setenv(baselineProductHelpEnv, "")
 		c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
 		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
 		CliHelpSearchFlag(ctx.Flags()).SetValue("region")
@@ -815,7 +817,24 @@ func TestCanonicalTextHelpSearchesRootProductAndRequestLocally(t *testing.T) {
 		require.NoError(t, c.help(ctx, []string{"demo"}))
 		assert.False(t, c.pluginLoaded)
 		assert.Empty(t, stderr.String())
-		assert.Contains(t, stdout.String(), "DescribeRegions")
+		assert.Contains(t, stdout.String(), "Version: 2026-01-01")
+		assert.Contains(t, stdout.String(), "  DescribeRegions")
+		assert.NotContains(t, stdout.String(), "  describe-regions")
+	})
+
+	t.Run("product api baseline kebab style", func(t *testing.T) {
+		t.Setenv(originalProductHelpEnv, "")
+		t.Setenv(baselineProductHelpEnv, "true")
+		c, ctx, stdout, stderr := newCanonicalHelpTestContext(t)
+		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
+		CliHelpSearchFlag(ctx.Flags()).SetValue("region")
+
+		require.NoError(t, c.help(ctx, []string{"demo"}))
+		assert.False(t, c.pluginLoaded)
+		assert.Empty(t, stderr.String())
+		assert.Contains(t, stdout.String(), "Version: 2025-01-01")
+		assert.Contains(t, stdout.String(), "  describe-regions")
+		assert.NotContains(t, stdout.String(), "  DescribeRegions")
 	})
 
 	t.Run("request parameter", func(t *testing.T) {

--- a/openapi/help_dispatch.go
+++ b/openapi/help_dispatch.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/openapi/runtimehost"
 )
 
@@ -35,13 +37,13 @@ func (c *Commando) beforeParseHelpRoute(ctx *cli.Context, args []string) (bool, 
 	}
 	requested := rawHelpRequested(args)
 	positionals := rawHelpPositionals(args)
-	if len(positionals) == 0 {
+	if len(positionals) > 0 && positionals[0] != "utils" && ctx != nil && ctx.Command() != nil && ctx.Command().GetSubCommand(positionals[0]) != nil {
+		return false, nil
+	}
+	if len(positionals) <= 1 {
 		if unknown := unknownRootOption(ctx, args); unknown != "" {
 			return true, cli.NewInvalidFlagError(unknown, ctx)
 		}
-	}
-	if len(positionals) > 0 && positionals[0] != "utils" && ctx != nil && ctx.Command() != nil && ctx.Command().GetSubCommand(positionals[0]) != nil {
-		return false, nil
 	}
 	implicitProductHelp := !requested && len(positionals) == 1
 	if !requested && !implicitProductHelp {
@@ -456,6 +458,7 @@ func (c *Commando) renderHostHelpTarget(ctx *cli.Context, target HelpTarget, aiM
 	if err := target.Validate(); err != nil {
 		return err
 	}
+	c.applyHostHelpLanguage(ctx)
 	service := newMachineHelpService(c.library.helpRepo)
 	jsonOutput := aiMode || target.Output == HelpOutputJSON
 	opts := helpOptions{
@@ -557,7 +560,41 @@ func (c *Commando) renderHostHelpTarget(ctx *cli.Context, target HelpTarget, aiM
 	if err := renderHostHelpText(ctx, document, target.SearchQuery); err != nil {
 		return err
 	}
+	if target.Level == HelpLevelProduct && target.CommandStyle == CommandStyleCamel &&
+		!productHelpEnvEnabled(baselineProductHelpEnv) && productHelpAvailable(target.Product) {
+		printProductHelpSwitchHint(ctx,
+			"To view baseline kebab-case product help, set "+baselineProductHelpEnv+"=true.",
+			"如需查看 baseline 的 kebab-case 产品帮助，请设置 "+baselineProductHelpEnv+"=true。")
+	}
 	return c.finishCanonicalTextHelp(ctx, aiMode)
+}
+
+func (c *Commando) applyHostHelpLanguage(ctx *cli.Context) {
+	lang := strings.TrimSpace(c.profile.Language)
+	if ctx != nil {
+		if flag := config.LanguageFlag(ctx.Flags()); flag != nil && flag.IsAssigned() {
+			lang = strings.TrimSpace(flag.GetStringOrDefault(lang))
+		}
+		if raw := rawHelpLanguage(ctx.InvocationArgs()); raw != "" {
+			lang = raw
+		}
+	}
+	switch strings.ToLower(lang) {
+	case "zh", "en":
+		i18n.SetLanguage(strings.ToLower(lang))
+	}
+}
+
+func rawHelpLanguage(args []string) string {
+	for index, arg := range args {
+		if strings.HasPrefix(arg, "--language=") {
+			return strings.TrimSpace(strings.TrimPrefix(arg, "--language="))
+		}
+		if arg == "--language" && index+1 < len(args) {
+			return strings.TrimSpace(args[index+1])
+		}
+	}
+	return ""
 }
 
 func rewriteResponseQueryVersionFlag(example *machineHelpQueryExample, versionFlag APIVersionFlag) {

--- a/openapi/help_dispatch_test.go
+++ b/openapi/help_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -121,6 +122,16 @@ func TestBeforeParseHelpRouteRejectsUnknownRootFlag(t *testing.T) {
 	var invalid *cli.InvalidFlagError
 	require.True(t, errors.As(err, &invalid))
 	assert.Equal(t, "--regoin", invalid.Flag)
+}
+
+func TestBeforeParseHelpRouteRejectsUnknownProductFlag(t *testing.T) {
+	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	handled, err := c.beforeParseHelpRoute(ctx, []string{"demo", "--hekp"})
+
+	assert.True(t, handled)
+	var invalid *cli.InvalidFlagError
+	require.True(t, errors.As(err, &invalid))
+	assert.Equal(t, "--hekp", invalid.Flag)
 }
 
 func TestValidateCanonicalAPICommandPrecedesProfileResolution(t *testing.T) {
@@ -243,4 +254,53 @@ func TestGoPluginHelpDelegationKeepsPascalCaseWithHost(t *testing.T) {
 		assert.True(t, delegated)
 		assert.True(t, *dispatched)
 	})
+}
+
+func TestLowercaseCanonicalCommandIsValidatedBeforeRuntimeProfileResolution(t *testing.T) {
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	t.Cleanup(cleanup)
+	require.NoError(t, os.MkdirAll(filepath.Join(testHome, ".aliyun", "plugins"), 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(testHome, ".aliyun", "plugins", "manifest.json"),
+		[]byte(`{"plugins":{}}`),
+		0644,
+	))
+
+	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	ctx.SetInvocationArgs([]string{"demo", "get-caller"})
+	originalArgs := os.Args
+	os.Args = []string{"aliyun", "demo", "get-caller"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	runtimeCalled := false
+	originalDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		runtimeCalled = true
+		return true, errors.New("profile default: failed to resolve credentials")
+	}
+	t.Cleanup(func() { runtimeTryDispatch = originalDispatch })
+
+	err := c.main(ctx, []string{"demo", "get-caller"})
+	var invalid *InvalidApiError
+	require.True(t, errors.As(err, &invalid), "err=%T %v", err, err)
+	assert.Equal(t, "get-caller", invalid.Name)
+	assert.False(t, runtimeCalled, "local command identity must be checked before runtime/profile setup")
+}
+
+func TestBundledSTSUnknownCommandIsLocallyIdentified(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	root := testMachineHelpRootCommand()
+	AddFlags(root.Flags())
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(root)
+	ctx.SetInvocationArgs([]string{"sts", "get"})
+	assert.False(t, EstimateCostFlag(ctx.Flags()).IsAssigned())
+	assert.False(t, ForceFlag(ctx.Flags()).IsAssigned())
+
+	err := c.validateCanonicalRuntimeCommand([]string{"sts", "get"}, ctx)
+	var invalid *InvalidApiError
+	require.True(t, errors.As(err, &invalid), "err=%T %v", err, err)
+	assert.Equal(t, "get", invalid.Name)
+	require.NoError(t, c.validateCanonicalAPICommand([]string{"sts", "GET"}, ctx), "uppercase REST method remains exempt")
 }

--- a/openapi/help_dispatch_test.go
+++ b/openapi/help_dispatch_test.go
@@ -126,6 +126,16 @@ func TestBeforeParseHelpRouteRejectsUnknownRootFlag(t *testing.T) {
 
 func TestBeforeParseHelpRouteRejectsUnknownProductFlag(t *testing.T) {
 	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	c.localManifest = &plugin.LocalManifest{Plugins: map[string]plugin.LocalPlugin{
+		"aliyun-cli-demo": {Name: "aliyun-cli-demo", Version: "1.0.0", Type: plugin.PluginTypeGo},
+	}}
+	originalDispatch := goPluginHelpDispatch
+	goPluginHelpDispatch = func(string, []string, *cli.Context) (bool, error) {
+		t.Fatal("the host must reject an invalid product-level flag before plugin Help delegation")
+		return false, nil
+	}
+	t.Cleanup(func() { goPluginHelpDispatch = originalDispatch })
+
 	handled, err := c.beforeParseHelpRoute(ctx, []string{"demo", "--hekp"})
 
 	assert.True(t, handled)
@@ -294,13 +304,14 @@ func TestBundledSTSUnknownCommandIsLocallyIdentified(t *testing.T) {
 	AddFlags(root.Flags())
 	ctx := cli.NewCommandContext(stdout, stderr)
 	ctx.EnterCommand(root)
-	ctx.SetInvocationArgs([]string{"sts", "get"})
+	ctx.SetInvocationArgs([]string{"sts", "get-caller"})
 	assert.False(t, EstimateCostFlag(ctx.Flags()).IsAssigned())
 	assert.False(t, ForceFlag(ctx.Flags()).IsAssigned())
 
-	err := c.validateCanonicalRuntimeCommand([]string{"sts", "get"}, ctx)
-	var invalid *InvalidApiError
+	err := c.validateCanonicalRuntimeCommand([]string{"sts", "get-caller"}, ctx)
+	var invalid *InvalidBaselineCommandError
 	require.True(t, errors.As(err, &invalid), "err=%T %v", err, err)
-	assert.Equal(t, "get", invalid.Name)
+	assert.Equal(t, "get-caller", invalid.Command)
+	assert.Contains(t, invalid.AgentSuggestions(), "get-caller-identity")
 	require.NoError(t, c.validateCanonicalAPICommand([]string{"sts", "GET"}, ctx), "uppercase REST method remains exempt")
 }

--- a/openapi/help_document_v2_test.go
+++ b/openapi/help_document_v2_test.go
@@ -59,6 +59,13 @@ func TestProductDefaultAllAndSearchProjectionSemantics(t *testing.T) {
 	require.NoError(t, renderCanonicalProductText(&defaultText, defaultDocument, ""))
 	assert.Contains(t, defaultText.String(), fmt.Sprintf("...\nShowing %d of 105 APIs.", wantShown))
 
+	nonAIDocument := newDocument()
+	applyProductHelpOptions(nonAIDocument, helpOptions{}, false)
+	assert.Len(t, nonAIDocument.APIs, 105)
+	assert.Equal(t, "Item title", nonAIDocument.APIs[0].Title.EN)
+	assert.Equal(t, "Complete item description", nonAIDocument.APIs[0].Description.EN)
+	assert.Equal(t, HelpResult{Shown: 105, Total: 105}, nonAIDocument.Result)
+
 	allDocument := newDocument()
 	applyProductHelpOptions(allDocument, helpOptions{All: true}, true)
 	assert.Len(t, allDocument.APIs, 105)

--- a/openapi/help_policy.go
+++ b/openapi/help_policy.go
@@ -5,9 +5,10 @@ const defaultHelpLogicalLineBudget = 100
 // These are internal policy switches, deliberately not flags or environment
 // variables. Keeping them here makes Text/JSON projection share one policy.
 const (
-	truncateNonAIModeTextHelp                  = true
-	truncateNonAIModeJSONHelp                  = true
-	showProductActionDescriptionsInDefaultHelp = false
+	truncateNonAIModeTextHelp                           = false
+	truncateNonAIModeJSONHelp                           = false
+	showProductActionDescriptionsInAIModeDefaultHelp    = false
+	showProductActionDescriptionsInNonAIModeDefaultHelp = true
 )
 
 // HelpResult describes the selected object range. It is present for both
@@ -80,6 +81,13 @@ func ShouldTruncateDefaultHelp(mode HelpProjectionMode) bool {
 		return truncateNonAIModeJSONHelp
 	}
 	return truncateNonAIModeTextHelp
+}
+
+func shouldShowProductActionDescriptions(aiMode bool) bool {
+	if aiMode {
+		return showProductActionDescriptionsInAIModeDefaultHelp
+	}
+	return showProductActionDescriptionsInNonAIModeDefaultHelp
 }
 
 // ProjectDefaultHelpObjects selects a stable prefix of complete objects under

--- a/openapi/help_policy_test.go
+++ b/openapi/help_policy_test.go
@@ -65,8 +65,7 @@ func TestProjectDefaultHelpObjectsAllAndInternalSwitches(t *testing.T) {
 	assert.Nil(t, all.Next)
 
 	assert.True(t, ShouldTruncateDefaultHelp(HelpProjectionMode{AIMode: true, JSON: true}))
-	assert.True(t, ShouldTruncateDefaultHelp(HelpProjectionMode{JSON: true}))
-	assert.True(t, ShouldTruncateDefaultHelp(HelpProjectionMode{}))
+	assert.False(t, ShouldTruncateDefaultHelp(HelpProjectionMode{JSON: true}))
+	assert.False(t, ShouldTruncateDefaultHelp(HelpProjectionMode{}))
 	assert.False(t, ShouldTruncateDefaultHelp(HelpProjectionMode{All: true}))
-	assert.False(t, showProductActionDescriptionsInDefaultHelp)
 }

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -106,8 +106,12 @@ func applyRootHelpOptions(document *machineHelpRootDocument, options helpOptions
 			}
 			if entry.kind == "command" {
 				document.Commands = append(document.Commands, entry.command)
+				aliases := entry.command.Aliases
+				if entry.command.Group == string(RootGroupUtils) {
+					aliases = nil
+				}
 				document.Matches = append(document.Matches, machineHelpRootMatch{
-					Kind: "command", Name: entry.command.Name, Aliases: entry.command.Aliases,
+					Kind: "command", Name: entry.command.Name, Aliases: aliases,
 					Command: strings.Join(entry.command.Path, " ") + " --help", Description: entry.command.Description,
 				})
 			} else if entry.kind == "flag" {

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -253,7 +253,7 @@ func applyProductHelpOptions(document *machineHelpProductDocument, options helpO
 	document.Next = projection.Next
 	document.Listing = nil
 
-	if !options.All && !showProductActionDescriptionsInDefaultHelp {
+	if !options.All && !shouldShowProductActionDescriptions(aiMode) {
 		for index := range document.APIs {
 			document.APIs[index].Title = machineHelpLocalizedText{}
 			document.APIs[index].Description = machineHelpLocalizedText{}

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -1251,11 +1251,18 @@ func (c *Commando) finishCanonicalTextHelp(ctx *cli.Context, aiMode bool) error 
 }
 
 func localizedMachineHelpText(text machineHelpLocalizedText) string {
-	if i18n.GetLanguage() == "zh" && text.ZH != "" {
+	if localizedMachineHelpLanguage() == "zh" && text.ZH != "" {
 		return text.ZH
 	}
 	if text.EN != "" {
 		return text.EN
 	}
 	return text.ZH
+}
+
+func localizedMachineHelpLanguage() string {
+	if i18n.GetLanguage() == "zh" {
+		return "zh"
+	}
+	return "en"
 }

--- a/openapi/local_command_validation.go
+++ b/openapi/local_command_validation.go
@@ -14,7 +14,7 @@ func (c *Commando) validateCanonicalAPICommand(args []string, ctx *cli.Context) 
 	if len(args) != 2 || c.library == nil || c.library.helpRepo == nil {
 		return nil
 	}
-	method := strings.ToUpper(args[1])
+	method := args[1]
 	if method == "GET" || method == "POST" || method == "PUT" || method == "DELETE" {
 		return nil
 	}
@@ -56,4 +56,18 @@ func (c *Commando) validateCanonicalAPICommand(args []string, ctx *cli.Context) 
 	default:
 		return nil
 	}
+}
+
+// validateCanonicalRuntimeCommand validates a command for products already
+// present in Canonical metadata without preventing unknown/plugin-only
+// products from continuing through the established runtime and auto-install
+// routing paths.
+func (c *Commando) validateCanonicalRuntimeCommand(args []string, ctx *cli.Context) error {
+	err := c.validateCanonicalAPICommand(args, ctx)
+	var invalidProduct *InvalidProductError
+	var invalidParameter *InvalidParameterError
+	if errors.As(err, &invalidProduct) || errors.As(err, &invalidParameter) {
+		return nil
+	}
+	return err
 }

--- a/openapi/local_command_validation.go
+++ b/openapi/local_command_validation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/openapi/runtimehost"
 )
 
 // validateCanonicalAPICommand performs only metadata-local command identity
@@ -68,6 +69,18 @@ func (c *Commando) validateCanonicalRuntimeCommand(args []string, ctx *cli.Conte
 	var invalidParameter *InvalidParameterError
 	if errors.As(err, &invalidProduct) || errors.As(err, &invalidParameter) {
 		return nil
+	}
+	var invalidAPI *InvalidApiError
+	if len(args) == 2 && strings.ToLower(args[1]) == args[1] && errors.As(err, &invalidAPI) {
+		candidates := runtimehost.ProductCommands(args[0])
+		if len(candidates) > 0 {
+			return &InvalidBaselineCommandError{
+				Product:    args[0],
+				Command:    args[1],
+				Candidates: candidates,
+				Err:        err,
+			}
+		}
 	}
 	return err
 }

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -1183,6 +1183,10 @@ func (document *machineHelpRootDocument) prepareJSONGroups() {
 	for _, command := range document.Commands {
 		switch command.Group {
 		case string(RootGroupUtils):
+			// Root-level aliases keep the historical hidden utility entrypoints
+			// searchable and executable, but they are implementation details and
+			// must not be exposed as part of the public utilities Help document.
+			command.Aliases = nil
 			document.Utilities = append(document.Utilities, command)
 		case string(RootGroupExtension):
 			document.Extensions = append(document.Extensions, command)

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -176,7 +176,7 @@ type machineHelpProduct struct {
 }
 
 type machineHelpAPISummary struct {
-	Name string `json:"name,omitempty"`
+	Name    string `json:"name,omitempty"`
 	CmdName string `json:"cmdName,omitempty"`
 	// DisplayName is the sort/search key in the active command style; in the
 	// emitted JSON it always equals the surviving name/cmdName, so it stays
@@ -185,6 +185,21 @@ type machineHelpAPISummary struct {
 	Title       machineHelpLocalizedText `json:"title"`
 	Description machineHelpLocalizedText `json:"description"`
 	Deprecated  bool                     `json:"deprecated"`
+}
+
+func (summary machineHelpAPISummary) MarshalJSON() ([]byte, error) {
+	type apiSummaryJSON struct {
+		Name        string                   `json:"name"`
+		Title       machineHelpLocalizedText `json:"title"`
+		Description machineHelpLocalizedText `json:"description"`
+		Deprecated  bool                     `json:"deprecated,omitempty"`
+	}
+	return json.Marshal(apiSummaryJSON{
+		Name:        firstNonEmptyMachineHelpString(summary.DisplayName, summary.CmdName, summary.Name),
+		Title:       summary.Title,
+		Description: summary.Description,
+		Deprecated:  summary.Deprecated,
+	})
 }
 
 type machineHelpProductDocument struct {
@@ -243,7 +258,7 @@ type machineHelpShape struct {
 }
 
 type machineHelpParameter struct {
-	Name    string `json:"name"`
+	Name string `json:"name"`
 	// RawName carries the wire name for legacy-camel views where it is set;
 	// it is only ever equal to Name, so it stays struct-only.
 	RawName       string                   `json:"-"`

--- a/openapi/machine_help.go
+++ b/openapi/machine_help.go
@@ -447,6 +447,12 @@ func (s *machineHelpService) buildProductForStyle(code, requestedVersion, style 
 	if err != nil {
 		return nil, err
 	}
+	if style == "" {
+		style = "kebab"
+		if product.Version != "" {
+			style = "camel"
+		}
+	}
 	versions := normalizedVersions(*product)
 	if style == "pascal" {
 		style = "camel"

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -75,7 +75,7 @@ func TestMachineHelpRootJSONOmitsUtilityAliases(t *testing.T) {
 	}}
 
 	var output bytes.Buffer
-	require.NoError(t, encodeMachineHelpJSON(&output, doc))
+	require.NoError(t, encodeMachineHelpJSON(&output, doc, false))
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
 
@@ -98,7 +98,7 @@ func TestMachineHelpRootSearchJSONOmitsUtilityAliases(t *testing.T) {
 	applyRootHelpOptions(doc, helpOptions{Search: "go-migrate"}, false)
 
 	var output bytes.Buffer
-	require.NoError(t, encodeMachineHelpJSON(&output, doc))
+	require.NoError(t, encodeMachineHelpJSON(&output, doc, false))
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
 
@@ -148,7 +148,7 @@ func TestMachineHelpProductJSONUsesSelectedLanguageAndActiveCommandName(t *testi
 	doc.APIs[1].Deprecated = true
 
 	var encoded bytes.Buffer
-	require.NoError(t, encodeMachineHelpJSON(&encoded, doc))
+	require.NoError(t, encodeMachineHelpJSON(&encoded, doc, false))
 	var output map[string]any
 	require.NoError(t, json.Unmarshal(encoded.Bytes(), &output))
 	apis := output["apis"].([]any)
@@ -295,7 +295,7 @@ func TestMachineHelpAPIResponseJSONKeepsOneLocalizedResponseSchema(t *testing.T)
 			require.NoError(t, err)
 
 			var encoded bytes.Buffer
-			require.NoError(t, encodeMachineHelpJSON(&encoded, doc))
+			require.NoError(t, encodeMachineHelpJSON(&encoded, doc, false))
 			output := encoded.String()
 			assert.Contains(t, output, `"responses"`)
 			assert.Contains(t, output, `"components"`)

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -228,6 +228,53 @@ func TestMachineHelpAPIResponseUsesCanonicalSchemaAndReachableComponents(t *test
 	assert.Empty(t, doc.Notice)
 }
 
+func TestMachineHelpAPIResponseJSONKeepsOneLocalizedResponseSchema(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+
+	tests := []struct {
+		language        string
+		wantDescription string
+		wantTitle       string
+	}{
+		{language: "en", wantDescription: "The request ID.", wantTitle: "Report ID"},
+		{language: "zh", wantDescription: "请求 ID。", wantTitle: "报表 ID"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.language, func(t *testing.T) {
+			i18n.SetLanguage(tt.language)
+			service := testMachineHelpService(t)
+			doc, err := service.buildAPIResponse("demo", "CreateReport", "2026-01-01")
+			require.NoError(t, err)
+
+			var encoded bytes.Buffer
+			require.NoError(t, encodeMachineHelpJSON(&encoded, doc))
+			output := encoded.String()
+			assert.Contains(t, output, `"responses"`)
+			assert.Contains(t, output, `"components"`)
+			assert.NotContains(t, output, `"outputSchema"`)
+			assert.NotContains(t, output, `"description_en"`)
+			assert.NotContains(t, output, `"description_zh"`)
+			assert.NotContains(t, output, `"title_en"`)
+			assert.NotContains(t, output, `"title_zh"`)
+			assert.Contains(t, output, fmt.Sprintf(`"description": %q`, tt.wantDescription))
+			assert.Contains(t, output, fmt.Sprintf(`"title": %q`, tt.wantTitle))
+		})
+	}
+}
+
+func TestLocalizeMachineHelpRawJSONOmitsEmptyLocalizedText(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	localized, err := localizeMachineHelpRawJSON(json.RawMessage(
+		`{"type":"object","description_en":"","description_zh":""}`,
+	))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"object"}`, string(localized))
+}
+
 func TestMachineHelpAPIResponseWithoutSchemaReturnsNotice(t *testing.T) {
 	service := testMachineHelpService(t)
 	doc, err := service.buildAPIResponse("demo", "DescribeRegions", "2026-01-01")
@@ -437,12 +484,12 @@ func TestCommandoHelpJSONResponseSection(t *testing.T) {
 	assert.False(t, c.pluginLoaded)
 	assert.Empty(t, stderr.String())
 
-	var doc machineHelpAPIResponseDocument
+	var doc map[string]any
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &doc))
-	assert.Equal(t, helpSectionResponse, doc.Section)
-	// The complete document carries the schema once, in responses.
-	assert.NotNil(t, doc.Responses)
-	assert.Nil(t, doc.OutputSchema)
+	assert.Equal(t, helpSectionResponse, doc["section"])
+	assert.Contains(t, doc, "responses")
+	assert.Contains(t, doc, "components")
+	assert.NotContains(t, doc, "outputSchema")
 	assert.NotContains(t, stdout.String(), `"parameterSets"`)
 }
 

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -60,6 +60,53 @@ func TestMachineHelpRootJSONUsesExplicitGroups(t *testing.T) {
 	assert.Contains(t, raw, "products")
 }
 
+func TestMachineHelpRootJSONOmitsUtilityAliases(t *testing.T) {
+	doc := &machineHelpRootDocument{Commands: []machineHelpCommandSummary{
+		{
+			Group:   string(RootGroupCore),
+			Name:    "configure",
+			Aliases: []string{"setup"},
+		},
+		{
+			Group:   string(RootGroupUtils),
+			Name:    "utils go-migrate",
+			Aliases: []string{"go-migrate"},
+		},
+	}}
+
+	var output bytes.Buffer
+	require.NoError(t, encodeMachineHelpJSON(&output, doc))
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+
+	utilities := raw["utilities"].([]any)
+	require.Len(t, utilities, 1)
+	assert.NotContains(t, utilities[0].(map[string]any), "aliases")
+
+	coreCommands := raw["coreCommands"].([]any)
+	require.Len(t, coreCommands, 1)
+	assert.Equal(t, []any{"setup"}, coreCommands[0].(map[string]any)["aliases"])
+}
+
+func TestMachineHelpRootSearchJSONOmitsUtilityAliases(t *testing.T) {
+	doc := &machineHelpRootDocument{Commands: []machineHelpCommandSummary{{
+		Group:   string(RootGroupUtils),
+		Path:    []string{"aliyun", "utils", "go-migrate"},
+		Name:    "utils go-migrate",
+		Aliases: []string{"go-migrate"},
+	}}}
+	applyRootHelpOptions(doc, helpOptions{Search: "go-migrate"}, false)
+
+	var output bytes.Buffer
+	require.NoError(t, encodeMachineHelpJSON(&output, doc))
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+
+	matches := raw["matches"].([]any)
+	require.Len(t, matches, 1)
+	assert.NotContains(t, matches[0].(map[string]any), "aliases")
+}
+
 func TestMachineHelpProduct(t *testing.T) {
 	service := testMachineHelpService(t)
 	doc, err := service.buildProduct("demo", "")

--- a/openapi/machine_help_test.go
+++ b/openapi/machine_help_test.go
@@ -89,6 +89,32 @@ func TestMachineHelpProductExplicitVersion(t *testing.T) {
 	assert.Equal(t, "describe-regions", doc.APIs[1].CmdName)
 }
 
+func TestMachineHelpProductJSONUsesSelectedLanguageAndActiveCommandName(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	service := testMachineHelpService(t)
+	doc, err := service.buildProductForStyle("demo", "2026-01-01", "camel")
+	require.NoError(t, err)
+	require.Len(t, doc.APIs, 2)
+	doc.APIs[1].Deprecated = true
+
+	var encoded bytes.Buffer
+	require.NoError(t, encodeMachineHelpJSON(&encoded, doc))
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(encoded.Bytes(), &output))
+	apis := output["apis"].([]any)
+	first := apis[0].(map[string]any)
+	assert.Equal(t, "CreateReport", first["name"])
+	assert.Equal(t, "Creates a report.", first["description"])
+	assert.ElementsMatch(t, []string{"name", "description"}, mapKeys(first))
+	second := apis[1].(map[string]any)
+	assert.Equal(t, true, second["deprecated"])
+	assert.NotContains(t, second, "cmdName")
+	assert.NotContains(t, second, "displayName")
+}
+
 func TestMachineHelpAPICamelAndKebabShareCanonicalIdentity(t *testing.T) {
 	service := testMachineHelpService(t)
 	camel, err := service.buildAPI("demo", "CreateReport", "2026-01-01")

--- a/openapi/response_help.go
+++ b/openapi/response_help.go
@@ -23,7 +23,11 @@ func renderResponseHelpText(w io.Writer, document *machineHelpAPIResponseDocumen
 		if _, err := fmt.Fprintln(w, "Responses:"); err != nil {
 			return err
 		}
-		if err := writeIndentedJSON(w, document.Responses); err != nil {
+		responses, err := localizeMachineHelpRawJSON(document.Responses)
+		if err != nil {
+			return err
+		}
+		if err := writeIndentedJSON(w, responses); err != nil {
 			return err
 		}
 		if err := renderMachineHelpComponents(w, document.Components); err != nil {
@@ -67,7 +71,11 @@ func renderResponseHelpText(w io.Writer, document *machineHelpAPIResponseDocumen
 	if _, err := fmt.Fprintf(w, "%s):\n", heading); err != nil {
 		return err
 	}
-	if err := writeIndentedJSON(w, document.OutputSchema.Schema); err != nil {
+	schema, err := localizeMachineHelpRawJSON(document.OutputSchema.Schema)
+	if err != nil {
+		return err
+	}
+	if err := writeIndentedJSON(w, schema); err != nil {
 		return err
 	}
 
@@ -88,12 +96,16 @@ func renderMachineHelpComponents(w io.Writer, components *machineHelpComponents)
 	if components == nil || len(components.Schemas) == 0 {
 		return nil
 	}
+	localized, err := localizeMachineHelpComponents(components)
+	if err != nil {
+		return err
+	}
 	if _, err := fmt.Fprintln(w, "\nComponents:"); err != nil {
 		return err
 	}
 	encoded, err := json.Marshal(struct {
 		Schemas map[string]json.RawMessage `json:"schemas"`
-	}{Schemas: components.Schemas})
+	}{Schemas: localized.Schemas})
 	if err != nil {
 		return err
 	}

--- a/openapi/response_help_locale.go
+++ b/openapi/response_help_locale.go
@@ -1,0 +1,145 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// MarshalJSON keeps the lossless OpenAPI responses/components view as the
+// public response Help contract. OutputSchema is an internal convenience view
+// of the same successful response and is emitted only for search projections,
+// where the complete responses document has intentionally been removed.
+func (document machineHelpAPIResponseDocument) MarshalJSON() ([]byte, error) {
+	type responseDocumentJSON machineHelpAPIResponseDocument
+
+	responses, err := localizeMachineHelpRawJSON(document.Responses)
+	if err != nil {
+		return nil, err
+	}
+	components, err := localizeMachineHelpComponents(document.Components)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputSchema *machineHelpOutputSchema
+	if len(bytes.TrimSpace(document.Responses)) == 0 {
+		outputSchema, err = localizeMachineHelpOutputSchema(document.OutputSchema)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return json.Marshal(struct {
+		responseDocumentJSON
+		Responses    json.RawMessage          `json:"responses"`
+		Components   *machineHelpComponents   `json:"components"`
+		OutputSchema *machineHelpOutputSchema `json:"outputSchema"`
+	}{
+		responseDocumentJSON: responseDocumentJSON(document),
+		Responses:            responses,
+		Components:           components,
+		OutputSchema:         outputSchema,
+	})
+}
+
+func localizeMachineHelpOutputSchema(schema *machineHelpOutputSchema) (*machineHelpOutputSchema, error) {
+	if schema == nil {
+		return nil, nil
+	}
+	localizedSchema, err := localizeMachineHelpRawJSON(schema.Schema)
+	if err != nil {
+		return nil, err
+	}
+	components, err := localizeMachineHelpComponents(schema.Components)
+	if err != nil {
+		return nil, err
+	}
+	return &machineHelpOutputSchema{
+		StatusCode:  schema.StatusCode,
+		ContentType: schema.ContentType,
+		Schema:      localizedSchema,
+		Components:  components,
+	}, nil
+}
+
+func localizeMachineHelpComponents(components *machineHelpComponents) (*machineHelpComponents, error) {
+	if components == nil {
+		return nil, nil
+	}
+	localized := &machineHelpComponents{Schemas: make(map[string]json.RawMessage, len(components.Schemas))}
+	for name, schema := range components.Schemas {
+		value, err := localizeMachineHelpRawJSON(schema)
+		if err != nil {
+			return nil, err
+		}
+		localized.Schemas[name] = value
+	}
+	return localized, nil
+}
+
+func localizeMachineHelpRawJSON(raw json.RawMessage) (json.RawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	localized := localizeMachineHelpJSONValue(value, localizedMachineHelpLanguage())
+	return json.Marshal(localized)
+}
+
+func localizeMachineHelpJSONValue(value any, language string) any {
+	switch typed := value.(type) {
+	case []any:
+		result := make([]any, len(typed))
+		for index, item := range typed {
+			result[index] = localizeMachineHelpJSONValue(item, language)
+		}
+		return result
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, item := range typed {
+			result[key] = localizeMachineHelpJSONValue(item, language)
+		}
+		projectMachineHelpLocalizedJSONText(result, "description", language)
+		projectMachineHelpLocalizedJSONText(result, "title", language)
+		return result
+	default:
+		return value
+	}
+}
+
+func projectMachineHelpLocalizedJSONText(node map[string]any, field, language string) {
+	enValue, enExists := node[field+"_en"]
+	zhValue, zhExists := node[field+"_zh"]
+	if !enExists && !zhExists {
+		return
+	}
+	en, enIsText := enValue.(string)
+	zh, zhIsText := zhValue.(string)
+	if (enExists && !enIsText) || (zhExists && !zhIsText) {
+		return
+	}
+	baseValue, baseExists := node[field]
+	base, baseIsText := baseValue.(string)
+	if baseExists && !baseIsText {
+		return
+	}
+
+	delete(node, field+"_en")
+	delete(node, field+"_zh")
+	var localized string
+	if language == "zh" {
+		localized = firstNonEmptyMachineHelpString(zh, base, en)
+	} else {
+		localized = firstNonEmptyMachineHelpString(en, base, zh)
+	}
+	if localized == "" {
+		delete(node, field)
+		return
+	}
+	node[field] = localized
+}

--- a/openapi/response_help_test.go
+++ b/openapi/response_help_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,4 +53,23 @@ func TestRenderResponseHelpTextKeepsFullResponsesWhenSuccessHasNoBody(t *testing
 	assert.Contains(t, output.String(), "Responses:")
 	assert.Contains(t, output.String(), `"400": {`)
 	assert.Contains(t, output.String(), "Notice: No response schema is available for this API.")
+}
+
+func TestRenderResponseHelpTextUsesSelectedSchemaLanguage(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("zh")
+
+	service := testMachineHelpService(t)
+	document, err := service.buildAPIResponse("demo", "CreateReport", "2026-01-01")
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, renderResponseHelpText(&output, document))
+	assert.Contains(t, output.String(), `"description": "请求 ID。"`)
+	assert.Contains(t, output.String(), `"title": "报表 ID"`)
+	assert.NotContains(t, output.String(), `"description_en"`)
+	assert.NotContains(t, output.String(), `"description_zh"`)
+	assert.NotContains(t, output.String(), `"title_en"`)
+	assert.NotContains(t, output.String(), `"title_zh"`)
 }


### PR DESCRIPTION
## Summary

- preserve legacy CamelCase product Help and legacy default versions unless baseline kebab-case Help is explicitly enabled
- reject invalid product flags and unknown canonical APIs locally, with command-style-aware recovery guidance
- localize JSON Help to the selected language, remove utility aliases, and emit response schemas only once
- honor explicit `--cli-output json` for eligible CLI-local errors even when AI Mode is disabled, without taking over remote, credential, or network errors

This supersedes #1415, #1418, and #1421 with one clean branch based on the latest `unify-meta-test`.

## Verification

- focused regression tests covering every behavior from the three superseded PRs
- `make test`
- `make test-runtime`
- `make test-release`
- built a packed-metadata macOS arm64 binary as version 5.0.0, archived and extracted it, then verified it directly
- end-to-end checks covered CamelCase/kebab-case style and multi-version defaults, invalid product flags, unknown API recovery, English/Chinese JSON Help, response schema de-duplication, utility alias omission, and AI/non-AI local error rendering

The `aliyun-openapi-meta` submodule remains unchanged at the existing v12 revision.
