### PR TITLE
test: raise unify unit coverage above 90 percent

### DIFF
--- a/aliyun-openapi-runtime/help/service_additional_test.go
+++ b/aliyun-openapi-runtime/help/service_additional_test.go
@@ -1,0 +1,360 @@
+package help
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/aliyun-openapi-runtime/meta"
+	"github.com/aliyun/aliyun-openapi-runtime/source"
+)
+
+type serviceTestSource struct {
+	product *meta.Product
+	index   *meta.APIIndex
+	api     *meta.API
+
+	ensureErr  error
+	resolveErr error
+	indexErr   error
+	apiErr     error
+
+	ensuredProduct   string
+	resolvedProduct  string
+	requestedVersion string
+	apiProduct       string
+	apiVersion       string
+	apiName          string
+}
+
+func (s *serviceTestSource) EnsureProduct(code string) error {
+	s.ensuredProduct = code
+	return s.ensureErr
+}
+
+func (s *serviceTestSource) LookupProduct(string) *meta.Product { return s.product }
+
+func (s *serviceTestSource) ResolveVersion(product, requested string) (string, error) {
+	s.resolvedProduct = product
+	s.requestedVersion = requested
+	if s.resolveErr != nil {
+		return "", s.resolveErr
+	}
+	return s.index.Version, nil
+}
+
+func (s *serviceTestSource) GetAPIIndex(string, string) (*meta.APIIndex, error) {
+	if s.indexErr != nil {
+		return nil, s.indexErr
+	}
+	return s.index, nil
+}
+
+func (s *serviceTestSource) GetAPI(product, version, name string) (*meta.API, error) {
+	s.apiProduct, s.apiVersion, s.apiName = product, version, name
+	if s.apiErr != nil {
+		return nil, s.apiErr
+	}
+	return s.api, nil
+}
+
+func (*serviceTestSource) Provenance(string) *source.Provenance {
+	return &source.Provenance{
+		Kind: source.KindUser, PluginName: "aliyun-cli-demo", PluginVersion: "2.0.0",
+		APIVersion: "v2", Origin: "unit-test",
+	}
+}
+
+type serviceTestResponses struct {
+	document *ResponseDocumentation
+	err      error
+	product  string
+	version  string
+	api      string
+}
+
+func (s *serviceTestResponses) GetResponseDocumentation(product, version, api string) (*ResponseDocumentation, error) {
+	s.product, s.version, s.api = product, version, api
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.document, nil
+}
+
+func newServiceTestFixtures() (*serviceTestSource, *serviceTestResponses) {
+	api := &meta.API{
+		Name: "ListThings", CmdName: "list-things", ProductCode: "Demo", Version: "v2",
+		Style: meta.StyleROA, Method: "GET", Protocol: "HTTPS", URL: "/things",
+		Title: meta.Description{EN: "List things", ZH: "查询资源"},
+		Parameters: []meta.Parameter{{
+			Name: "resource_id", RawName: "ResourceId", Options: []string{"--resource-id"},
+			Type: meta.TypeString, Required: true,
+		}},
+	}
+	data := &serviceTestSource{
+		product: &meta.Product{
+			Code: "demo", Name: meta.Description{EN: "Demo", ZH: "演示"},
+			Versions: []string{"v1", "v2"}, DefaultVersion: "v2",
+		},
+		index: &meta.APIIndex{
+			ProductCode: "demo", Version: "v2",
+			Entries: map[string]meta.APIIndexEntry{
+				"ListThings": {APIName: "ListThings", CmdName: "list-things"},
+			},
+		},
+		api: api,
+	}
+	responses := &serviceTestResponses{document: &ResponseDocumentation{
+		Responses:  json.RawMessage(`{"200":{"description":"OK"}}`),
+		Schema:     json.RawMessage(`{"type":"object","properties":{"Items":{"type":"array","items":{"type":"string"}}}}`),
+		StatusCode: "200", ContentType: "application/json",
+	}}
+	return data, responses
+}
+
+func TestServiceBuildsEveryHelpLevelThroughSmallInterfaces(t *testing.T) {
+	data, responses := newServiceTestFixtures()
+	service := Service{Data: data, Responses: responses}
+
+	product, err := service.BuildProduct("  DEMO  ", "v1", HelpOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if product.Kind != "product" || product.Target.APIVersion != "v2" ||
+		product.Provenance == nil || product.Provenance.PluginVersion != "2.0.0" {
+		t.Fatalf("product document = %#v", product)
+	}
+	if data.ensuredProduct != "demo" || data.resolvedProduct != "demo" || data.requestedVersion != "v1" {
+		t.Fatalf("product source calls = ensure:%q resolve:%q requested:%q",
+			data.ensuredProduct, data.resolvedProduct, data.requestedVersion)
+	}
+
+	request, err := service.BuildAPI(" DEMO ", "v1", "list-things", HelpOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Kind != "request" || request.Target.APIVersion != "v2" || request.Provenance == nil {
+		t.Fatalf("compatibility request document = %#v", request)
+	}
+	action, err := service.BuildAction(" DEMO ", "v1", "list-things", HelpOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action.Kind != "api" || action.Target.APIVersion != "v2" || action.Provenance == nil {
+		t.Fatalf("action document = %#v", action)
+	}
+	if data.apiProduct != "demo" || data.apiVersion != "v2" || data.apiName != "list-things" {
+		t.Fatalf("API source call = %q/%q/%q", data.apiProduct, data.apiVersion, data.apiName)
+	}
+	if responses.product != "demo" || responses.version != "v2" || responses.api != "ListThings" {
+		t.Fatalf("response source call = %q/%q/%q", responses.product, responses.version, responses.api)
+	}
+
+	parameter, err := service.BuildParameter(" DEMO ", "v1", "list-things", "--resource-id", HelpOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parameter.Kind != "parameter" || parameter.Parameter.RawName != "ResourceId" || parameter.Provenance == nil {
+		t.Fatalf("parameter document = %#v", parameter)
+	}
+	response, err := service.BuildResponse(" DEMO ", "v1", "list-things", HelpOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Kind != "response" || len(response.Responses) == 0 || response.Provenance == nil {
+		t.Fatalf("response document = %#v", response)
+	}
+}
+
+func TestServiceRejectsMissingDependenciesAndPropagatesSourceErrors(t *testing.T) {
+	if _, err := (Service{}).BuildProduct("demo", "", HelpOptions{}); err == nil || !strings.Contains(err.Error(), "data source") {
+		t.Fatalf("BuildProduct nil source error = %v", err)
+	}
+	if _, err := (Service{}).BuildParameter("demo", "", "ListThings", "id", HelpOptions{}); err == nil || !strings.Contains(err.Error(), "data source") {
+		t.Fatalf("BuildParameter nil source error = %v", err)
+	}
+	data, _ := newServiceTestFixtures()
+	if _, err := (Service{Data: data}).BuildResponse("demo", "", "ListThings", HelpOptions{}); err == nil || !strings.Contains(err.Error(), "response sources") {
+		t.Fatalf("BuildResponse nil response source error = %v", err)
+	}
+
+	testErr := errors.New("source failed")
+	tests := []struct {
+		name  string
+		setup func(*serviceTestSource, *serviceTestResponses)
+		call  func(Service) error
+	}{
+		{
+			name:  "ensure product",
+			setup: func(data *serviceTestSource, _ *serviceTestResponses) { data.ensureErr = testErr },
+			call: func(service Service) error {
+				_, err := service.BuildProduct("demo", "", HelpOptions{})
+				return err
+			},
+		},
+		{
+			name:  "resolve version",
+			setup: func(data *serviceTestSource, _ *serviceTestResponses) { data.resolveErr = testErr },
+			call: func(service Service) error {
+				_, err := service.BuildRequest("demo", "", "ListThings", HelpOptions{})
+				return err
+			},
+		},
+		{
+			name:  "load index",
+			setup: func(data *serviceTestSource, _ *serviceTestResponses) { data.indexErr = testErr },
+			call: func(service Service) error {
+				_, err := service.BuildProduct("demo", "", HelpOptions{})
+				return err
+			},
+		},
+		{
+			name:  "load API",
+			setup: func(data *serviceTestSource, _ *serviceTestResponses) { data.apiErr = testErr },
+			call: func(service Service) error {
+				_, err := service.BuildAction("demo", "", "ListThings", HelpOptions{})
+				return err
+			},
+		},
+		{
+			name:  "load response",
+			setup: func(_ *serviceTestSource, responses *serviceTestResponses) { responses.err = testErr },
+			call: func(service Service) error {
+				_, err := service.BuildResponse("demo", "", "ListThings", HelpOptions{})
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, responses := newServiceTestFixtures()
+			test.setup(data, responses)
+			err := test.call(Service{Data: data, Responses: responses})
+			if !errors.Is(err, testErr) {
+				t.Fatalf("error = %v, want %v", err, testErr)
+			}
+		})
+	}
+
+	missingProduct, responses := newServiceTestFixtures()
+	missingProduct.product = nil
+	if _, err := (Service{Data: missingProduct, Responses: responses}).BuildProduct("demo", "", HelpOptions{}); err == nil || !strings.Contains(err.Error(), "unavailable after loading") {
+		t.Fatalf("missing product error = %v", err)
+	}
+}
+
+func TestRequestSearchCoversParametersNestedFieldsAndRuntimeGlobals(t *testing.T) {
+	api := &meta.API{
+		Name: "RunThing", CmdName: "run-thing", ProductCode: "demo", Version: "v1",
+		Parameters: []meta.Parameter{
+			{
+				Name: "config", RawName: "Config", Type: meta.TypeObject,
+				Fields: []meta.Parameter{{
+					Name: "retry_count", RawName: "RetryCount", Type: meta.TypeInteger,
+					Description: meta.Description{EN: "Number of retry attempts"},
+				}},
+			},
+			{
+				Name: "state", RawName: "State", Type: meta.TypeString,
+				Enum: []string{"Running", "Stopped"},
+			},
+		},
+	}
+	product := &meta.Product{Code: "demo", Versions: []string{"v1"}}
+
+	nested := BuildRequestDocument(product, api, nil, HelpOptions{Search: "retry count"})
+	if len(nested.Parameters) != 1 || nested.Parameters[0].Name != "config" || len(nested.GlobalParameters) != 0 {
+		t.Fatalf("nested parameter search = %#v", nested)
+	}
+	enum := BuildRequestDocument(product, api, nil, HelpOptions{Search: "stopped"})
+	if len(enum.Parameters) != 1 || enum.Parameters[0].Name != "state" {
+		t.Fatalf("enum parameter search = %#v", enum.Parameters)
+	}
+	global := BuildRequestDocument(product, api, nil, HelpOptions{Search: "region"})
+	if len(global.Parameters) != 0 || len(global.GlobalParameters) == 0 {
+		t.Fatalf("global parameter search = params:%#v globals:%#v", global.Parameters, global.GlobalParameters)
+	}
+	foundRegion := false
+	for _, parameter := range global.GlobalParameters {
+		if parameter.Name == "--region" {
+			foundRegion = true
+		}
+	}
+	if !foundRegion {
+		t.Fatalf("global parameter search omitted --region: %#v", global.GlobalParameters)
+	}
+}
+
+func TestProductTextRendererLocalizesAndMarksDeprecatedAPIs(t *testing.T) {
+	product := &meta.Product{
+		Code: "demo", Name: meta.Description{EN: "Demo", ZH: "演示产品"},
+		Description: meta.Description{EN: "Demo service", ZH: "演示服务"}, Versions: []string{"v1"},
+	}
+	index := &meta.APIIndex{ProductCode: "demo", Version: "v1", Entries: map[string]meta.APIIndexEntry{
+		"OldAPI": {
+			APIName: "OldAPI", CmdName: "old-api", Deprecated: true,
+			Title: meta.Description{EN: "Old API", ZH: "旧接口"},
+		},
+	}}
+	document := BuildProductDocument(product, index, HelpOptions{All: true})
+	document.Provenance = &MetadataProvenance{Kind: "user", PluginName: "aliyun-cli-demo", PluginVersion: "2.0.0"}
+
+	var output bytes.Buffer
+	if err := Render(&output, document, HelpOptions{Language: "zh"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"产品: demo (演示产品)", "描述: 演示服务", "元数据来源: aliyun-cli-demo (2.0.0)", "[已废弃] 旧接口"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("product text missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestRenderRejectsInvalidOutputsAndDocuments(t *testing.T) {
+	documentTests := []struct {
+		name     string
+		document any
+		want     string
+	}{
+		{name: "nil product", document: (*ProductDocument)(nil), want: "product Help document is nil"},
+		{name: "nil action", document: (*ActionDocument)(nil), want: "action Help document is nil"},
+		{name: "nil request", document: (*RequestDocument)(nil), want: "request Help document is nil"},
+		{name: "nil parameter", document: (*APIParameterDocument)(nil), want: "parameter Help document is nil"},
+		{name: "nil response", document: (*APIResponseDocument)(nil), want: "response Help document is nil"},
+		{name: "unsupported", document: struct{}{}, want: "unsupported Runtime Help"},
+	}
+	for _, test := range documentTests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := Render(&output, test.document, HelpOptions{})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+
+	if err := Render(nil, &ProductDocument{}, HelpOptions{}); err == nil || !strings.Contains(err.Error(), "output is nil") {
+		t.Fatalf("text nil output error = %v", err)
+	}
+	if err := Render(nil, &ProductDocument{}, HelpOptions{Format: FormatJSON}); err == nil || !strings.Contains(err.Error(), "output is nil") {
+		t.Fatalf("JSON nil output error = %v", err)
+	}
+	var output bytes.Buffer
+	if err := Render(&output, make(chan int), HelpOptions{Format: FormatJSON}); err == nil {
+		t.Fatal("JSON renderer accepted a non-serializable document")
+	}
+}
+
+func TestUnknownParameterErrorIncludesCandidates(t *testing.T) {
+	err := (&UnknownParameterError{Parameter: "instnace-id", Candidates: []string{"instance-id"}}).Error()
+	for _, want := range []string{"instnace-id", "instance-id"} {
+		if !strings.Contains(err, want) {
+			t.Fatalf("UnknownParameterError %q does not include %q", err, want)
+		}
+	}
+	if got := (&UnknownParameterError{API: "ListThings", Parameter: "unknown"}).Error(); got != "unknown parameter --unknown for ListThings" {
+		t.Fatalf("UnknownParameterError without candidates = %q", got)
+	}
+}

--- a/aliyun-openapi-runtime/help/service_additional_test.go
+++ b/aliyun-openapi-runtime/help/service_additional_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -356,5 +357,183 @@ func TestUnknownParameterErrorIncludesCandidates(t *testing.T) {
 	}
 	if got := (&UnknownParameterError{API: "ListThings", Parameter: "unknown"}).Error(); got != "unknown parameter --unknown for ListThings" {
 		t.Fatalf("UnknownParameterError without candidates = %q", got)
+	}
+}
+
+func TestDocumentBuildersCoverFallbackIdentityAndRPCProjection(t *testing.T) {
+	index := &meta.APIIndex{ProductCode: "dns", Version: "v1"}
+	if BuildProductDocument(nil, index, HelpOptions{}) != nil {
+		t.Fatal("BuildProductDocument accepted a nil product")
+	}
+	if BuildProductDocument(&meta.Product{Code: "dns"}, nil, HelpOptions{}) != nil {
+		t.Fatal("BuildProductDocument accepted a nil API index")
+	}
+	if BuildRequestDocument(nil, nil, nil, HelpOptions{}) != nil {
+		t.Fatal("BuildRequestDocument accepted a nil API")
+	}
+	if BuildActionDocument(nil, nil, nil, HelpOptions{}) != nil {
+		t.Fatal("BuildActionDocument accepted a nil API")
+	}
+
+	api := &meta.API{
+		Name: "DescribeDNSRecords", ProductCode: "DNS", Version: "v1",
+		Style: meta.StyleRPC, Method: "POST", Protocol: "HTTPS", URL: "/rpc",
+		ReqBodyType: "json", ContentType: "application/json", IsSSE: true, HasWildcardPath: true,
+		Description: meta.Description{EN: "Describe DNS records"},
+		Examples:    []string{"aliyun dns describe-dns-records"},
+	}
+	request := BuildAPIRequestDocument(nil, api, nil, HelpOptions{})
+	if request.Command != "describe-dns-records" || request.CmdFullName != "dns describe-dns-records" ||
+		request.Target.Product != "dns" || request.Examples.Kebab == "" {
+		t.Fatalf("request fallback identity = %#v", request)
+	}
+	if request.Operation.Method != "POST" || request.Operation.Protocol != "HTTPS" || !request.Operation.IsSSE {
+		t.Fatalf("request RPC wire metadata = %#v", request.Operation)
+	}
+
+	action := BuildActionDocument(nil, api, nil, HelpOptions{})
+	if action.Description.EN != "Describe DNS records" {
+		t.Fatalf("action description = %#v", action.Description)
+	}
+	if action.Operation.Method != "" || action.Operation.Protocol != "" || action.Operation.URL != "" ||
+		action.Operation.RequestBodyType != "" || action.Operation.ContentType != "" ||
+		action.Operation.IsSSE || action.Operation.HasWildcardPath {
+		t.Fatalf("RPC action leaked ROA-only wire metadata: %#v", action.Operation)
+	}
+}
+
+func TestActionSearchReportsTheFullMatchCount(t *testing.T) {
+	api := &meta.API{Name: "RunThing", CmdName: "run-thing", ProductCode: "demo", Version: "v1"}
+	for i := 0; i < 25; i++ {
+		api.Parameters = append(api.Parameters, meta.Parameter{
+			Name:    fmt.Sprintf("coverage_probe_%02d", i),
+			Options: []string{fmt.Sprintf("--coverage-probe-%02d", i)},
+			Type:    meta.TypeString,
+		})
+	}
+	product := &meta.Product{Code: "demo", Versions: []string{"v1"}}
+	limited := BuildActionDocument(product, api, nil, HelpOptions{Search: "coverage probe"})
+	if len(limited.Parameters) != 20 || limited.Result.Total != 25 || !limited.Result.Truncated ||
+		limited.Next == nil || limited.Next.SearchAll == "" {
+		t.Fatalf("limited action search = %#v", limited)
+	}
+	unlimited := BuildActionDocument(product, api, nil, HelpOptions{Search: "coverage probe", All: true})
+	if len(unlimited.Parameters) != 25 || unlimited.Result.Total != 25 || unlimited.Result.Truncated || unlimited.Next != nil {
+		t.Fatalf("unlimited action search = %#v", unlimited)
+	}
+}
+
+func TestResponseTextRendererCoversSchemaAndResponsesComponents(t *testing.T) {
+	schemaDocument := &APIResponseDocument{
+		Warnings: []string{"schema warning"},
+		Matches:  []string{"Items.Name"},
+		OutputSchema: &OutputSchema{
+			StatusCode: "200",
+			Schema: json.RawMessage(`{
+				"type":"object",
+				"description_en":"English schema",
+				"description_zh":"中文结构"
+			}`),
+			Components: map[string]json.RawMessage{
+				"Thing": json.RawMessage(`{
+					"type":"object",
+					"description_en":"English component",
+					"description_zh":"中文组件"
+				}`),
+			},
+		},
+		ResponseQuery: &QueryExample{QueryCommand: "aliyun demo list-things --cli-query Items"},
+		Result:        Result{Shown: 1, Total: 2, Truncated: true},
+		Next:          &Next{ShowAll: "aliyun demo list-things --help-all"},
+	}
+	var output bytes.Buffer
+	if err := Render(&output, schemaDocument, HelpOptions{Language: "zh"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"警告:", "schema warning", "匹配的响应路径:", "Items.Name",
+		"响应结构 (HTTP 200):", "中文结构", "组件:", "中文组件",
+		"使用 JMESPath 查询:", "显示全部: aliyun demo list-things --help-all",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("response schema text missing %q:\n%s", want, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "English schema") || strings.Contains(output.String(), "English component") {
+		t.Fatalf("response schema text mixed languages:\n%s", output.String())
+	}
+
+	responsesDocument := &APIResponseDocument{
+		Responses: json.RawMessage(`{
+			"200":{"description_en":"Success","description_zh":"成功"}
+		}`),
+		Components: map[string]json.RawMessage{
+			"Error": json.RawMessage(`{
+				"type":"object",
+				"title_en":"Error response",
+				"title_zh":"错误响应"
+			}`),
+		},
+	}
+	output.Reset()
+	if err := Render(&output, responsesDocument, HelpOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Responses:", "Success", "Components:", "Error response"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("responses text missing %q:\n%s", want, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "成功") || strings.Contains(output.String(), "错误响应") {
+		t.Fatalf("responses text mixed languages:\n%s", output.String())
+	}
+}
+
+func TestResponseTextRendererPropagatesMalformedJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		document *APIResponseDocument
+	}{
+		{
+			name: "output schema",
+			document: &APIResponseDocument{OutputSchema: &OutputSchema{
+				Schema: json.RawMessage(`{`),
+			}},
+		},
+		{
+			name: "output component",
+			document: &APIResponseDocument{OutputSchema: &OutputSchema{
+				Schema:     json.RawMessage(`{}`),
+				Components: map[string]json.RawMessage{"Broken": json.RawMessage(`{`)},
+			}},
+		},
+		{
+			name:     "responses",
+			document: &APIResponseDocument{Responses: json.RawMessage(`{`)},
+		},
+		{
+			name: "response component",
+			document: &APIResponseDocument{
+				Responses:  json.RawMessage(`{}`),
+				Components: map[string]json.RawMessage{"Broken": json.RawMessage(`{`)},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := Render(&output, test.document, HelpOptions{}); err == nil {
+				t.Fatalf("Render accepted malformed JSON: %s", output.String())
+			}
+		})
+	}
+
+	var output bytes.Buffer
+	if err := writePrettyJSON(&output, nil); err != nil || output.String() != "{}\n" {
+		t.Fatalf("empty pretty JSON = %q, %v", output.String(), err)
+	}
+	localized, err := LocalizeRawJSONMap(nil, "en")
+	if err != nil || localized != nil {
+		t.Fatalf("nil localized component map = %#v, %v", localized, err)
 	}
 }

--- a/canonicalmeta/legacy_view_additional_test.go
+++ b/canonicalmeta/legacy_view_additional_test.go
@@ -1,0 +1,213 @@
+package canonicalmeta
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLegacyParameterViewAccessorsForEverySource(t *testing.T) {
+	canonical := &Parameter{
+		RawName: "Canonical", Type: "string", Required: true, DocRequired: true,
+		Location: "query", IsWildcard: true, Example: "canonical-example",
+		HelpZh: "规范中文", HelpEn: "canonical English",
+		Enum: []string{"a"}, Minimum: "1", Maximum: "9", MinLength: "2", MaxLength: "8", Pattern: "a+",
+	}
+	field := &Field{
+		RawName: "Field", Type: "int", Required: true, DocRequired: true,
+		Example: "field-example", HelpZh: "字段中文", HelpEn: "field English",
+		Enum: []string{"2"}, Minimum: "2", Maximum: "4", MinLength: "1", MaxLength: "3", Pattern: "[0-9]+",
+	}
+	body := &V1Parameter{
+		Name: "Body", Position: "body", Type: "string", Required: true,
+		Example: "body-example", DescriptionZh: "正文中文", DescriptionEn: "body English",
+	}
+	v1 := &V1Parameter{
+		Name: "Legacy", Position: "header", Type: "long", Required: true,
+		Example: "legacy-example", HelpZh: "旧版中文", HelpEn: "legacy English",
+	}
+
+	tests := []struct {
+		name         string
+		view         *LegacyParameterView
+		legacyName   string
+		position     string
+		typeName     string
+		description  string
+		example      string
+		required     bool
+		docRequired  bool
+		wildcard     bool
+		constraintTy string
+	}{
+		{"canonical", NewCanonicalView(canonical), "Canonical", "Query", "string", "canonical English", "canonical-example", true, true, true, "string"},
+		{"field", NewFieldView(field, "form"), "Field", "FormData", "int", "field English", "field-example", true, true, false, "int"},
+		{"body", NewBodyView(body), "Body", "Body", "string", "body English", "body-example", true, false, false, "string"},
+		{"v1", NewV1View(v1), "Legacy", "Header", "long", "legacy English", "legacy-example", true, false, false, "long"},
+		{"unknown", &LegacyParameterView{source: LegacyParameterSource(99)}, "", "", "", "", "", false, false, false, ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.view.LegacyName(); got != test.legacyName {
+				t.Fatalf("LegacyName() = %q, want %q", got, test.legacyName)
+			}
+			if got := test.view.LegacyPosition(); got != test.position {
+				t.Fatalf("LegacyPosition() = %q, want %q", got, test.position)
+			}
+			if got := test.view.LegacyType(); got != test.typeName {
+				t.Fatalf("LegacyType() = %q, want %q", got, test.typeName)
+			}
+			if got := test.view.LegacyRequired(); got != test.required {
+				t.Fatalf("LegacyRequired() = %v, want %v", got, test.required)
+			}
+			if got := test.view.DocRequired(); got != test.docRequired {
+				t.Fatalf("DocRequired() = %v, want %v", got, test.docRequired)
+			}
+			if got := test.view.IsWildcard(); got != test.wildcard {
+				t.Fatalf("IsWildcard() = %v, want %v", got, test.wildcard)
+			}
+			if got := test.view.LegacyDescription("en"); got != test.description {
+				t.Fatalf("LegacyDescription() = %q, want %q", got, test.description)
+			}
+			if got := test.view.LegacyExample(); got != test.example {
+				t.Fatalf("LegacyExample() = %q, want %q", got, test.example)
+			}
+			if got := test.view.ConstraintType(); got != test.constraintTy {
+				t.Fatalf("ConstraintType() = %q, want %q", got, test.constraintTy)
+			}
+		})
+	}
+
+	if got := NewCanonicalView(canonical).Constraints(); !reflect.DeepEqual(got.Enum, []string{"a"}) || got.MinLength != "2" || got.MaxLength != "8" {
+		t.Fatalf("canonical Constraints() = %#v", got)
+	}
+	if got := NewFieldView(field, "query").Constraints(); !reflect.DeepEqual(got.Enum, []string{"2"}) || got.Minimum != "2" || got.Maximum != "4" {
+		t.Fatalf("field Constraints() = %#v", got)
+	}
+	if got := NewBodyView(body).Constraints(); !reflect.DeepEqual(got, Constraints{}) {
+		t.Fatalf("body Constraints() = %#v, want empty", got)
+	}
+}
+
+func TestLegacyParameterViewScalarArrayConstraints(t *testing.T) {
+	shape := &TypeShape{
+		Type: "integer", Enum: []string{"1", "2"}, Minimum: "1", Maximum: "2",
+		MinLength: "1", MaxLength: "1", Pattern: "[12]",
+	}
+	canonical := NewCanonicalView(&Parameter{Type: "array", Element: shape})
+	field := NewFieldView(&Field{Type: "array", Element: shape}, "query")
+	for _, view := range []*LegacyParameterView{canonical, field} {
+		if got := view.ConstraintType(); got != "integer" {
+			t.Fatalf("ConstraintType() = %q, want integer", got)
+		}
+		constraints := view.Constraints()
+		if !reflect.DeepEqual(constraints.Enum, []string{"1", "2"}) || constraints.Minimum != "1" || constraints.Maximum != "2" || constraints.Pattern != "[12]" {
+			t.Fatalf("Constraints() = %#v", constraints)
+		}
+	}
+
+	for _, typ := range []string{"string", "int", "integer", "int32", "int64", "long", "float", "double", "number", "bool", "boolean"} {
+		if !isScalarTypeShape(&TypeShape{Type: typ}) {
+			t.Errorf("isScalarTypeShape(%q) = false", typ)
+		}
+	}
+	for _, shape := range []*TypeShape{nil, {Type: "object"}, {Type: "array"}, {Type: "map"}} {
+		if isScalarTypeShape(shape) {
+			t.Errorf("isScalarTypeShape(%#v) = true", shape)
+		}
+	}
+	if got := NewCanonicalView(&Parameter{Type: "array", Element: &TypeShape{Type: "object"}}).ConstraintType(); got != "array" {
+		t.Fatalf("non-scalar array ConstraintType() = %q", got)
+	}
+}
+
+func TestLegacyLocationsRepeatListsAndChildren(t *testing.T) {
+	for _, test := range []struct{ input, top, sub string }{
+		{"query", "Query", "Query"}, {"body", "Body", "Body"}, {"host", "Host", "Host"},
+		{"domain", "Domain", "Domain"}, {"path", "Path", "Path"}, {"header", "Header", "Header"},
+		{"form", "Body", "FormData"}, {"formData", "Body", "FormData"}, {"unknown", "", ""},
+	} {
+		if got := legacyPosition(test.input); got != test.top {
+			t.Errorf("legacyPosition(%q) = %q", test.input, got)
+		}
+		if got := legacySubPosition(test.input); got != test.sub {
+			t.Errorf("legacySubPosition(%q) = %q", test.input, got)
+		}
+	}
+
+	fields := []Field{{RawName: "Name", Type: "string"}}
+	canonical := NewCanonicalView(&Parameter{Type: "array", ParamStyle: "repeatList", Location: "query", Element: &TypeShape{Type: "object", Fields: fields}})
+	if !canonical.LegacyHasChildren() || !canonical.IsLegacyRepeatList() {
+		t.Fatal("canonical repeat list should expose children")
+	}
+	children := canonical.LegacyChildren()
+	if len(children) != 1 || children[0].LegacyName() != "Name" || children[0].LegacyChildren() != nil {
+		t.Fatalf("canonical children = %#v", children)
+	}
+
+	for _, style := range []string{"flat", "json"} {
+		view := NewCanonicalView(&Parameter{Type: "array", ParamStyle: style, Element: &TypeShape{Type: "object", Fields: fields}})
+		if view.IsLegacyRepeatList() {
+			t.Fatalf("style %q unexpectedly behaves as RepeatList", style)
+		}
+		if style == "flat" && view.LegacyHasChildren() {
+			t.Fatal("flat array unexpectedly exposes legacy children")
+		}
+		if style == "json" && !view.LegacyHasChildren() {
+			t.Fatal("json object array should retain its schema children for help")
+		}
+	}
+	if NewCanonicalView(&Parameter{Type: "string"}).LegacyHasChildren() {
+		t.Fatal("scalar canonical parameter should not have children")
+	}
+	if NewFieldView(&Field{Type: "array"}, "query").LegacyHasChildren() || !NewFieldView(&Field{Type: "array"}, "query").IsLegacyRepeatList() {
+		t.Fatal("field array should be a leaf repeat list")
+	}
+	unknown := &LegacyParameterView{source: LegacyParameterSource(99)}
+	if unknown.LegacyHasChildren() || unknown.IsLegacyRepeatList() || unknown.LegacyChildren() != nil {
+		t.Fatal("unknown source should have no legacy structure")
+	}
+
+	body := &V1Parameter{Name: "body", Type: "array", ParamStyle: "repeatList", SubParameters: []V1Parameter{{Name: "Value", Position: "form", Type: "string"}}}
+	bodyView := NewBodyView(body)
+	bodyView.isTopBody = true
+	if !bodyView.IsTopLevelBody() || !bodyView.LegacyHasChildren() || !bodyView.IsLegacyRepeatList() {
+		t.Fatal("top-level body repeat list state was not preserved")
+	}
+	bodyChildren := bodyView.LegacyChildren()
+	if len(bodyChildren) != 1 || bodyChildren[0].LegacyPosition() != "FormData" || bodyChildren[0].IsTopLevelBody() {
+		t.Fatalf("body children = %#v", bodyChildren)
+	}
+	for _, style := range []string{"flat", "json"} {
+		if NewBodyView(&V1Parameter{Type: "array", ParamStyle: style}).IsLegacyRepeatList() {
+			t.Fatalf("V1 style %q unexpectedly behaves as RepeatList", style)
+		}
+	}
+}
+
+func TestLegacyBodyFieldsAndProtocolDefaults(t *testing.T) {
+	api := &API{
+		Method: "GET|POST", Protocol: "HTTP|HTTPS",
+		Parameters: []Parameter{
+			{RawName: "Query", Location: "query"},
+			{RawName: "Body", Location: "body"},
+			{RawName: "Form", Location: "form"},
+			{RawName: "FormData", Location: "formData"},
+			{RawName: "Action", Location: "body"},
+		},
+	}
+	fields := api.LegacyBodyFields()
+	if got := []string{fields[0].RawName, fields[1].RawName, fields[2].RawName}; !reflect.DeepEqual(got, []string{"Body", "Form", "FormData"}) {
+		t.Fatalf("LegacyBodyFields() = %v", got)
+	}
+	if api.GetMethod() != "POST" || api.GetProtocol() != "https" {
+		t.Fatalf("method/protocol = %q/%q", api.GetMethod(), api.GetProtocol())
+	}
+	if (&API{Method: "PATCH", Protocol: "HTTP"}).GetMethod() != "GET" || (&API{Protocol: "HTTP"}).GetProtocol() != "http" {
+		t.Fatal("legacy method/protocol defaults changed")
+	}
+	v1 := []V1Parameter{}
+	api.V1Parameters = &v1
+	if api.LegacyBodyFields() != nil {
+		t.Fatal("V1 projection must suppress canonical body fields")
+	}
+}

--- a/canonicalmeta/reader_additional_test.go
+++ b/canonicalmeta/reader_additional_test.go
@@ -1,0 +1,97 @@
+package canonicalmeta
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReaderFallbackLayoutsAndDirectAPIPath(t *testing.T) {
+	fsys := fstest.MapFS{
+		"canonical/metadatas/products.json":             {Data: []byte(`{"products":[{"code":"demo"}]}`)},
+		"canonical/demo/canonical/demo/v1/version.json": {Data: []byte(`{"version":"v1","apis":{}}`)},
+		"custom/Create.json": {Data: []byte(`{
+			"name":"Create","parameters":[{"name":"id","raw_name":"Id","location":"query","type":"string"}]
+		}`)},
+	}
+	reader := NewReader(fsys)
+
+	products, err := reader.ReadProducts()
+	require.NoError(t, err)
+	require.Len(t, products.Products, 1)
+	assert.Equal(t, "demo", products.Products[0].Code)
+
+	index, err := reader.ReadVersionIndex("DEMO", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", index.Version)
+
+	api, err := reader.ReadAPIFromPath("custom/Create.json")
+	require.NoError(t, err)
+	assert.Equal(t, "Create", api.Name)
+}
+
+func TestReaderReportsMissingMalformedAndValidationErrors(t *testing.T) {
+	t.Run("missing indexes", func(t *testing.T) {
+		reader := NewReader(fstest.MapFS{})
+		_, err := reader.ReadProducts()
+		assert.ErrorContains(t, err, "read canonical products failed")
+		_, err = reader.ReadVersionIndex("Demo", "v1")
+		assert.ErrorContains(t, err, "demo/v1")
+		_, err = reader.ReadAPI("Demo", "v1", "Missing")
+		assert.Error(t, err)
+	})
+
+	t.Run("malformed indexes", func(t *testing.T) {
+		reader := NewReader(fstest.MapFS{
+			"metadatas/products.json":        {Data: []byte(`{broken`)},
+			"canonical/demo/v1/version.json": {Data: []byte(`{broken`)},
+		})
+		_, err := reader.ReadProducts()
+		assert.ErrorContains(t, err, "parse canonical products")
+		_, err = reader.ReadVersionIndex("demo", "v1")
+		assert.ErrorContains(t, err, "parse canonical version index")
+	})
+
+	t.Run("api parse and canonical parameter validation", func(t *testing.T) {
+		reader := NewReader(fstest.MapFS{
+			"bad.json": {Data: []byte(`{broken`)},
+			"location.json": {Data: []byte(`{
+				"name":"BadLocation","parameters":[{"name":"id","raw_name":"Id","location":"cookie"}]
+			}`)},
+			"v1.json": {Data: []byte(`{
+				"name":"BadV1","parameters":[],"v1_parameters":[{
+					"name":"Parent","position":"query","sub_parameters":[{"name":"Child","position":"cookie"}]
+				}]
+			}`)},
+		})
+		_, err := reader.ReadAPIFromPath("bad.json")
+		assert.ErrorContains(t, err, "parse canonical API")
+		_, err = reader.ReadAPIFromPath("location.json")
+		assert.ErrorContains(t, err, "unknown canonical location")
+		_, err = reader.ReadAPIFromPath("v1.json")
+		assert.ErrorContains(t, err, "unknown v1 parameter position")
+	})
+
+	t.Run("api name mismatch", func(t *testing.T) {
+		reader := NewReader(fstest.MapFS{
+			"canonical/demo/v1/Wrong.json": {Data: []byte(`{"name":"Actual","parameters":[]}`)},
+		})
+		_, err := reader.ReadAPI("demo", "v1", "Wrong")
+		assert.ErrorContains(t, err, "name mismatch")
+	})
+}
+
+func TestAPIAndVersionEntrySmallContracts(t *testing.T) {
+	assert.False(t, (&API{}).IsAnonymous())
+	assert.True(t, (&API{Security: []string{"AK", "Anonymous"}}).IsAnonymous())
+	assert.Empty(t, (*API)(nil).Title("en"))
+	assert.Empty(t, (*API)(nil).TitleOrDescription("zh"))
+
+	entry := VersionAPIEntry{TitleZh: "标题", DescriptionZh: "描述", DescriptionEn: "description"}
+	assert.Equal(t, "标题", entry.Title("zh"))
+	assert.Empty(t, entry.Title("en"))
+	assert.Equal(t, "标题", entry.TitleOrDescription("zh"))
+	assert.Equal(t, "description", entry.TitleOrDescription("en"))
+}

--- a/canonicalmeta/response_section_additional_test.go
+++ b/canonicalmeta/response_section_additional_test.go
@@ -1,0 +1,121 @@
+package canonicalmeta
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseSectionKeepsAllResponsesAndReachableComponents(t *testing.T) {
+	api := &API{
+		Responses: rawJSON(`{
+			"200":{"schema":{"$ref":"#/components/schemas/Result"}},
+			"400":{"schema":{"$ref":"#/components/schemas/Error"}}
+		}`),
+		Components: rawJSON(`{"schemas":{
+			"Result":{"properties":{"item":{"$ref":"#/components/schemas/Item"}}},
+			"Item":{"properties":{"parent":{"$ref":"#/components/schemas/Result"}}},
+			"Error":{"type":"object"},
+			"Unused":{"type":"object"}
+		}}`),
+	}
+
+	document, err := api.ResponseSection()
+	require.NoError(t, err)
+	require.JSONEq(t, string(api.Responses), string(document.Responses))
+	assert.Len(t, document.Components, 3)
+	assert.Contains(t, document.Components, "Result")
+	assert.Contains(t, document.Components, "Item")
+	assert.Contains(t, document.Components, "Error")
+	assert.NotContains(t, document.Components, "Unused")
+	assert.Contains(t, strings.Join(document.Warnings, "\n"), "cyclic")
+}
+
+func TestResponseSectionEmptyInlineAndWarningCases(t *testing.T) {
+	for _, api := range []*API{nil, {}, {Responses: rawJSON(`null`)}} {
+		document, err := api.ResponseSection()
+		require.NoError(t, err)
+		assert.Empty(t, document.Responses)
+	}
+
+	inline := &API{Responses: rawJSON(`{"200":{"schema":{"type":"string"}}}`), Components: rawJSON(`{broken`)}
+	document, err := inline.ResponseSection()
+	require.NoError(t, err, "components stay lazy when responses have no references")
+	assert.NotEmpty(t, document.Responses)
+	assert.Empty(t, document.Components)
+
+	warnings := &API{
+		Responses: rawJSON(`{"200":{"schema":{"allOf":[
+			{"$ref":"#/components/schemas/Missing"},
+			{"$ref":"https://example.com/remote.json"},
+			{"$ref":"#/components/schemas/Missing"}
+		]}}}`),
+		Components: rawJSON(`{"schemas":{}}`),
+	}
+	document, err = warnings.ResponseSection()
+	require.NoError(t, err)
+	joined := strings.Join(document.Warnings, "\n")
+	assert.Contains(t, joined, "Missing")
+	assert.Contains(t, joined, "non-local")
+	assert.Equal(t, 2, len(document.Warnings), "duplicate warnings should be collapsed")
+}
+
+func TestResponseSectionReturnsTypedErrorsForMalformedMetadata(t *testing.T) {
+	tests := []struct {
+		name      string
+		api       *API
+		wantField string
+	}{
+		{name: "responses object", api: &API{Responses: rawJSON(`{broken`)}, wantField: "responses"},
+		{name: "response traversal", api: &API{Responses: rawJSON(`{"200":{"schema":`)}, wantField: "responses"},
+		{
+			name: "components object",
+			api: &API{
+				Responses:  rawJSON(`{"200":{"schema":{"$ref":"#/components/schemas/Result"}}}`),
+				Components: rawJSON(`{"schemas":[]}`),
+			},
+			wantField: "components",
+		},
+		{
+			name: "component traversal",
+			api: &API{
+				Responses:  rawJSON(`{"200":{"schema":{"$ref":"#/components/schemas/Result"}}}`),
+				Components: rawJSON(`{"schemas":{"Result":{"properties":`),
+			},
+			wantField: "components",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.api.ResponseSection()
+			require.Error(t, err)
+			var typed *ResponseSchemaError
+			require.True(t, errors.As(err, &typed))
+			assert.Equal(t, tc.wantField, typed.Field)
+			assert.Contains(t, typed.Error(), "parse canonical response "+tc.wantField+" failed")
+			assert.Error(t, typed.Unwrap())
+		})
+	}
+}
+
+func TestResponseSchemaPointerAndWarningEdgeCases(t *testing.T) {
+	assert.Equal(t, "A/B~C", func() string {
+		value, ok := localComponentName("#/components/schemas/A~1B~0C/path")
+		require.True(t, ok)
+		return value
+	}())
+	_, ok := localComponentName("#/components/schemas/")
+	assert.False(t, ok)
+	_, ok = localComponentName("https://example.com/schema")
+	assert.False(t, ok)
+
+	warnings := newWarningCollector()
+	warnings.add("same")
+	warnings.add("same")
+	warnings.add("")
+	assert.Equal(t, []string{"same", ""}, warnings.values())
+}

--- a/cli/coverage_additional_test.go
+++ b/cli/coverage_additional_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandSubCommandNamesAndMetadata(t *testing.T) {
+	var nilCommand *Command
+	assert.Nil(t, nilCommand.SubCommandNames())
+	root := &Command{
+		Name: "aliyun", Short: i18n.T("root short", "根命令"), Long: i18n.T("root long", "根说明"),
+		Usage: "aliyun <command>", Sample: "aliyun configure", Hidden: false,
+	}
+	assert.Nil(t, root.SubCommandNames())
+	child := &Command{Name: "demo", Short: i18n.T("demo short", "演示")}
+	root.AddSubCommand(child)
+	root.subCommands = append(root.subCommands, nil)
+	assert.Equal(t, []string{"demo"}, root.SubCommandNames())
+
+	flag := &Flag{
+		Name: "profile", Shorthand: 'p', Short: i18n.T("profile short", "配置短说明"), Long: i18n.T("profile long", "配置长说明"),
+		DefaultValue: "default", Required: true, Aliases: []string{"account"}, AssignedMode: AssignedOnce,
+		Persistent: true, Hidden: true, Category: "global",
+	}
+	root.Flags().Add(flag)
+	// Metadata recursion expects actual child commands; keep the nil entry only
+	// for the SubCommandNames nil-filter contract above.
+	root.subCommands = root.subCommands[:1]
+	metadata := map[string]*Metadata{}
+	root.GetMetadata(metadata)
+	require.Contains(t, metadata, "aliyun")
+	require.Contains(t, metadata, "aliyun demo")
+	rootMetadata := metadata["aliyun"]
+	assert.Equal(t, "root long", rootMetadata.Long["en"])
+	require.Contains(t, rootMetadata.Flags, "profile")
+	profile := rootMetadata.Flags["profile"]
+	assert.Equal(t, 'p', profile.Shorthand)
+	assert.Equal(t, "default", profile.DefaultValue)
+	assert.True(t, profile.Required)
+	assert.True(t, profile.Persistent)
+	assert.True(t, profile.Hidden)
+	assert.Equal(t, "global", profile.Category)
+}
+
+func TestContextRuntimeSettingsAccessors(t *testing.T) {
+	ctx := NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+	assert.False(t, ctx.Insecure())
+	ctx.SetInsecure(true)
+	assert.True(t, ctx.Insecure())
+	envs := map[string]string{"LANG": "en"}
+	ctx.SetRuntimeEnvs(envs)
+	assert.Equal(t, envs, ctx.GetRuntimeEnvs())
+}
+
+func TestErrorAgentContractsAndDefaultWriters(t *testing.T) {
+	invalidCommand := &InvalidCommandError{Name: "missing"}
+	invalidCommand.AIRecoveryEligible()
+	assert.Nil(t, invalidCommand.GetSuggestions())
+	assert.Equal(t, "Use `--help` for more information.", invalidCommand.GetTip("en"))
+
+	invalidFlag := &InvalidFlagError{Flag: "--missing"}
+	invalidFlag.AIRecoveryEligible()
+	assert.Equal(t, "invalid flag --missing", invalidFlag.AgentMessage())
+	assert.Equal(t, "aliyun help", invalidFlag.AgentHelpCommand())
+	assert.Nil(t, invalidFlag.AgentSuggestions())
+
+	option := &HelpOptionError{Code: HelpOptionErrorCode("future")}
+	assert.Equal(t, "invalid Help options", option.Error())
+	assert.Nil(t, option.GetSuggestions())
+	option.AIRecoveryEligible()
+
+	assert.NotNil(t, DefaultStdoutWriter())
+	assert.NotNil(t, DefaultStderrWriter())
+	assert.False(t, IsAIRecoveryEligible(errors.New("plain")))
+}

--- a/cli/levenshtein_test.go
+++ b/cli/levenshtein_test.go
@@ -233,6 +233,13 @@ func TestEditScriptForStrings(t *testing.T) {
 	}
 }
 
+func TestEditScriptForMatrixAndDeprecatedLogger(t *testing.T) {
+	matrix := MatrixForStrings([]rune("cat"), []rune("cut"), DefaultOptions)
+	assert.Equal(t, EditScriptForStrings([]rune("cat"), []rune("cut"), DefaultOptions),
+		EditScriptForMatrix(matrix, DefaultOptions))
+	LogMatrix([]rune("a"), []rune("b"), MatrixForStrings([]rune("a"), []rune("b"), DefaultOptions))
+}
+
 func equal(a, b EditScript) bool {
 	for i := range a {
 		if a[i] != b[i] {

--- a/cli/plugin/execution_additional_test.go
+++ b/cli/plugin/execution_additional_test.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstalledPluginTypeAndPublicVersionValidation(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvPluginsDir, dir)
+	manifest := LocalManifest{Plugins: map[string]LocalPlugin{
+		"aliyun-cli-go-demo": {
+			Name: "aliyun-cli-go-demo", Version: "1.0.0", ProductCode: "go-demo", Command: "go-demo",
+		},
+		"aliyun-cli-meta-demo": {
+			Name: "aliyun-cli-meta-demo", Version: "1.0.0", ProductCode: "meta-demo", Command: "meta-demo", Type: PluginTypeMeta,
+		},
+	}}
+	encoded, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), encoded, 0600))
+
+	pluginType, ok := InstalledPluginType("go-demo")
+	assert.True(t, ok)
+	assert.Equal(t, PluginTypeGo, pluginType)
+	pluginType, ok = InstalledPluginType("meta-demo")
+	assert.True(t, ok)
+	assert.Equal(t, PluginTypeMeta, pluginType)
+	_, ok = InstalledPluginType("missing")
+	assert.False(t, ok)
+
+	require.NoError(t, ValidatePluginCliVersion("go-demo"))
+	assert.Error(t, ValidatePluginCliVersion("missing"))
+	metaPlugin := manifest.Plugins["aliyun-cli-meta-demo"]
+	goPlugin := manifest.Plugins["aliyun-cli-go-demo"]
+	assert.True(t, metaPlugin.IsMeta())
+	assert.False(t, goPlugin.IsMeta())
+	assert.False(t, (*LocalPlugin)(nil).IsMeta())
+}

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -3439,6 +3439,54 @@ func TestCollectPluginsForProductCodes(t *testing.T) {
 	assert.Equal(t, "aliyun-cli-pds", matched[1].Name)
 }
 
+func TestValidateAndResolvePackageTypeBranches(t *testing.T) {
+	dir := t.TempDir()
+	metadata := &MetadataDescriptor{}
+
+	tests := []struct {
+		name     string
+		manifest PluginManifest
+		wantType string
+		wantErr  string
+	}{
+		{name: "legacy go default", manifest: PluginManifest{}, wantType: PluginTypeGo},
+		{name: "explicit go", manifest: PluginManifest{Type: " GO "}, wantType: PluginTypeGo},
+		{name: "go cannot declare metadata", manifest: PluginManifest{Type: PluginTypeGo, Metadata: metadata}, wantErr: `type "meta" is required`},
+		{name: "implicit go cannot declare metadata", manifest: PluginManifest{Metadata: metadata}, wantErr: `type "meta" is required`},
+		{name: "unsupported", manifest: PluginManifest{Type: "python"}, wantErr: "unsupported type"},
+		{name: "meta requires descriptor", manifest: PluginManifest{Type: PluginTypeMeta}, wantErr: "metadata descriptor is required"},
+		{name: "meta rejects binary", manifest: func() PluginManifest {
+			m := PluginManifest{Type: PluginTypeMeta, Metadata: metadata}
+			m.Bin.Path = "plugin"
+			return m
+		}(), wantErr: "bin.path must be empty"},
+		{name: "invalid metadata descriptor", manifest: PluginManifest{Type: PluginTypeMeta, Metadata: metadata}, wantErr: "metadata"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manifest := test.manifest
+			err := validateAndResolvePackageType(dir, &manifest)
+			if test.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantType, manifest.Type)
+		})
+	}
+}
+
+func TestExpandPluginSourcePathHomeAndEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := expandPluginSourcePath("~/package.tgz")
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "package.tgz"), path)
+	_, err = expandPluginSourcePath("   ")
+	assert.ErrorContains(t, err, "source path is empty")
+}
+
 func TestManager_InstallCustom(t *testing.T) {
 	t.Run("Success - install only custom products", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -224,9 +224,6 @@ func TestDoUpgrade_DirectWhenNotBrew(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUpgradeViaDirect_FullFlow(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non-linux platform")
-	}
 	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
 	archive := createTarGzInMemory(t, "aliyun", binaryContent)
 
@@ -376,9 +373,6 @@ func TestConfirmUpgrade_StdinEmpty(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDownloadAndExtract_Success(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non-linux platform")
-	}
 	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
 	archiveBuf := createTarGzInMemory(t, "aliyun", binaryContent)
 

--- a/config/flags_accessors_additional_test.go
+++ b/config/flags_accessors_additional_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreviouslyUncalledFlagAccessors(t *testing.T) {
+	flags := cli.NewFlagSet()
+	for _, flag := range []*cli.Flag{
+		{Name: SourceProfileFlagName},
+		{Name: RegionIdFlagName},
+		{Name: SkipSecureVerifyName},
+		{Name: OAuthSiteTypeName},
+	} {
+		flags.Add(flag)
+	}
+	assert.Equal(t, SourceProfileFlagName, SourceProfileFlag(flags).Name)
+	assert.Equal(t, RegionIdFlagName, RegionIdFlag(flags).Name)
+	assert.Equal(t, SkipSecureVerifyName, SkipSecureVerify(flags).Name)
+	assert.Equal(t, OAuthSiteTypeName, OAuthSiteTypeFlag(flags).Name)
+}

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -1,12 +1,37 @@
 package export
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
 )
+
+func testExportProduct() *productExt {
+	return &productExt{
+		Code: "Demo", Version: "2026-01-01", ApiStyle: "ROA",
+		Name:                 map[string]string{"en": "Demo Service", "zh": "演示服务"},
+		RegionalEndpoints:    map[string]string{"cn-test": "demo.cn-test.example.com", "cn-extra": "demo.cn-extra.example.com"},
+		RegionalVpcEndpoints: map[string]string{"cn-test": "demo-vpc.cn-test.example.com"},
+		ApiNames:             []string{"CreateReport", "DescribeRegions"},
+		LegacyExport: &legacyExportData{
+			EndpointType: "regional",
+			Regions: map[string]legacyRegion{
+				"cn-test": {
+					RegionID: "cn-test", AreaID: "china",
+					RegionName: map[string]string{"en": "Test Region", "zh": "测试地域"},
+					AreaName:   map[string]string{"en": "China", "zh": "中国"},
+				},
+			},
+			APITitles: map[string]legacyAPITitle{
+				"CreateReport": {En: "Create a report", Zh: "创建报表"},
+			},
+		},
+	}
+}
 
 func TestExportProductFailsWhenCanonicalAPIMissing(t *testing.T) {
 	repo := canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
@@ -23,5 +48,165 @@ func TestExportProductFailsWhenCanonicalAPIMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "MissingAPI") {
 		t.Fatalf("expected error to mention MissingAPI, got %s", err)
+	}
+}
+
+func TestExportProductWritesLegacyExecutionAndLocaleTrees(t *testing.T) {
+	repo := canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+	product := testExportProduct()
+	output := t.TempDir()
+
+	if err := exportProduct(repo, product, output); err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{
+		"metadatas/demo/CreateReport.json",
+		"metadatas/demo/DescribeRegions.json",
+		"en-US/demo/CreateReport.json",
+		"zh-CN/demo/CreateReport.json",
+		"en-US/demo/version.json",
+		"zh-CN/demo/version.json",
+	}
+	for _, relative := range paths {
+		if _, err := os.Stat(filepath.Join(output, relative)); err != nil {
+			t.Fatalf("missing exported file %s: %v", relative, err)
+		}
+	}
+
+	var execution legacyExecAPI
+	readJSONFile(t, filepath.Join(output, "metadatas/demo/DescribeRegions.json"), &execution)
+	if execution.Name != "DescribeRegions" || execution.Protocol != "HTTP|HTTPS" || execution.Method != "GET|POST" {
+		t.Fatalf("execution metadata = %#v", execution)
+	}
+	if len(execution.Parameters) != 2 || execution.Parameters[1].Name != "Tags" ||
+		execution.Parameters[1].Type != "RepeatList" || len(execution.Parameters[1].SubParameters) != 2 {
+		t.Fatalf("execution parameters = %#v", execution.Parameters)
+	}
+
+	var english legacyLocaleAPI
+	readJSONFile(t, filepath.Join(output, "en-US/demo/CreateReport.json"), &english)
+	if english.Name != "CreateReport" || len(english.Parameters) == 0 ||
+		english.Parameters[0].Description != "The ID of the report to create." {
+		t.Fatalf("English locale metadata = %#v", english)
+	}
+	var chinese legacyLocaleAPI
+	readJSONFile(t, filepath.Join(output, "zh-CN/demo/CreateReport.json"), &chinese)
+	if len(chinese.Parameters) == 0 || chinese.Parameters[0].Description != "要创建的报表 ID。" {
+		t.Fatalf("Chinese locale metadata = %#v", chinese)
+	}
+
+	var englishVersion versionFile
+	readJSONFile(t, filepath.Join(output, "en-US/demo/version.json"), &englishVersion)
+	if englishVersion.Version != "2026-01-01" || englishVersion.Style != "ROA" ||
+		englishVersion.APIs["CreateReport"].Title != "Create a report" ||
+		englishVersion.APIs["CreateReport"].Summary != "Creates a report." {
+		t.Fatalf("English version metadata = %#v", englishVersion)
+	}
+	var chineseVersion versionFile
+	readJSONFile(t, filepath.Join(output, "zh-CN/demo/version.json"), &chineseVersion)
+	if chineseVersion.APIs["CreateReport"].Title != "创建报表" ||
+		chineseVersion.APIs["CreateReport"].Summary != "创建报表。" {
+		t.Fatalf("Chinese version metadata = %#v", chineseVersion)
+	}
+}
+
+func TestLocaleProductsAndEndpointsUseFallbacks(t *testing.T) {
+	product := testExportProduct()
+	endpoints := buildLocaleEndpoints(product, "zh")
+	if len(endpoints) != 2 || endpoints["cn-test"].RegionName != "测试地域" ||
+		endpoints["cn-test"].Public != "demo.cn-test.example.com" ||
+		endpoints["cn-test"].Vpc != "demo-vpc.cn-test.example.com" ||
+		endpoints["cn-extra"].RegionID != "cn-extra" {
+		t.Fatalf("localized endpoints = %#v", endpoints)
+	}
+
+	fallback := &productExt{Code: "Empty", Version: "v1"}
+	output := t.TempDir()
+	if err := exportLocaleProductsJSON(&productSetExt{Products: []productExt{*product, *fallback}}, "en", output); err != nil {
+		t.Fatal(err)
+	}
+	var products localeProductSet
+	readJSONFile(t, filepath.Join(output, "products.json"), &products)
+	if len(products.Products) != 2 || products.Products[0].Name != "Demo Service" ||
+		products.Products[0].EndpointType != "regional" || products.Products[1].Name != "Empty" ||
+		products.Products[1].EndpointType != "regional" {
+		t.Fatalf("locale products = %#v", products.Products)
+	}
+}
+
+func TestBundledProductsCanBeLoadedAndExportedWithoutLegacyFields(t *testing.T) {
+	products, err := loadProductsExt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(products.Products) == 0 {
+		t.Fatal("bundled products are empty")
+	}
+	output := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(output, "metadatas"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exportMetadatasProductsJSON(output); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(filepath.Join(output, "metadatas/products.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(content), "legacy_export") {
+		t.Fatal("clean products export retained legacy_export")
+	}
+	var exported cleanProductSet
+	if err := json.Unmarshal(content, &exported); err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Products) != len(products.Products) {
+		t.Fatalf("exported %d products, want %d", len(exported.Products), len(products.Products))
+	}
+}
+
+func TestExportBuilderDefaultsAndWriteErrors(t *testing.T) {
+	repo := canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+	product := testExportProduct()
+	product.ApiStyle = ""
+	product.LegacyExport.APITitles = nil
+	output := t.TempDir()
+	if err := exportVersionJSON(repo, product, "en", output); err != nil {
+		t.Fatal(err)
+	}
+	var version versionFile
+	readJSONFile(t, filepath.Join(output, "demo/version.json"), &version)
+	if version.Style != "rpc" || version.APIs["CreateReport"].Title != "CreateReport" {
+		t.Fatalf("default version metadata = %#v", version)
+	}
+
+	api, err := repo.GetAPI("demo", "2026-01-01", "CreateReport")
+	if err != nil {
+		t.Fatal(err)
+	}
+	execution := buildMetadatasJSON(api)
+	localized := buildLocaleJSON(api, "en")
+	if execution.Name != "CreateReport" || localized.Name != "CreateReport" || len(execution.Parameters) == 0 {
+		t.Fatalf("builder outputs = %#v / %#v", execution, localized)
+	}
+	if got := legacyDisplayType(api.LegacyTopLevelParameters()[0]); got != "string" {
+		t.Fatalf("scalar display type = %q", got)
+	}
+	if err := writeJSON(filepath.Join(output, "missing", "value.json"), map[string]string{"value": "x"}); err == nil {
+		t.Fatal("writeJSON unexpectedly created its missing parent")
+	}
+	if err := writeJSON(filepath.Join(output, "bad.json"), make(chan int)); err == nil {
+		t.Fatal("writeJSON accepted an unsupported JSON value")
+	}
+}
+
+func readJSONFile(t *testing.T, path string, target any) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(content, target); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"embed"
 	"encoding/json"
 	"io"
 	"os"
@@ -12,6 +13,41 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/config"
 	sysmock "github.com/aliyun/aliyun-cli/v3/sysconfig/mock"
 )
+
+//go:embed testdata/dump
+var testDumpFS embed.FS
+
+func TestDumpFilesCopiesEmbeddedTree(t *testing.T) {
+	output := t.TempDir()
+	dumpFiles(testDumpFS, "./testdata/dump", output)
+
+	root, err := os.ReadFile(filepath.Join(output, "testdata", "dump", "root.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(root) != "root fixture\n" {
+		t.Fatalf("root fixture = %q", root)
+	}
+	child, err := os.ReadFile(filepath.Join(output, "testdata", "dump", "nested", "child.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(child) != "child fixture\n" {
+		t.Fatalf("child fixture = %q", child)
+	}
+}
+
+func TestDumpFilesMissingPathReturnsWithoutWriting(t *testing.T) {
+	output := t.TempDir()
+	dumpFiles(testDumpFS, "missing", output)
+	entries, err := os.ReadDir(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("unexpected output entries: %v", entries)
+	}
+}
 
 func TestMainWithNoArgs(t *testing.T) {
 	clearAgentDetectionEnv(t)

--- a/main/testdata/dump/nested/child.txt
+++ b/main/testdata/dump/nested/child.txt
@@ -1,0 +1,1 @@
+child fixture

--- a/main/testdata/dump/root.txt
+++ b/main/testdata/dump/root.txt
@@ -1,0 +1,1 @@
+root fixture

--- a/meta/repository_additional_test.go
+++ b/meta/repository_additional_test.go
@@ -1,0 +1,18 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryGetProductIsCaseInsensitive(t *testing.T) {
+	repository, err := MockLoadRepository([]Product{{Code: "ECS"}})
+	require.NoError(t, err)
+	product, ok := repository.GetProduct("ecs")
+	assert.True(t, ok)
+	assert.Equal(t, "ECS", product.Code)
+	_, ok = repository.GetProduct("missing")
+	assert.False(t, ok)
+}

--- a/openapi/agent_error_additional_test.go
+++ b/openapi/agent_error_additional_test.go
@@ -1,0 +1,140 @@
+package openapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAgentErrorWrapperAndMessageFallbacks(t *testing.T) {
+	assert.Nil(t, normalizeAgentError(nil, nil))
+	plain := errors.New("plain failure")
+	assert.Same(t, plain, normalizeAgentError(plain, []string{"ecs", "DescribeInstances"}))
+	assert.Equal(t, " explicit ", nonEmptyMessage(" explicit ", plain))
+	assert.Equal(t, "plain failure", nonEmptyMessage("", plain))
+	assert.Equal(t, "CLI request is invalid.", nonEmptyMessage("", nil))
+	assert.Equal(t, "first", firstString([]string{"first", "second"}))
+	assert.Empty(t, firstString(nil))
+	assert.Equal(t, "value", firstNonEmpty("", " value ", "later"))
+	assert.Empty(t, firstNonEmpty("", "  "))
+}
+
+func TestTeaRequestIDPayloadVariants(t *testing.T) {
+	assert.Empty(t, teaRequestID(&tea.SDKError{}))
+	assert.Empty(t, teaRequestID(&tea.SDKError{Data: tea.String("not-json")}))
+	assert.Equal(t, "upper", teaRequestID(&tea.SDKError{Data: tea.String(`{"RequestId":"upper"}`)}))
+	assert.Equal(t, "lower", teaRequestID(&tea.SDKError{Data: tea.String(`{"requestId":"lower"}`)}))
+	assert.Empty(t, teaRequestID(&tea.SDKError{Data: tea.String(`{"requestId":42}`)}))
+}
+
+func TestOAuthAgentMessageVariants(t *testing.T) {
+	assert.Equal(t, "refresh: invalid_grant (expired)", oauthAgentMessage(&config.OAuthTokenError{Stage: "refresh", Code: "invalid_grant", Description: "expired"}))
+	assert.Equal(t, "refresh: invalid_grant", oauthAgentMessage(&config.OAuthTokenError{Stage: "refresh", Code: "invalid_grant"}))
+	assert.Equal(t, "refresh (HTTP 400)", oauthAgentMessage(&config.OAuthTokenError{Stage: "refresh", StatusCode: 400}))
+}
+
+func TestConstraintMessagesHintsAndLegacyFactsAllKinds(t *testing.T) {
+	tests := []struct {
+		constraint string
+		bound      string
+		message    string
+		hint       string
+	}{
+		{"enum", "", "not allowed", "allowed values"},
+		{"minimum", "1", "greater than or equal", "greater than or equal"},
+		{"maximum", "9", "less than or equal", "less than or equal"},
+		{"minLength", "2", "at least", "at least"},
+		{"maxLength", "8", "at most", "at most"},
+		{"pattern", "^[a-z]+$", "does not match", "documented pattern"},
+		{"future", "", "violates", "documented constraint"},
+	}
+	for _, test := range tests {
+		facts := constraintFacts{flag: "Name", value: "bad", constraint: test.constraint, bound: test.bound}
+		assert.Contains(t, constraintViolationMessage(facts), test.message, test.constraint)
+		assert.Contains(t, constraintViolationHint(facts), test.hint, test.constraint)
+
+		legacy := &ConstraintViolationError{Flag: "Name", Value: "bad", Constraint: test.constraint, Allowed: []string{"a"}}
+		switch test.constraint {
+		case "minimum":
+			legacy.Minimum = test.bound
+		case "maximum":
+			legacy.Maximum = test.bound
+		case "minLength":
+			legacy.MinLength = test.bound
+		case "maxLength":
+			legacy.MaxLength = test.bound
+		case "pattern":
+			legacy.Pattern = test.bound
+		}
+		converted := legacyConstraintFacts(legacy)
+		assert.Equal(t, test.bound, converted.bound, test.constraint)
+		assert.Equal(t, []string{"a"}, converted.allowed)
+	}
+
+	for _, kind := range []string{"minimum", "maximum", "minLength", "maxLength"} {
+		assert.Contains(t, constraintViolationHint(constraintFacts{flag: "Name", constraint: kind}), "documented constraint")
+	}
+}
+
+func TestHelpOptionAgentErrorEveryRecovery(t *testing.T) {
+	cause := errors.New("invalid options")
+	assert.Same(t, cause, helpOptionAgentError(cause, nil))
+	tests := []struct {
+		code   cli.HelpOptionErrorCode
+		action string
+		hint   string
+	}{
+		{cli.HelpOptionConflict, "fix_option_combination", "Use only one"},
+		{cli.HelpOptionDuplicate, "fix_option_combination", "duplicate"},
+		{cli.HelpOptionEmptySearch, "fix_help_options", "non-empty"},
+		{cli.HelpOptionInvalidOutput, "fix_help_options", "--cli-output json"},
+		{cli.HelpOptionInvalidSection, "fix_help_options", "request or --cli-section response"},
+		{cli.HelpOptionErrorCode("future"), "fix_help_options", "Correct the Help options"},
+	}
+	for _, test := range tests {
+		option := &cli.HelpOptionError{Code: test.code, Option: "--help", ConflictsWith: "--help-all", Value: "bad"}
+		err := helpOptionAgentError(cause, option)
+		var agent *cli.AgentError
+		require.ErrorAs(t, err, &agent)
+		envelope := agent.Envelope()
+		assert.Equal(t, test.action, envelope.Recovery.Action)
+		assert.Contains(t, envelope.Recovery.Hint, test.hint)
+	}
+}
+
+func TestRecoveryContextFallbackAndSuffixCommands(t *testing.T) {
+	empty := newRecoveryContext(nil)
+	assert.Equal(t, "aliyun --help", empty.productHelpCommand())
+	assert.Equal(t, "aliyun --help", empty.productSearchCommand("bad token"))
+	assert.Equal(t, "aliyun --help", empty.actionHelpCommand())
+	assert.Equal(t, "aliyun --help", empty.parameterHelpCommand("Name"))
+	assert.Empty(t, empty.parameterGuidanceCommand("Name"))
+	assert.Equal(t, "aliyun --help", empty.requestHelpCommand())
+	assert.Equal(t, "aliyun --help", empty.responseSectionCommand())
+
+	context := newRecoveryContext([]string{"ecs", "DescribeInstances", "--version=2014-05-26"})
+	assert.Equal(t, "aliyun ecs DescribeInstances --version 2014-05-26 --help", context.parameterHelpCommand("bad.name"))
+	assert.Equal(t, context.requestHelpCommand(), context.requestSearchCommand("bad token"))
+	assert.Equal(t, context.actionHelpCommand(), context.actionSearchCommand("bad token"))
+	parent := newRecoveryContext([]string{"ecs", "DescribeInstances"})
+	assert.Equal(t, "aliyun ecs --help", parent.parentHelpCommand("DescribeInstances"))
+	assert.Equal(t, "aliyun ecs --help", parent.parentSearchCommand("DescribeInstances", "bad token"))
+
+	assert.Equal(t, "aliyun --help", suffixHelpCommand("not-aliyun command"))
+	assert.Equal(t, "aliyun --help-search profile", suffixSearchCommand("not-aliyun command", "profile"))
+	assert.Equal(t, "aliyun --help", suffixSearchCommand("aliyun", "bad token"))
+	assert.Nil(t, helpCommandParts("other ecs --help"))
+	assert.Nil(t, helpCommandParts("aliyun ecs;rm --help"))
+	assert.Equal(t, []string{"ecs", "DescribeInstances"}, helpCommandParts("aliyun help ecs DescribeInstances --help"))
+}
+
+func TestAPICandidateFormsForStyle(t *testing.T) {
+	assert.Equal(t, []string{"describe-instances"}, apiCandidateFormsForStyle([]string{"DescribeInstances", "", "DescribeInstances"}, "kebab"))
+	assert.Equal(t, []string{"DescribeInstances", "ListTags"}, apiCandidateFormsForStyle([]string{"describe-instances", "list_tags"}, "pascal"))
+	assert.Equal(t, []string{"Already"}, apiCandidateFormsForStyle([]string{"Already"}, "unknown"))
+}

--- a/openapi/commando_coverage_test.go
+++ b/openapi/commando_coverage_test.go
@@ -1,0 +1,457 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/aliyun/aliyun-openapi-runtime/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandoConfigurationSettersCopyInputs(t *testing.T) {
+	c, _, _ := newTestCommando()
+	validator := func(RecoverySearchRequest) bool { return true }
+	c.SetRecoverySearchValidator(validator)
+	require.NotNil(t, c.recoverySearchValidator)
+	assert.True(t, c.recoverySearchValidator(RecoverySearchRequest{}))
+
+	commands := []RootCommandSpec{{Path: []string{"configure"}}}
+	flags := []RootFlagSpec{{Name: "--profile"}}
+	c.SetRootHelpSpecs(commands, flags)
+	commands[0] = RootCommandSpec{Path: []string{"mutated"}}
+	flags[0].Name = "--mutated"
+	assert.Equal(t, "configure", c.rootCommandHelpSpecs[0].Path[0])
+	assert.Equal(t, "--profile", c.rootFlagHelpSpecs[0].Name)
+}
+
+func TestLegacyHelpCanonicalRootProductRequestAndResponse(t *testing.T) {
+	t.Run("root search", func(t *testing.T) {
+		c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
+		CliHelpSearchFlag(ctx.Flags()).SetValue("demo")
+		require.NoError(t, c.legacyHelp(ctx, nil))
+		assert.Contains(t, stdout.String(), "demo")
+		assert.Contains(t, stdout.String(), cli.AIModeEnableCommand)
+	})
+
+	t.Run("product all", func(t *testing.T) {
+		c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+		CliHelpAllFlag(ctx.Flags()).SetAssigned(true)
+		require.NoError(t, c.legacyHelp(ctx, []string{"demo"}))
+		assert.Contains(t, stdout.String(), "Product: demo")
+		assert.Contains(t, stdout.String(), "DescribeRegions")
+	})
+
+	t.Run("request search", func(t *testing.T) {
+		c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+		c.library.helpRepo = canonicalmeta.NewRepository(os.DirFS("../aliyun-openapi-meta"))
+		c.library.baselineHelpRepo = c.library.helpRepo
+		c.library.builtinRepo = getRepository()
+		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
+		CliHelpSearchFlag(ctx.Flags()).SetValue("instance id")
+		require.NoError(t, c.legacyHelp(ctx, []string{"ecs", "DescribeInstances"}))
+		assert.Contains(t, stdout.String(), "InstanceId")
+	})
+
+	t.Run("response search", func(t *testing.T) {
+		c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+		CliHelpSectionFlag(ctx.Flags()).SetAssigned(true)
+		CliHelpSectionFlag(ctx.Flags()).SetValue("response")
+		CliHelpSearchFlag(ctx.Flags()).SetAssigned(true)
+		CliHelpSearchFlag(ctx.Flags()).SetValue("report-id")
+		require.NoError(t, c.legacyHelp(ctx, []string{"demo", "CreateReport"}))
+		assert.Contains(t, stdout.String(), "ReportId")
+	})
+
+	t.Run("machine JSON", func(t *testing.T) {
+		c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+		MachineHelpFormatFlag(ctx.Flags()).SetAssigned(true)
+		MachineHelpFormatFlag(ctx.Flags()).SetValue("json")
+		require.NoError(t, c.legacyHelp(ctx, []string{"demo"}))
+		assert.Contains(t, stdout.String(), `"kind": "product"`)
+	})
+}
+
+func TestCommandoPrintUsageAndNonInteractiveInstallHint(t *testing.T) {
+	c, stdout, stderr := newTestCommando()
+	command := testMachineHelpRootCommand()
+	ctx := cli.NewCommandContext(stdout, stderr)
+	ctx.EnterCommand(command)
+	c.printUsage(ctx)
+	assert.Contains(t, stdout.String(), "Alibaba Cloud CLI")
+	assert.Contains(t, stdout.String(), "configure")
+
+	pluginName, err := c.promptInstallInNonInteractiveMode(ctx, "aliyun-cli-demo", "demo list")
+	require.NoError(t, err)
+	assert.Empty(t, pluginName)
+	assert.Contains(t, stderr.String(), "aliyun plugin install --names aliyun-cli-demo")
+	assert.Contains(t, stderr.String(), "--enable-pre")
+}
+
+func TestMarshalDryRunInvokeMeta(t *testing.T) {
+	request := requests.NewCommonRequest()
+	request.Product = "ecs"
+	request.Version = "2014-05-26"
+	request.ApiName = "DescribeRegions"
+	request.RegionId = "cn-hangzhou"
+	request.Domain = "ecs.cn-hangzhou.aliyuncs.com"
+	invoker := &RpcInvoker{BasicInvoker: &BasicInvoker{request: request}}
+
+	encoded, err := marshalDryRunInvokeMeta(nil, invoker)
+	require.NoError(t, err)
+	var document dryRunInvokeMeta
+	require.NoError(t, json.Unmarshal([]byte(encoded), &document))
+	assert.Equal(t, "DescribeRegions", document.API)
+	assert.Equal(t, "cn-hangzhou", document.Region)
+}
+
+func TestCheckApiParamWithBuiltInArgsCopiesOnlyQueryValues(t *testing.T) {
+	c := &Commando{}
+	ctx := cli.NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+	ctx.SetUnknownFlags(cli.NewFlagSet())
+	query := &cli.Flag{Name: "RegionId"}
+	query.SetAssigned(true)
+	query.SetValue("cn-hangzhou")
+	body := &cli.Flag{Name: "Payload"}
+	body.SetAssigned(true)
+	body.SetValue("body")
+	ctx.Flags().Add(query)
+	ctx.Flags().Add(body)
+	api := &canonicalAPIForCoverage
+	c.CheckApiParamWithBuildInArgs(ctx, api.value())
+	assert.Equal(t, "cn-hangzhou", assignedFlagValue(ctx.UnknownFlags(), "RegionId"))
+	assert.Empty(t, assignedFlagValue(ctx.UnknownFlags(), "Payload"))
+	c.CheckApiParamWithBuildInArgs(ctx, nil)
+}
+
+type canonicalAPIForCoverageType struct{}
+
+var canonicalAPIForCoverage canonicalAPIForCoverageType
+
+func (canonicalAPIForCoverageType) value() *canonicalmeta.API {
+	return &canonicalmeta.API{Parameters: []canonicalmeta.Parameter{
+		{RawName: "RegionId", Type: "string", Location: "query"},
+		{RawName: "Payload", Type: "string", Location: "body"},
+	}}
+}
+
+func assignedFlagValue(flags *cli.FlagSet, name string) string {
+	flag := flags.Get(name)
+	if flag == nil || !flag.IsAssigned() {
+		return ""
+	}
+	value, _ := flag.GetValue()
+	return strings.TrimSpace(value)
+}
+
+func TestLegacyHelpFallbackRootProductAPIAndTooManyArguments(t *testing.T) {
+	repo, err := meta.MockLoadRepository([]meta.Product{{
+		Code: "demo", Version: "2026-01-01", ApiStyle: "rpc",
+		ApiNames: []string{"CreateReport"}, Name: map[string]string{"en": "Demo Service"},
+	}})
+	require.NoError(t, err)
+	canonical := newFakeCanonicalRepo()
+	canonical.AddAPI("demo", "2026-01-01", &canonicalmeta.API{
+		Name: "CreateReport", Protocol: "HTTPS", Method: "POST",
+		Parameters: []canonicalmeta.Parameter{{Name: "ReportId", RawName: "ReportId", Type: "string", Location: "query"}},
+	})
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		contains string
+	}{
+		{name: "root", contains: "Products:"},
+		{name: "product", args: []string{"demo"}, contains: "Available Api List:"},
+		{name: "api", args: []string{"demo", "CreateReport"}, contains: "--ReportId"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+			c.library.builtinRepo = repo
+			c.library.canonicalRepo = canonical
+			c.pluginLoaded = true
+			require.NoError(t, c.legacyHelp(ctx, tc.args))
+			assert.Contains(t, stdout.String(), tc.contains)
+			assert.Contains(t, stdout.String(), cli.AIModeEnableCommand)
+		})
+	}
+
+	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	c.library.builtinRepo = repo
+	c.pluginLoaded = true
+	err = c.legacyHelp(ctx, []string{"demo", "CreateReport", "nested"})
+	assert.ErrorContains(t, err, "too many arguments: 3")
+}
+
+func TestLegacyHelpAIModeDefaultCanonicalViews(t *testing.T) {
+	repo, err := meta.MockLoadRepository([]meta.Product{{
+		Code: "demo", Version: "2026-01-01", ApiStyle: "rpc",
+		ApiNames: []string{"CreateReport", "DescribeRegions"},
+	}})
+	require.NoError(t, err)
+	canonical := canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		contains string
+	}{
+		{name: "root", contains: "demo"},
+		{name: "product", args: []string{"demo"}, contains: "Product: demo"},
+		{name: "api", args: []string{"demo", "CreateReport"}, contains: "--ReportId"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+			t.Setenv("ALIBABA_CLOUD_CLI_AI_MODE", "1")
+			c.library.builtinRepo = repo
+			c.library.canonicalRepo = canonical
+			c.pluginLoaded = true
+			require.NoError(t, c.legacyHelp(ctx, tc.args))
+			assert.Contains(t, stdout.String(), tc.contains)
+			assert.NotContains(t, stdout.String(), cli.AIModeEnableCommand)
+		})
+	}
+}
+
+func TestCommandoCompletionCoversProductsParametersAndRestfulMethods(t *testing.T) {
+	products, err := meta.MockLoadRepository([]meta.Product{
+		{Code: "ecs", Version: "2014-05-26", ApiStyle: "rpc", ApiNames: []string{"DescribeInstances"}},
+		{Code: "cs", Version: "2015-12-15", ApiStyle: "restful", ApiNames: []string{"DescribeCluster"}},
+	})
+	require.NoError(t, err)
+	canonical := newFakeCanonicalRepo()
+	canonical.AddAPI("ecs", "2014-05-26", &canonicalmeta.API{
+		Name: "DescribeInstances",
+		Parameters: []canonicalmeta.Parameter{
+			{Name: "InstanceId", RawName: "InstanceId", Type: "string", Location: "query"},
+			{Name: "Host", RawName: "Host", Type: "string", Location: "header"},
+			{Name: "Domain", RawName: "Domain", Type: "string", Location: "domain"},
+		},
+	})
+	c := &Commando{library: &Library{builtinRepo: products, canonicalRepo: canonical}}
+	stdout := &bytes.Buffer{}
+	ctx := cli.NewCommandContext(stdout, &bytes.Buffer{})
+	root := testMachineHelpRootCommand()
+	root.AddSubCommand(&cli.Command{Name: "configure"})
+	ctx.EnterCommand(root)
+
+	ctx.SetCompletion(&cli.Completion{Current: "ec"})
+	assert.Empty(t, c.complete(ctx, nil))
+	assert.Contains(t, stdout.String(), "ecs")
+	stdout.Reset()
+
+	ctx.SetCompletion(&cli.Completion{Current: "--In"})
+	assert.Empty(t, c.complete(ctx, []string{"ecs", "DescribeInstances"}))
+	assert.Equal(t, "--InstanceId\n", stdout.String())
+	stdout.Reset()
+
+	ctx.SetCompletion(&cli.Completion{})
+	assert.Empty(t, c.complete(ctx, []string{"cs"}))
+	assert.Contains(t, stdout.String(), "GET\n")
+	assert.Contains(t, stdout.String(), "POST\n")
+	assert.Empty(t, c.complete(ctx, []string{"missing"}))
+}
+
+func TestCommandoSmallRoutingHelpers(t *testing.T) {
+	c := &Commando{rootCommandHelpSpecs: []RootCommandSpec{
+		{Group: RootGroupExtension, Path: []string{"plugin"}},
+		{Group: RootGroupCore, Path: []string{"configure"}},
+	}}
+	assert.False(t, c.isExtensionInvocation(nil))
+	assert.True(t, c.isExtensionInvocation([]string{"plugin", "list"}))
+	assert.False(t, c.isExtensionInvocation([]string{"configure"}))
+
+	cause := errors.New("ordinary")
+	assert.NoError(t, c.adaptEngineUnknownCommand(nil))
+	assert.Same(t, cause, c.adaptEngineUnknownCommand(cause))
+	adapted := c.adaptEngineUnknownCommand(&engine.UnknownCommandError{Product: "ecs", Command: "describe-instnaces"})
+	var invalid *InvalidBaselineCommandError
+	require.ErrorAs(t, adapted, &invalid)
+	assert.Equal(t, "ecs", invalid.Product)
+	assert.Equal(t, "describe-instnaces", invalid.Command)
+
+	assert.Equal(t, "", buildCommandName(nil))
+	assert.Equal(t, "ecs", buildCommandName([]string{"ecs"}))
+	assert.Equal(t, "ecs DescribeInstances", buildCommandName([]string{"ecs", "DescribeInstances", "ignored"}))
+}
+
+func TestRecoveryNormalizationArgsAndDryRunPathLookup(t *testing.T) {
+	ctx := cli.NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+	root := testMachineHelpRootCommand()
+	AddFlags(root.Flags())
+	ctx.EnterCommand(root)
+
+	assert.Equal(t, []string{"ecs", "DescribeInstances"}, recoveryNormalizationArgs(ctx,
+		[]string{"--cli-ai-mode", "ecs", "DescribeInstances", "--no-cli-ai-mode"}))
+	VersionFlag(ctx.Flags()).SetAssigned(true)
+	VersionFlag(ctx.Flags()).SetValue("2014-05-26")
+	assert.Equal(t, []string{"ecs", "DescribeInstances", "--version", "2014-05-26"},
+		recoveryNormalizationArgs(ctx, []string{"ecs", "DescribeInstances"}))
+	assert.Equal(t, []string{"ecs", "describe-instances", "--api-version", "2014-05-26"},
+		recoveryNormalizationArgs(ctx, []string{"ecs", "describe-instances"}))
+	assert.Equal(t, []string{"ecs", "DescribeInstances", "--version", "2020-01-01"},
+		recoveryNormalizationArgs(ctx, []string{"ecs", "DescribeInstances", "--version", "2020-01-01"}))
+	assert.Equal(t, []string{"ecs"}, recoveryNormalizationArgs(nil, []string{"ecs"}))
+
+	repo, err := meta.MockLoadRepository([]meta.Product{{
+		Code: "cs", Version: "2015-12-15", ApiStyle: "restful", ApiNames: []string{"DescribeCluster"},
+	}})
+	require.NoError(t, err)
+	canonical := newFakeCanonicalRepo()
+	canonical.AddAPI("cs", "2015-12-15", &canonicalmeta.API{
+		Name: "DescribeCluster", Method: "GET", PathPattern: "/clusters/[ClusterId]",
+	})
+	library := &Library{builtinRepo: repo, canonicalRepo: canonical}
+	assert.Equal(t, "DescribeCluster", dryRunRestfulAPIByPath(library, "cs", "2015-12-15", "GET", "/clusters/c-1"))
+	assert.Equal(t, "GET /missing", dryRunRestfulAPIByPath(library, "cs", "2015-12-15", "GET", "/missing"))
+	assert.Equal(t, "GET /clusters", dryRunRestfulAPIByPath(nil, "cs", "2015-12-15", "GET", "/clusters"))
+	assert.Equal(t, "/clusters", dryRunRestfulAPIByPath(library, "cs", "2015-12-15", "", "/clusters"))
+}
+
+func TestPrintProductsCoversBuiltinAndPluginCombinations(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+	i18n.SetLanguage("en")
+
+	builtin, err := meta.MockLoadRepository([]meta.Product{
+		{Code: "both-installed", Name: map[string]string{"en": "Built-in installed"}},
+		{Code: "both-missing", Name: map[string]string{"en": "Built-in missing"}},
+		{Code: "builtin-only", Name: map[string]string{"en": "Built-in only"}},
+	})
+	require.NoError(t, err)
+	c := &Commando{
+		library: &Library{builtinRepo: builtin},
+		pluginIndex: &plugin.Index{Plugins: []plugin.PluginInfo{
+			{Name: "aliyun-cli-both-installed", ProductCode: "both-installed", ProductName: map[string]string{"en": "Localized installed"}},
+			{Name: "aliyun-cli-both-missing", ProductCode: "both-missing", Description: "Available plugin"},
+			{Name: "aliyun-cli-plugin-missing", ProductCode: "plugin-missing"},
+			{Name: "aliyun-cli-plugin-installed", ProductCode: "plugin-installed", Description: "Installed plugin"},
+		}},
+		localManifest: &plugin.LocalManifest{Plugins: map[string]plugin.LocalPlugin{
+			"aliyun-cli-both-installed":   {Name: "aliyun-cli-both-installed"},
+			"aliyun-cli-plugin-installed": {Name: "aliyun-cli-plugin-installed"},
+		}},
+	}
+	stdout := &bytes.Buffer{}
+	ctx := cli.NewCommandContext(stdout, &bytes.Buffer{})
+	c.printProducts(ctx)
+
+	output := stdout.String()
+	assert.Contains(t, output, "Localized installed (Plugin: aliyun-cli-both-installed)")
+	assert.Contains(t, output, "Available plugin (Plugin available but not installed: aliyun-cli-both-missing)")
+	assert.Contains(t, output, "plugin-missing (Plugin: aliyun-cli-plugin-missing, Not Installed)")
+	assert.Contains(t, output, "Installed plugin (Plugin: aliyun-cli-plugin-installed)")
+	assert.Contains(t, output, "Built-in only")
+	assert.Contains(t, output, "aliyun plugin install --names <plugin_name>")
+}
+
+func TestPreviouslyUncalledOpenAPICompatibilityHelpers(t *testing.T) {
+	flag := NewMachineHelpFormatFlag()
+	assert.Equal(t, CliOutputFlagName, flag.Name)
+
+	products, err := meta.MockLoadRepository([]meta.Product{{
+		Code: "cs", Version: "v1", ApiStyle: "restful", ApiNames: []string{"GetThing"},
+	}})
+	require.NoError(t, err)
+	repository := newFakeCanonicalRepo()
+	repository.AddAPI("cs", "v1", &canonicalmeta.API{Name: "GetThing", Method: "GET", PathPattern: "/things/[Id]"})
+	library := &Library{builtinRepo: products, canonicalRepo: repository}
+	assert.Equal(t, "GetThing", library.GetCanonicalApiByPath("cs", "v1", "GET", "/things/1").Name)
+	assert.Nil(t, library.GetCanonicalApiByPath("cs", "v1", "GET", "/missing"))
+}
+
+func TestCreateInvokerAdditionalRoutingAndErrorBranches(t *testing.T) {
+	products, err := meta.MockLoadRepository([]meta.Product{
+		{Code: "ecs", Version: "2014-05-26", ApiStyle: "rpc", ApiNames: []string{"DescribeInstances"}},
+		{Code: "cs", Version: "2015-12-15", ApiStyle: "restful", ApiNames: []string{"DescribeCluster"}},
+	})
+	require.NoError(t, err)
+	profile := config.Profile{
+		Mode: config.AK, AccessKeyId: "test-ak", AccessKeySecret: "test-sk", RegionId: "cn-hangzhou", Endpoint: "service.aliyuncs.com",
+	}
+	newCase := func() (*Commando, *cli.Context) {
+		ctx := cli.NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+		root := &cli.Command{Name: "DescribeCluster", EnableUnknownFlag: true}
+		config.AddFlags(root.Flags())
+		AddFlags(root.Flags())
+		root.Flags().Add(&cli.Flag{Name: "style"})
+		ctx.EnterCommand(root)
+		return &Commando{
+			profile: profile, pluginLoaded: true,
+			library: &Library{builtinRepo: products, canonicalRepo: newFakeCanonicalRepo()},
+		}, ctx
+	}
+
+	t.Run("unknown product without force", func(t *testing.T) {
+		c, ctx := newCase()
+		_, err := c.createInvoker(ctx, "missing", "DescribeThings", "")
+		var invalid *InvalidProductError
+		require.ErrorAs(t, err, &invalid)
+	})
+
+	t.Run("unknown rpc api without installed plugin", func(t *testing.T) {
+		c, ctx := newCase()
+		_, err := c.createInvoker(ctx, "ecs", "MissingAPI", "")
+		var invalid *InvalidApiError
+		require.ErrorAs(t, err, &invalid)
+	})
+
+	t.Run("unknown rpc api with installed plugin", func(t *testing.T) {
+		c, ctx := newCase()
+		c.localManifest = &plugin.LocalManifest{Plugins: map[string]plugin.LocalPlugin{
+			"aliyun-cli-ecs": {Name: "aliyun-cli-ecs", CmdNames: []string{"describe-instances"}},
+		}}
+		_, err := c.createInvoker(ctx, "ecs", "MissingAPI", "")
+		var invalid *InvalidUnifiedApiError
+		require.ErrorAs(t, err, &invalid)
+	})
+
+	t.Run("force unknown version requires style", func(t *testing.T) {
+		c, ctx := newCase()
+		ForceFlag(ctx.Flags()).SetAssigned(true)
+		VersionFlag(ctx.Flags()).SetAssigned(true)
+		VersionFlag(ctx.Flags()).SetValue("2099-01-01")
+		_, err := c.createInvoker(ctx, "ecs", "DescribeThings", "")
+		assert.ErrorContains(t, err, "uncheked version")
+
+		ctx.Flags().Get("style").SetAssigned(true)
+		ctx.Flags().Get("style").SetValue("rpc")
+		invoker, err := c.createInvoker(ctx, "ecs", "DescribeThings", "")
+		require.NoError(t, err)
+		assert.IsType(t, &ForceRpcInvoker{}, invoker)
+	})
+
+	t.Run("restful method required and accepted", func(t *testing.T) {
+		c, ctx := newCase()
+		_, err := c.createInvoker(ctx, "cs", "not-a-method", "")
+		assert.ErrorContains(t, err, "need restful call")
+		invoker, err := c.createInvoker(ctx, "cs", "GET", "/clusters")
+		require.NoError(t, err)
+		assert.IsType(t, &RestfulInvoker{}, invoker)
+	})
+
+	t.Run("forced unknown product supports restful and rpc", func(t *testing.T) {
+		c, ctx := newCase()
+		ForceFlag(ctx.Flags()).SetAssigned(true)
+		VersionFlag(ctx.Flags()).SetAssigned(true)
+		VersionFlag(ctx.Flags()).SetValue("2026-01-01")
+		invoker, err := c.createInvoker(ctx, "custom", "GET", "/things")
+		require.NoError(t, err)
+		assert.IsType(t, &RestfulInvoker{}, invoker)
+		invoker, err = c.createInvoker(ctx, "custom", "DoThing", "")
+		require.NoError(t, err)
+		assert.IsType(t, &ForceRpcInvoker{}, invoker)
+	})
+}

--- a/openapi/errors_additional_test.go
+++ b/openapi/errors_additional_test.go
@@ -1,0 +1,109 @@
+package openapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalErrorContractsCoverMessagesMarkersAndUnwrap(t *testing.T) {
+	cause := errors.New("original error")
+
+	missing := &LegacyMissingRequiredError{Err: cause}
+	assert.Equal(t, "original error", missing.Error())
+	assert.ErrorIs(t, missing, cause)
+	missing.AIRecoveryEligible()
+	assert.Equal(t, "required parameters are not assigned", (*LegacyMissingRequiredError)(nil).Error())
+	assert.NoError(t, (*LegacyMissingRequiredError)(nil).Unwrap())
+	assert.NoError(t, newLegacyMissingRequiredError(nil))
+	assert.Same(t, missing, newLegacyMissingRequiredError(missing))
+
+	argument := &InvalidArgumentError{Err: cause}
+	assert.Equal(t, "original error", argument.Error())
+	assert.ErrorIs(t, argument, cause)
+	argument.AIRecoveryEligible()
+	assert.Equal(t, "invalid argument", (&InvalidArgumentError{}).Error())
+
+	combination := &InvalidOptionCombinationError{Err: cause}
+	assert.Equal(t, "original error", combination.Error())
+	assert.ErrorIs(t, combination, cause)
+	combination.AIRecoveryEligible()
+	assert.Nil(t, combination.GetSuggestions())
+	assert.Equal(t, "invalid option combination", (&InvalidOptionCombinationError{}).Error())
+
+	header := &InvalidHeaderError{Err: cause}
+	assert.Equal(t, "original error", header.Error())
+	assert.ErrorIs(t, header, cause)
+	header.AIRecoveryEligible()
+	assert.Equal(t, "invalid header", (&InvalidHeaderError{}).Error())
+
+	body := &InvalidBodyFileError{Err: cause}
+	assert.Equal(t, "original error", body.Error())
+	assert.ErrorIs(t, body, cause)
+	body.AIRecoveryEligible()
+	assert.Equal(t, "invalid body file", (&InvalidBodyFileError{}).Error())
+}
+
+func TestProductAPIAndParameterAgentContracts(t *testing.T) {
+	product := &InvalidProductError{Code: "ECX"}
+	assert.Equal(t, `"ecx" is not a valid command or product.`, product.AgentMessage())
+	product.AIRecoveryEligible()
+	assert.Nil(t, product.AgentSuggestions())
+
+	api := &InvalidApiError{Name: "DescribeInstnaces", product: &meta.Product{
+		Code: "ecs", ApiNames: []string{"DescribeInstances"},
+	}}
+	assert.Equal(t, `"DescribeInstnaces" is not a valid api.`, api.AgentMessage())
+	api.AIRecoveryEligible()
+	assert.Contains(t, api.AgentSuggestions(), "DescribeInstances")
+	assert.Nil(t, (&InvalidApiError{Name: "missing"}).AgentSuggestions())
+
+	flags := cli.NewFlagSet()
+	flags.Add(&cli.Flag{Name: "region"})
+	parameter := &InvalidParameterError{
+		Name: "regoin", ProductCode: "ecs", ApiName: "DescribeInstances",
+		ParameterNames: []string{"RegionId"}, flags: flags,
+	}
+	assert.Equal(t, `"--regoin" is not a valid parameter or flag.`, parameter.AgentMessage())
+	parameter.AIRecoveryEligible()
+	assert.NotEmpty(t, parameter.AgentSuggestions())
+
+	pluginProduct := &InvalidProductOrPluginError{
+		Code:    "ecx",
+		plugins: []plugin.PluginInfo{{ProductCode: "ecs"}},
+	}
+	assert.Equal(t, `"ecx" is not a valid product.`, pluginProduct.AgentMessage())
+	pluginProduct.AIRecoveryEligible()
+	assert.Contains(t, pluginProduct.AgentSuggestions(), "ecs")
+
+	unified := &InvalidUnifiedApiError{
+		Name:    "describe-instnaces",
+		product: &meta.Product{Code: "ecs", ApiNames: []string{"DescribeInstances"}},
+		lPlugin: plugin.LocalPlugin{CmdNames: []string{"describe-instances"}},
+	}
+	assert.Equal(t, `"describe-instnaces" is not a valid api.`, unified.AgentMessage())
+	unified.AIRecoveryEligible()
+	assert.Contains(t, unified.AgentSuggestions(), "describe-instances")
+	assert.Nil(t, (&InvalidUnifiedApiError{Name: "missing"}).AgentSuggestions())
+}
+
+func TestInvalidBaselineCommandContract(t *testing.T) {
+	cause := errors.New("unknown command")
+	err := &InvalidBaselineCommandError{
+		Product: "ecs", Command: "describe-instnaces",
+		Candidates: []string{"describe-instances"}, Err: cause,
+	}
+	assert.Contains(t, err.Error(), "unknown command")
+	assert.ErrorIs(t, err, cause)
+	err.AIRecoveryEligible()
+	require.NotEmpty(t, err.GetSuggestions())
+	require.NotEmpty(t, err.AgentSuggestions())
+
+	fallback := &InvalidBaselineCommandError{Product: "ecs", Command: "bad"}
+	assert.Contains(t, fallback.Error(), "invalid baseline command")
+}

--- a/openapi/help_dispatch_test.go
+++ b/openapi/help_dispatch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
 	"github.com/aliyun/aliyun-cli/v3/cli"
 	"github.com/aliyun/aliyun-cli/v3/cli/plugin"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/aimode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,133 @@ func TestRuntimeHelpCandidateRequiresKebabAction(t *testing.T) {
 	assert.False(t, runtimeHelpCandidate([]string{"fc"}), "product Help must retain host style selection")
 	assert.False(t, runtimeHelpCandidate([]string{"fc", "CreateAlias"}))
 	assert.True(t, runtimeHelpCandidate([]string{"fc", "create-alias"}))
+}
+
+func TestContainsPluginHelpOperation(t *testing.T) {
+	for _, args := range [][]string{
+		{"--help"}, {"-h"}, {"--help-all"}, {"--help-search", "instance"}, {"--help-search=instance"},
+	} {
+		assert.True(t, containsPluginHelpOperation(args), "args=%v", args)
+	}
+	assert.False(t, containsPluginHelpOperation([]string{"--cli-output", "json"}))
+}
+
+func TestAdaptMachineHelpTargetErrorAndInvalidParameter(t *testing.T) {
+	target := HelpTarget{Product: "demo", Action: "Missing", Parameter: "--Wrong"}
+	assert.Nil(t, adaptMachineHelpTargetError(target, nil, nil))
+
+	unknownProduct := newMachineHelpError("UNKNOWN_PRODUCT", "missing", nil, nil)
+	var productError *InvalidProductError
+	assert.ErrorAs(t, adaptMachineHelpTargetError(target, unknownProduct, nil), &productError)
+
+	unknownAPI := newMachineHelpError("UNKNOWN_API", "missing", nil, nil)
+	var commandError *InvalidBaselineCommandError
+	assert.ErrorAs(t, adaptMachineHelpTargetError(target, unknownAPI, nil), &commandError)
+	assert.Equal(t, "Missing", commandError.Command)
+
+	other := newMachineHelpError("OTHER", "other", nil, nil)
+	assert.Same(t, other, adaptMachineHelpTargetError(target, other, nil))
+
+	cause := errors.New("unknown parameter flag --Wrong")
+	assert.Same(t, cause, invalidMachineHelpParameter(target, nil, nil, cause))
+	different := errors.New("different")
+	assert.Same(t, different, invalidMachineHelpParameter(target, &machineHelpAPIDocument{}, nil, different))
+	action := &machineHelpAPIDocument{
+		ActiveParameterSet: "camel",
+		ParameterSets: machineHelpParameterSets{Camel: []machineHelpParameter{
+			{Name: "region-id", RawName: "RegionId", Options: []string{"--RegionId", "--region-id"}},
+			{Name: "name", RawName: "Name"},
+		}},
+		GlobalParameters: []machineHelpParameter{{Name: "profile", Options: []string{"--profile"}}},
+	}
+	var parameterError *InvalidParameterError
+	require.ErrorAs(t, invalidMachineHelpParameter(target, action, cli.NewFlagSet(), cause), &parameterError)
+	assert.ElementsMatch(t, []string{"RegionId", "region-id", "name", "profile"}, parameterError.ParameterNames)
+}
+
+func TestBuildRootHelpDocumentFromExplicitSpecs(t *testing.T) {
+	c, _, _, _ := newCanonicalHelpTestContext(t)
+	root := &cli.Command{Name: "aliyun", Short: i18n.T("Alibaba Cloud CLI", "阿里云 CLI")}
+	root.AddSubCommand(&cli.Command{Name: "configure", Short: i18n.T("Configure credentials", "配置凭证")})
+	root.Flags().Add(&cli.Flag{Name: "profile", Shorthand: 'p', Short: i18n.T("Profile", "配置")})
+	c.SetRootHelpSpecs(
+		[]RootCommandSpec{{Path: []string{"configure"}, Group: RootGroupCore, Aliases: []string{"config"}}},
+		[]RootFlagSpec{{Name: "profile", Visibility: RootVisibilityDefault}},
+	)
+	document, err := c.buildRootHelpDocument(root)
+	require.NoError(t, err)
+	require.Len(t, document.Commands, 1)
+	require.Len(t, document.GlobalFlags, 1)
+	require.Len(t, document.Products, 1)
+	assert.Equal(t, []string{"aliyun", "configure"}, document.Commands[0].Path)
+	assert.Equal(t, "-p", document.GlobalFlags[0].Shorthand)
+	assert.Equal(t, "demo", document.Products[0].Code)
+
+	missing := &Commando{}
+	_, err = missing.buildRootHelpDocument(root)
+	assert.ErrorContains(t, err, "repository is unavailable")
+}
+
+func TestHelpNextBuildersAndDocumentSetters(t *testing.T) {
+	target := HelpTarget{
+		Level: HelpLevelProduct, Product: "ecs", Operation: HelpOperationSearch,
+		SearchQuery: "instance", Output: HelpOutputJSON,
+	}
+	next := buildHelpNext(target, false)
+	assert.Contains(t, next.ShowAll, "--help-all")
+	assert.Contains(t, next.Search, "--help-search")
+	assert.Contains(t, next.SearchAll, "instance")
+	assert.Contains(t, next.SearchAll, "--help-all")
+
+	aiNext := buildHelpNext(HelpTarget{Level: HelpLevelAction, Product: "ecs", Action: "DescribeInstances", Output: HelpOutputJSON}, true)
+	assert.NotContains(t, aiNext.ShowAll, "--cli-output json")
+
+	root := &machineHelpRootDocument{}
+	product := &machineHelpProductDocument{}
+	action := &machineHelpAPIDocument{}
+	setRootHelpNext(root, target, false)
+	setProductHelpNext(product, target, false)
+	setActionHelpNext(action, target, false)
+	assert.Nil(t, root.Next)
+	assert.Nil(t, product.Next)
+	assert.Nil(t, action.Next)
+	root.Result.Truncated, product.Result.Truncated, action.Result.Truncated = true, true, true
+	setRootHelpNext(root, target, false)
+	setProductHelpNext(product, target, false)
+	setActionHelpNext(action, target, false)
+	assert.NotNil(t, root.Next)
+	assert.NotNil(t, product.Next)
+	assert.NotNil(t, action.Next)
+	setRootHelpNext(nil, target, false)
+	setProductHelpNext(nil, target, false)
+	setActionHelpNext(nil, target, false)
+}
+
+func TestRenderHostHelpTextAndHintDispatch(t *testing.T) {
+	ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+	assert.ErrorContains(t, renderHostHelpText(ctx, struct{}{}, ""), "unsupported Help document")
+
+	documents := []any{
+		&machineHelpRootDocument{}, &machineHelpProductDocument{}, &machineHelpAPIDocument{},
+		&machineHelpAPIResponseDocument{}, &machineHelpParameterDocument{}, struct{}{},
+	}
+	for _, document := range documents {
+		attachMachineHelpAIModeHint(document)
+	}
+	assert.NotNil(t, documents[0].(*machineHelpRootDocument).AIModeHint)
+	assert.NotNil(t, documents[1].(*machineHelpProductDocument).AIModeHint)
+	assert.NotNil(t, documents[2].(*machineHelpAPIDocument).AIModeHint)
+	assert.NotNil(t, documents[3].(*machineHelpAPIResponseDocument).AIModeHint)
+	assert.NotNil(t, documents[4].(*machineHelpParameterDocument).AIModeHint)
+}
+
+func TestHelpRepositoryForStyleNilAndFallback(t *testing.T) {
+	var nilCommando *Commando
+	assert.Nil(t, nilCommando.helpRepositoryForStyle("camel"))
+	assert.Nil(t, (&Commando{}).helpRepositoryForStyle("camel"))
+	repo := canonicalmeta.NewRepository(os.DirFS("../canonicalmeta/testdata"))
+	c := &Commando{library: &Library{helpRepo: repo}}
+	assert.Equal(t, repo, c.helpRepositoryForStyle("camel"))
 }
 
 func TestHelpRepositoryForStyleNeverProjectsMetaOnlyProductAsCamel(t *testing.T) {

--- a/openapi/help_projection_additional_test.go
+++ b/openapi/help_projection_additional_test.go
@@ -1,0 +1,223 @@
+package openapi
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type alwaysFailWriter struct{}
+
+func (alwaysFailWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+func TestRenderCanonicalRootTextAllSectionsAndSearch(t *testing.T) {
+	document := &machineHelpRootDocument{
+		Version:    "9.9.9",
+		QuickStart: []string{"aliyun configure", "aliyun ecs DescribeRegions"},
+		Commands: []machineHelpCommandSummary{
+			{Name: "configure", Path: []string{"aliyun", "configure"}, Description: machineHelpLocalizedText{EN: "Configure credentials"}},
+			{Group: "utils", Name: "mcp-proxy", Path: []string{"aliyun", "utils", "mcp-proxy"}, Description: machineHelpLocalizedText{EN: "Run MCP proxy"}},
+			{Group: "extension", Name: "completion", Path: []string{"aliyun", "completion"}, Description: machineHelpLocalizedText{EN: "Generate completion"}},
+		},
+		GlobalFlags: []machineHelpFlagSummary{{Name: "--profile", Shorthand: "-p", Description: machineHelpLocalizedText{EN: "Profile name"}}},
+		Products:    []machineHelpProductSummary{{Code: "ecs", Name: machineHelpLocalizedText{EN: "Elastic Compute Service"}}},
+		Listing:     &machineHelpListing{Shown: 1, Total: 2, Hint: "list hint"},
+		Result:      HelpResult{Shown: 3, Total: 9, Truncated: true},
+		Next:        &HelpNext{ShowAll: "aliyun --help-all", Search: "aliyun --help-search ecs", SearchAll: "aliyun --help-search ecs --help-all"},
+	}
+	var out strings.Builder
+	require.NoError(t, renderCanonicalRootText(&out, document, ""))
+	rendered := out.String()
+	for _, expected := range []string{"Version 9.9.9", "Quick Start:", "Core Commands:", "Utilities:", "Global Flags:", "Extensions:", "Products:", "Showing 1 of 2 products", "Show all:", "Search:", "Show all matches:"} {
+		assert.Contains(t, rendered, expected)
+	}
+
+	search := &machineHelpRootDocument{
+		Version: "9.9.9",
+		Matches: []machineHelpRootMatch{{Kind: "product", Name: "ecs", Command: "aliyun ecs --help", Description: machineHelpLocalizedText{EN: "Elastic Compute Service"}}},
+		Result:  HelpResult{Shown: 1, Total: 2, Truncated: true},
+	}
+	out.Reset()
+	require.NoError(t, renderCanonicalRootText(&out, search, "compute"))
+	assert.Contains(t, out.String(), "Matches:")
+	assert.Contains(t, out.String(), "aliyun ecs --help")
+	assert.Contains(t, out.String(), "Use a more specific --help-search")
+
+	out.Reset()
+	require.NoError(t, renderCanonicalRootText(&out, &machineHelpRootDocument{Version: "9.9.9"}, "absent"))
+	assert.Contains(t, out.String(), `No Help entries matched --help-search "absent".`)
+	assert.Error(t, renderCanonicalRootText(&out, nil, ""))
+	assert.Error(t, renderCanonicalRootText(alwaysFailWriter{}, document, ""))
+}
+
+func TestRenderCanonicalProductTextFullAndEmpty(t *testing.T) {
+	document := &machineHelpProductDocument{
+		Product: machineHelpProduct{
+			Code: "ecs", Name: machineHelpLocalizedText{EN: "Elastic Compute Service"}, SelectedVersion: "2014-05-26",
+			Plugin: "aliyun-cli-ecs", PluginVersion: "1.2.3",
+		},
+		APIs: []machineHelpAPISummary{
+			{DisplayName: "CreateInstance", Title: machineHelpLocalizedText{EN: "Create"}, Description: machineHelpLocalizedText{EN: "Create an instance"}},
+			{Name: "DescribeInstances", CmdName: "describe-instances", Description: machineHelpLocalizedText{EN: "List instances"}},
+		},
+		Listing: &machineHelpListing{Shown: 2, Total: 4, Hint: "use search"},
+		Result:  HelpResult{Shown: 2, Total: 5, Truncated: true, OmittedDeprecated: 2},
+		Next:    &HelpNext{ShowAll: "aliyun ecs --help-all"},
+	}
+	var out strings.Builder
+	require.NoError(t, renderCanonicalProductText(&out, document, ""))
+	rendered := out.String()
+	for _, expected := range []string{"Product: ecs", "Provided by plugin: aliyun-cli-ecs (1.2.3)", "Available API List:", "Create — Create an instance", "describe-instances", "Omitting 2 deprecated APIs", "Showing 2 of 4 APIs", "Show all:"} {
+		assert.Contains(t, rendered, expected)
+	}
+
+	out.Reset()
+	require.NoError(t, renderCanonicalProductText(&out, &machineHelpProductDocument{Product: machineHelpProduct{Code: "ecs"}}, "absent"))
+	assert.Contains(t, out.String(), `No Help entries matched --help-search "absent".`)
+	assert.Error(t, renderCanonicalProductText(&out, nil, ""))
+	assert.Error(t, renderCanonicalProductText(alwaysFailWriter{}, document, ""))
+}
+
+func TestRenderCanonicalRequestSearchAndFullDocuments(t *testing.T) {
+	parameter := machineHelpParameter{Name: "instance-id", Type: "string", Required: true, Options: []string{"--InstanceId"}, Help: machineHelpLocalizedText{EN: "Instance ID"}}
+	document := &machineHelpAPIDocument{
+		Target:             machineHelpTarget{Path: []string{"aliyun", "ecs", "DescribeInstances"}},
+		Product:            machineHelpProduct{Plugin: "aliyun-cli-ecs"},
+		ActiveParameterSet: "camel",
+		API: machineHelpAPI{
+			Title:       machineHelpLocalizedText{EN: "Describe instances"},
+			Description: machineHelpLocalizedText{EN: "Returns detailed instance information"},
+			Operation:   machineHelpOperation{APIVersion: "2014-05-26"},
+		},
+		ParameterSets:    machineHelpParameterSets{Camel: []machineHelpParameter{parameter}},
+		GlobalParameters: []machineHelpParameter{{Name: "region", Type: "string", Options: []string{"--region"}, Help: machineHelpLocalizedText{EN: "Region"}}},
+		Listing:          &machineHelpListing{Shown: 1, Total: 2, Hint: "use all"},
+		Result:           HelpResult{Shown: 1, Total: 2, Truncated: true},
+		Next:             &HelpNext{Search: "aliyun ecs DescribeInstances --help-search id"},
+		QueryOptions:     []machineHelpQueryOption{{Name: "--cli-query", Type: "string", Required: true, Help: machineHelpLocalizedText{EN: "JMESPath expression"}}},
+		ResponseQuery:    &machineHelpQueryExample{Path: "Instances.Instance", SchemaCommand: "schema command", QueryCommand: "query command"},
+		Examples:         machineHelpExamples{Camel: "aliyun ecs DescribeInstances --InstanceId i-1"},
+	}
+
+	var out strings.Builder
+	require.NoError(t, renderCanonicalRequestSearchText(&out, document, "instance"))
+	assert.Contains(t, out.String(), "Provided by plugin")
+	assert.Contains(t, out.String(), "Parameters:")
+	assert.Contains(t, out.String(), "Global Parameters:")
+
+	out.Reset()
+	require.NoError(t, renderCanonicalRequestText(&out, document))
+	rendered := out.String()
+	for _, expected := range []string{"Description: Describe instances", "Details: Returns detailed instance information", "API Version: 2014-05-26", "Usage:", "Showing 1 of 2 parameters", "Query Options:", "JMESPath expression", "Response aggregation example", "Example:"} {
+		assert.Contains(t, rendered, expected)
+	}
+
+	out.Reset()
+	require.NoError(t, renderCanonicalRequestSearchText(&out, &machineHelpAPIDocument{}, "absent"))
+	assert.Contains(t, out.String(), `No Help entries matched --help-search "absent".`)
+	assert.Error(t, renderCanonicalRequestSearchText(&out, nil, ""))
+	assert.Error(t, renderCanonicalRequestText(&out, nil))
+	assert.Error(t, renderCanonicalRequestSearchText(alwaysFailWriter{}, document, "instance"))
+	assert.Error(t, renderCanonicalRequestText(alwaysFailWriter{}, document))
+}
+
+func TestHelpProjectionSmallHelpers(t *testing.T) {
+	assert.Nil(t, projectMachineHelpListing(nil))
+	assert.Equal(t, &machineHelpListing{Shown: 2, Total: 3, Hint: "hint"}, projectMachineHelpListing(&HelpListingMetadata{Shown: 2, Total: 3, Hint: "hint"}))
+	assert.Equal(t, ResponseCommandStyleKebab, responseCommandStyle("kebab"))
+	assert.Equal(t, ResponseCommandStylePascal, responseCommandStyle("camel"))
+	assert.Nil(t, activeMachineHelpParameters(nil))
+
+	matches := []HelpSearchMatch{
+		{Candidate: HelpSearchCandidate{Value: "one"}},
+		{Candidate: HelpSearchCandidate{Value: 2}},
+	}
+	assert.Equal(t, []string{"one"}, helpSearchValues[string](matches))
+
+	assert.Equal(t, "plain", stripHelpANSI("\x1b[31mplain\x1b[0m"))
+	assert.Equal(t, "before\x1b[", stripHelpANSI("before\x1b["))
+	assert.Equal(t, "plugin", machineHelpPluginProvider(machineHelpProduct{Plugin: "plugin"}))
+	assert.Empty(t, machineHelpPluginProvider(machineHelpProduct{}))
+
+	t.Setenv("ALIBABA_CLOUD_CLI_MAX_LINE_LENGTH", "120")
+	assert.Equal(t, 120, machineHelpMaxLineLength())
+	t.Setenv("ALIBABA_CLOUD_CLI_MAX_LINE_LENGTH", "invalid")
+	assert.Equal(t, 80, machineHelpMaxLineLength())
+	assert.Nil(t, wrapMachineHelpText("  ", 8))
+	assert.Equal(t, []string{"short"}, wrapMachineHelpLine("short", 80))
+	assert.Equal(t, 12, len([]rune(wrapMachineHelpText("abcdefghijklmnopqrst", 1)[0])))
+
+	var output bytes.Buffer
+	require.NoError(t, renderTextListing(&output, "items", nil))
+	require.NoError(t, renderHelpProjectionResult(&output, "items", HelpResult{}, nil))
+	require.NoError(t, renderRequestQueryExampleText(&output, nil))
+}
+
+func TestCanonicalTextRenderersPropagateFailuresFromLaterWrites(t *testing.T) {
+	root := &machineHelpRootDocument{
+		Version:    "9.9.9",
+		QuickStart: []string{"aliyun configure", "aliyun ecs DescribeRegions"},
+		Commands: []machineHelpCommandSummary{
+			{Name: "configure", Description: machineHelpLocalizedText{EN: "Configure credentials"}},
+			{Group: "utils", Name: "mcp-proxy", Description: machineHelpLocalizedText{EN: "MCP proxy"}},
+			{Group: "extension", Name: "completion", Description: machineHelpLocalizedText{EN: "Completion"}},
+		},
+		GlobalFlags: []machineHelpFlagSummary{{Name: "--profile", Shorthand: "-p", Description: machineHelpLocalizedText{EN: "Profile"}}},
+		Products:    []machineHelpProductSummary{{Code: "ecs", Name: machineHelpLocalizedText{EN: "Elastic Compute Service"}}},
+		Listing:     &machineHelpListing{Shown: 1, Total: 2, Hint: "hint"},
+		Result:      HelpResult{Shown: 1, Total: 2, Truncated: true},
+		Next:        &HelpNext{ShowAll: "aliyun --help-all", Search: "aliyun --help-search ecs", SearchAll: "aliyun --help-search ecs --help-all"},
+	}
+	exerciseWriterFailures(t, func(w *failAfterWrites) error { return renderCanonicalRootText(w, root, "") })
+
+	rootSearch := &machineHelpRootDocument{
+		Version: "9.9.9",
+		Matches: []machineHelpRootMatch{
+			{Kind: "product", Name: "ecs", Command: "aliyun ecs", Description: machineHelpLocalizedText{EN: "Compute"}},
+			{Kind: "command", Name: "configure", Command: "aliyun configure", Description: machineHelpLocalizedText{EN: "Configure"}},
+		},
+		Result: HelpResult{Shown: 2, Total: 3, Truncated: true},
+	}
+	exerciseWriterFailures(t, func(w *failAfterWrites) error { return renderCanonicalRootText(w, rootSearch, "ec") })
+
+	product := &machineHelpProductDocument{
+		Product: machineHelpProduct{Code: "ecs", Name: machineHelpLocalizedText{EN: "Elastic Compute Service"}, SelectedVersion: "v1", Plugin: "plugin", PluginVersion: "1.0"},
+		APIs: []machineHelpAPISummary{
+			{DisplayName: "CreateInstance", Description: machineHelpLocalizedText{EN: "Create"}},
+			{DisplayName: "DescribeInstances", Description: machineHelpLocalizedText{EN: "Describe"}},
+		},
+		Listing: &machineHelpListing{Shown: 2, Total: 3, Hint: "hint"},
+		Result:  HelpResult{Shown: 2, Total: 4, Truncated: true, OmittedDeprecated: 1},
+		Next:    &HelpNext{ShowAll: "aliyun ecs --help-all", Search: "aliyun ecs --help-search instance"},
+	}
+	exerciseWriterFailures(t, func(w *failAfterWrites) error { return renderCanonicalProductText(w, product, "") })
+
+	parameter := machineHelpParameter{
+		Name: "instance-id", RawName: "InstanceId", Options: []string{"--InstanceId"},
+		Type: "string", Location: "query", Required: true,
+		Help: machineHelpLocalizedText{EN: "Instance ID"}, Example: "i-1",
+	}
+	request := &machineHelpAPIDocument{
+		Target:             machineHelpTarget{Path: []string{"aliyun", "ecs", "DescribeInstances"}},
+		Product:            machineHelpProduct{Plugin: "plugin"},
+		ActiveParameterSet: "camel",
+		API: machineHelpAPI{
+			Title: machineHelpLocalizedText{EN: "Describe instances"}, Description: machineHelpLocalizedText{EN: "Details"},
+			Operation: machineHelpOperation{APIVersion: "v1"},
+		},
+		ParameterSets:    machineHelpParameterSets{Camel: []machineHelpParameter{parameter}},
+		GlobalParameters: []machineHelpParameter{{Name: "region", Options: []string{"--region"}, Type: "string", Help: machineHelpLocalizedText{EN: "Region"}}},
+		QueryOptions:     []machineHelpQueryOption{{Name: "--cli-query", Type: "string", Help: machineHelpLocalizedText{EN: "Query"}}},
+		ResponseQuery:    &machineHelpQueryExample{Path: "Instances", SchemaCommand: "schema", QueryCommand: "query"},
+		Examples:         machineHelpExamples{Camel: "aliyun ecs DescribeInstances"},
+		Listing:          &machineHelpListing{Shown: 1, Total: 2, Hint: "hint"},
+		Result:           HelpResult{Shown: 1, Total: 2, Truncated: true},
+		Next:             &HelpNext{ShowAll: "aliyun ecs DescribeInstances --help-all", Search: "aliyun ecs DescribeInstances --help-search id"},
+	}
+	exerciseWriterFailures(t, func(w *failAfterWrites) error { return renderCanonicalRequestSearchText(w, request, "id") })
+	exerciseWriterFailures(t, func(w *failAfterWrites) error { return renderCanonicalRequestText(w, request) })
+}

--- a/openapi/help_render_error_paths_test.go
+++ b/openapi/help_render_error_paths_test.go
@@ -1,0 +1,193 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failAfterWrites struct {
+	remaining int
+}
+
+func (w *failAfterWrites) Write(p []byte) (int, error) {
+	if w.remaining == 0 {
+		return 0, errors.New("forced write failure")
+	}
+	w.remaining--
+	return len(p), nil
+}
+
+func exerciseWriterFailures(t *testing.T, render func(*failAfterWrites) error) {
+	t.Helper()
+	failures := 0
+	succeeded := false
+	for writes := 0; writes < 100; writes++ {
+		err := render(&failAfterWrites{remaining: writes})
+		if err != nil {
+			failures++
+			continue
+		}
+		succeeded = true
+		break
+	}
+	assert.True(t, succeeded, "renderer should eventually complete when enough writes are allowed")
+	assert.GreaterOrEqual(t, failures, 3, "renderer should propagate failures from multiple write sites")
+}
+
+func completeParameterHelpForRendering() machineHelpParameter {
+	constraints := machineHelpConstraints{
+		Enum: []string{"one", "two"}, Pattern: "^value$",
+		Minimum: "1", Maximum: "9", MinLength: "1", MaxLength: "16",
+	}
+	leaf := machineHelpParameter{
+		Name: "child", RawName: "Child", Options: []string{"--child"},
+		Type: "string", Location: "body", Required: true,
+		Serialization: "json", Help: machineHelpLocalizedText{EN: "child help"},
+		Example: "value", Constraints: constraints,
+	}
+	shape := &machineHelpShape{
+		Type: "object", Format: "map", Constraints: constraints,
+		Fields:  []machineHelpParameter{leaf},
+		Element: &machineHelpShape{Type: "string", Constraints: constraints},
+		Value:   &machineHelpShape{Type: "integer", Format: "int64"},
+	}
+	return machineHelpParameter{
+		Name: "config", RawName: "Config", Options: []string{"--config"},
+		Type: "object", Location: "query", Required: true,
+		Serialization: "json", Help: machineHelpLocalizedText{EN: "config help"},
+		Example: "{}", Constraints: constraints, Fields: []machineHelpParameter{leaf},
+		Element: shape, Value: shape,
+	}
+}
+
+func TestParameterHelpRenderersPropagateEveryWriterFailure(t *testing.T) {
+	parameter := completeParameterHelpForRendering()
+
+	t.Run("default document", func(t *testing.T) {
+		document := &machineHelpParameterDocument{
+			Parameter: parameter,
+			Result:    &HelpResult{Shown: 1, Total: 2, Truncated: true},
+		}
+		exerciseWriterFailures(t, func(w *failAfterWrites) error {
+			return renderParameterHelpText(w, document)
+		})
+	})
+
+	t.Run("search document", func(t *testing.T) {
+		document := &machineHelpParameterDocument{
+			Query: "child", Parameter: parameter,
+			Matches: []machineHelpParameterMatch{{Path: "Config.Child", Parameter: parameter}},
+			Result:  &HelpResult{Shown: 1, Total: 1},
+		}
+		exerciseWriterFailures(t, func(w *failAfterWrites) error {
+			return renderParameterHelpText(w, document)
+		})
+	})
+
+	t.Run("no search matches", func(t *testing.T) {
+		var output bytes.Buffer
+		require.NoError(t, renderParameterHelpText(&output, &machineHelpParameterDocument{Query: "absent"}))
+		assert.Contains(t, output.String(), "No Help entries matched")
+	})
+
+	assert.Error(t, renderParameterHelpText(&bytes.Buffer{}, nil))
+	assert.NoError(t, renderMachineHelpShapeNode(&bytes.Buffer{}, nil, nil, 0))
+}
+
+func TestParameterHelpBuilderAndWalkerEdgeCases(t *testing.T) {
+	assert.Error(t, func() error { _, err := buildParameterHelpDocument(nil, "--id"); return err }())
+	assert.Error(t, func() error { _, err := buildParameterHelpDocument(&machineHelpAPIDocument{}, " "); return err }())
+
+	action := &machineHelpAPIDocument{
+		Target: machineHelpTarget{Path: []string{"aliyun", "demo", "create"}},
+		API:    machineHelpAPI{Operation: machineHelpOperation{APIVersion: "2026-01-01"}},
+		ParameterSets: machineHelpParameterSets{Camel: []machineHelpParameter{
+			{Options: []string{"--same"}}, {Options: []string{"--same"}},
+		}},
+		ActiveParameterSet: "camel",
+	}
+	_, err := buildParameterHelpDocument(action, "--same")
+	assert.ErrorContains(t, err, "ambiguous")
+	_, err = buildParameterHelpDocument(action, "--missing")
+	assert.ErrorContains(t, err, "unknown parameter")
+
+	visited := make([]string, 0)
+	walkMachineHelpShape(&machineHelpShape{
+		Fields:  []machineHelpParameter{{Name: "field"}},
+		Element: &machineHelpShape{Fields: []machineHelpParameter{{RawName: "ElementField"}}},
+		Value:   &machineHelpShape{Fields: []machineHelpParameter{{Name: "value_field"}}},
+	}, []string{"Root"}, func(path string, _ machineHelpParameter) {
+		visited = append(visited, path)
+	})
+	assert.ElementsMatch(t, []string{"Root.field", "Root.ElementField", "Root.value_field"}, visited)
+	walkMachineHelpShape(nil, nil, func(string, machineHelpParameter) { t.Fatal("nil shape must not visit") })
+
+	assert.Equal(t, "--a", helpParameterDisplayName(machineHelpParameter{Options: []string{"--z", "--a"}}))
+	assert.Equal(t, "name", helpParameterDisplayName(machineHelpParameter{Name: "name", RawName: "raw"}))
+	assert.Equal(t, "raw", helpParameterDisplayName(machineHelpParameter{RawName: "raw"}))
+}
+
+func completeResponseHelpDocument(useResponses bool) *machineHelpAPIResponseDocument {
+	components := &machineHelpComponents{Schemas: map[string]json.RawMessage{
+		"Item": json.RawMessage(`{"type":"object","properties":{"id":{"type":"string"}}}`),
+	}}
+	document := &machineHelpAPIResponseDocument{
+		Provider: "aliyun-cli-demo", Components: components,
+		Warnings:      []string{"first warning", "second warning"},
+		ResponseQuery: &machineHelpQueryExample{QueryCommand: "aliyun demo list --cli-query Items"},
+		Notice:        "notice", Result: HelpResult{Shown: 1, Total: 2, Truncated: true},
+		Next: &HelpNext{ShowAll: "aliyun demo --help-all"},
+	}
+	if useResponses {
+		document.Responses = json.RawMessage(`{"200":{"description":"ok","schema":{"$ref":"#/components/schemas/Item"}}}`)
+		return document
+	}
+	document.Matches = []string{"Items", "Items.Id"}
+	document.OutputSchema = &machineHelpOutputSchema{
+		StatusCode: "200", ContentType: "application/json",
+		Schema:     json.RawMessage(`{"type":"array","items":{"$ref":"#/components/schemas/Item"}}`),
+		Components: components,
+	}
+	return document
+}
+
+func TestResponseHelpRenderersPropagateWriterAndJSONErrors(t *testing.T) {
+	for _, useResponses := range []bool{true, false} {
+		document := completeResponseHelpDocument(useResponses)
+		t.Run(map[bool]string{true: "responses", false: "selected schema"}[useResponses], func(t *testing.T) {
+			exerciseWriterFailures(t, func(w *failAfterWrites) error {
+				return renderResponseHelpText(w, document)
+			})
+		})
+	}
+
+	assert.Error(t, renderResponseHelpText(&bytes.Buffer{}, nil))
+	assert.Error(t, renderResponseHelpText(&bytes.Buffer{}, &machineHelpAPIResponseDocument{
+		Responses: json.RawMessage(`{broken`),
+	}))
+	assert.Error(t, renderResponseHelpText(&bytes.Buffer{}, &machineHelpAPIResponseDocument{
+		Matches:      []string{"Items"},
+		OutputSchema: &machineHelpOutputSchema{StatusCode: "200", Schema: json.RawMessage(`{broken`)},
+	}))
+	assert.Error(t, writeIndentedJSON(&bytes.Buffer{}, json.RawMessage(`{broken`)))
+}
+
+func TestResponseHelpSmallHelpers(t *testing.T) {
+	assert.Equal(t, []string{"one", "two", "three"}, mergeMachineHelpWarnings(
+		[]string{"", "one", "two"}, []string{"two", "three"},
+	))
+	assert.Empty(t, mergeMachineHelpWarnings())
+	assert.Equal(t, HelpResult{}, completeMachineHelpJSONResult(json.RawMessage(`[]`)))
+	assert.Equal(t, HelpResult{Shown: 2, Total: 2}, completeMachineHelpJSONResult(json.RawMessage(`{"a":1,"b":2}`)))
+
+	var output bytes.Buffer
+	require.NoError(t, renderMachineHelpResponseWarnings(&output, nil))
+	require.NoError(t, renderMachineHelpResponseQuery(&output, nil))
+	require.NoError(t, renderMachineHelpComponents(&output, nil))
+	require.NoError(t, renderMachineHelpComponents(&output, &machineHelpComponents{}))
+}

--- a/openapi/help_search_additional_test.go
+++ b/openapi/help_search_additional_test.go
@@ -1,0 +1,117 @@
+package openapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustResponseSchemaNode(t *testing.T, raw string) *responseSchemaNode {
+	t.Helper()
+	node, err := parseResponseSchemaNode(json.RawMessage(raw))
+	require.NoError(t, err)
+	return node
+}
+
+func TestResponseSchemaSearchStatePathOrderingAndDeduplication(t *testing.T) {
+	state := newResponseSchemaSearchState(&responseSchemaDocument{}, newHelpSearchText("item"))
+	state.addPath("", HelpSearchTextContains)
+	state.addPath("Items.Zeta", HelpSearchTextContains)
+	state.addPath("Items.Alpha", HelpSearchTextContains)
+	state.addPath("Items.Zeta", HelpSearchExactName)
+	state.addPath("Items.Beta", HelpSearchNameTokenPrefix)
+
+	assert.Equal(t, []string{"Items.Zeta", "Items.Beta", "Items.Alpha"}, state.sortedPaths())
+	assert.Len(t, state.sortedPathMatches(), 3)
+	assert.Nil(t, state.keepFor(nil))
+	require.NotNil(t, state.keepFor(mustResponseSchemaNode(t, `{"type":"string"}`)))
+}
+
+func TestResponseSchemaSearchStateMarksArraysCompositionsAndComponents(t *testing.T) {
+	componentA := mustResponseSchemaNode(t, `{"type":"object","properties":{"b":{"$ref":"#/components/schemas/B"}}}`)
+	componentB := mustResponseSchemaNode(t, `{"type":"object","properties":{"a":{"$ref":"#/components/schemas/A"}}}`)
+	document := &responseSchemaDocument{components: map[string]*responseSchemaNode{"A": componentA, "B": componentB}}
+	state := newResponseSchemaSearchState(document, newHelpSearchText("value"))
+
+	state.markFullComponent("")
+	state.markFullComponent("Missing")
+	state.markFullComponent("A")
+	assert.True(t, state.fullComponents["A"])
+	assert.True(t, state.fullComponents["B"])
+	state.markFullComponent("A")
+
+	composition := mustResponseSchemaNode(t, `{"allOf":[{"type":"string"}]}`)
+	state.markNodeSelf(composition, map[string]bool{})
+	assert.True(t, state.fullNodes[composition])
+
+	array := mustResponseSchemaNode(t, `{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"}}}}`)
+	state.markNodeSelf(array, map[string]bool{})
+	assert.True(t, state.keep[array].items)
+	assert.True(t, state.fullNodes[array.items])
+
+	ref := mustResponseSchemaNode(t, `{"$ref":"#/components/schemas/A"}`)
+	state.markNodeSelf(ref, map[string]bool{})
+	assert.NotNil(t, state.keep[componentA])
+	state.markNodeSelf(ref, map[string]bool{"A": true})
+	state.markNodeSelf(nil, nil)
+	state.markFullNode(nil)
+	state.markFullNode(componentA)
+}
+
+func TestResponseSchemaNodeParsingEdgeShapes(t *testing.T) {
+	primitive, err := parseResponseSchemaNode(json.RawMessage(`true`))
+	require.NoError(t, err)
+	assert.Empty(t, primitive.fields)
+
+	node, err := parseResponseSchemaNode(json.RawMessage(`{
+		"title":123,
+		"description":"useful",
+		"properties":[],
+		"items":"not-a-schema",
+		"allOf":{"type":"string"},
+		"oneOf":[{"type":"string"}],
+		"anyOf":[true]
+	}`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"useful"}, node.describes)
+	assert.Empty(t, node.properties)
+	assert.Nil(t, node.items)
+	assert.Len(t, node.compositions["oneOf"], 1)
+	assert.Len(t, node.compositions["anyOf"], 1)
+
+	_, err = parseResponseSchemaNode(json.RawMessage(`{broken`))
+	assert.ErrorContains(t, err, "invalid JSON")
+	fields, object, err := decodeOrderedRawObject(json.RawMessage(`[]`))
+	require.NoError(t, err)
+	assert.False(t, object)
+	assert.Nil(t, fields)
+
+	assert.False(t, responseSchemaNodeIsArray(nil))
+	assert.True(t, responseSchemaNodeIsArray(&responseSchemaNode{items: &responseSchemaNode{}}))
+	assert.Equal(t, []string{"A", "B"}, collectLocalResponseRefs(json.RawMessage(`{
+		"one":{"$ref":"#/components/schemas/B"},
+		"two":{"$ref":"#/components/schemas/A"},
+		"duplicate":{"$ref":"#/components/schemas/A"}
+	}`)))
+	assert.Nil(t, collectLocalResponseRefs(json.RawMessage(`{broken`)))
+}
+
+func TestMachineHelpLogicalLineCountingNestedShapes(t *testing.T) {
+	shape := &machineHelpShape{
+		Fields: []machineHelpParameter{{
+			Name:   "field",
+			Fields: []machineHelpParameter{{Name: "nested"}},
+		}},
+		Element: &machineHelpShape{Fields: []machineHelpParameter{{Name: "element"}}},
+		Value:   &machineHelpShape{Fields: []machineHelpParameter{{Name: "value"}}},
+	}
+	parameter := machineHelpParameter{
+		Fields:  []machineHelpParameter{{Name: "direct"}},
+		Element: shape,
+		Value:   shape,
+	}
+	assert.Equal(t, 10, machineHelpParameterLogicalLines(parameter))
+	assert.Equal(t, 0, machineHelpShapeLogicalLines(nil))
+}

--- a/openapi/legacy_constraint_validator_test.go
+++ b/openapi/legacy_constraint_validator_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
@@ -176,5 +178,158 @@ func TestValidateLegacyConstraintsFailOpenInvalidSchemaAndUnknownFlag(t *testing
 	assignLegacyUnknown(t, ctx, "Unknown", "anything")
 	if err := validateLegacyConstraints(ctx, api); err != nil {
 		t.Fatalf("invalid producer schema, raw body and unknown flags must fail open: %v", err)
+	}
+}
+
+func TestConstraintViolationErrorMessages(t *testing.T) {
+	tests := []struct {
+		violation  ConstraintViolationError
+		wantPhrase string
+	}{
+		{ConstraintViolationError{Flag: "Mode", Value: "bad", Constraint: "enum"}, "not allowed"},
+		{ConstraintViolationError{Flag: "Count", Value: "0", Constraint: "minimum", Minimum: "1"}, "greater than or equal to 1"},
+		{ConstraintViolationError{Flag: "Count", Value: "4", Constraint: "maximum", Maximum: "3"}, "less than or equal to 3"},
+		{ConstraintViolationError{Flag: "Name", Value: "a", Constraint: "minLength", MinLength: "2"}, "at least 2 characters"},
+		{ConstraintViolationError{Flag: "Name", Value: "abcd", Constraint: "maxLength", MaxLength: "3"}, "at most 3 characters"},
+		{ConstraintViolationError{Flag: "Name", Value: "A", Constraint: "pattern", Pattern: "^[a-z]+$"}, "does not match pattern"},
+		{ConstraintViolationError{Flag: "Value", Value: "x", Constraint: "future"}, "violates its schema constraint"},
+	}
+	for _, test := range tests {
+		if got := test.violation.Error(); !strings.Contains(got, test.wantPhrase) {
+			t.Errorf("Error() = %q, want phrase %q", got, test.wantPhrase)
+		}
+	}
+
+	docRequired := &LegacyDocRequiredError{Flags: []string{"--Name", "--RegionId"}}
+	if got := docRequired.Error(); got != "missing required parameter(s): --Name, --RegionId" {
+		t.Fatalf("LegacyDocRequiredError.Error() = %q", got)
+	}
+	docRequired.AIRecoveryEligible()
+}
+
+func TestValidateLegacyDocRequiredScalarAndRepeatLists(t *testing.T) {
+	api := &canonicalmeta.API{Parameters: []canonicalmeta.Parameter{
+		{Name: "name", RawName: "Name", Type: "string", Location: "query", DocRequired: true},
+		{Name: "tags", RawName: "Tag", Type: "array", Location: "query", ParamStyle: "repeatList", DocRequired: true,
+			Element: &canonicalmeta.TypeShape{Type: "object", Fields: []canonicalmeta.Field{
+				{Name: "key", RawName: "Key", Type: "string", DocRequired: true},
+				{Name: "value", RawName: "Value", Type: "string"},
+			}}},
+		{Name: "zones", RawName: "Zone", Type: "array", Location: "query", ParamStyle: "repeatList", DocRequired: true,
+			Element: &canonicalmeta.TypeShape{Type: "string"}},
+	}}
+
+	t.Run("all documentation-required paths are reported", func(t *testing.T) {
+		ctx := legacyConstraintContext(t, true, false)
+		err := validateLegacyDocRequired(ctx, api)
+		var missing *LegacyDocRequiredError
+		if !errors.As(err, &missing) {
+			t.Fatalf("error = %v, want LegacyDocRequiredError", err)
+		}
+		assertStringSliceEqual(t, []string{"--Name", "--Tag", "--Zone"}, missing.Flags)
+	})
+
+	t.Run("child paths are checked for every assigned instance", func(t *testing.T) {
+		ctx := legacyConstraintContext(t, true, false)
+		assignLegacyUnknown(t, ctx, "Name", "demo")
+		assignLegacyUnknown(t, ctx, "Tag.2.Value", "value")
+		assignLegacyUnknown(t, ctx, "Tag.10.Key", "key")
+		assignLegacyUnknown(t, ctx, "Zone.1", "cn-a")
+		err := validateLegacyDocRequired(ctx, api)
+		var missing *LegacyDocRequiredError
+		if !errors.As(err, &missing) {
+			t.Fatalf("error = %v, want LegacyDocRequiredError", err)
+		}
+		assertStringSliceEqual(t, []string{"--Tag.2.Key"}, missing.Flags)
+	})
+
+	t.Run("all assigned values pass", func(t *testing.T) {
+		ctx := legacyConstraintContext(t, true, false)
+		assignLegacyUnknown(t, ctx, "Name", "demo")
+		assignLegacyUnknown(t, ctx, "Tag.1.Key", "key")
+		assignLegacyUnknown(t, ctx, "Zone.1", "cn-a")
+		if err := validateLegacyDocRequired(ctx, api); err != nil {
+			t.Fatalf("validateLegacyDocRequired() = %v", err)
+		}
+	})
+
+	t.Run("assigned empty scalar stays missing", func(t *testing.T) {
+		ctx := legacyConstraintContext(t, true, false)
+		assignLegacyUnknown(t, ctx, "Name", "")
+		err := validateLegacyDocRequired(ctx, &canonicalmeta.API{Parameters: api.Parameters[:1]})
+		if err == nil || !strings.Contains(err.Error(), "--Name") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestValidateLegacyDocRequiredEarlyReturnsAndRawBody(t *testing.T) {
+	ctx := legacyConstraintContext(t, true, false)
+	api := &canonicalmeta.API{Parameters: []canonicalmeta.Parameter{{RawName: "Payload", Type: "string", Location: "body", DocRequired: true}}}
+	if err := validateLegacyDocRequired(nil, api); err != nil {
+		t.Fatalf("nil context: %v", err)
+	}
+	if err := validateLegacyDocRequired(ctx, nil); err != nil {
+		t.Fatalf("nil API: %v", err)
+	}
+	ctxWithoutUnknown := cli.NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+	if err := validateLegacyDocRequired(ctxWithoutUnknown, api); err != nil {
+		t.Fatalf("nil unknown flags: %v", err)
+	}
+	off := legacyConstraintContext(t, false, false)
+	if err := validateLegacyDocRequired(off, api); err != nil {
+		t.Fatalf("AI mode off: %v", err)
+	}
+
+	ctx.Flags().Add(NewBodyFlag())
+	BodyFlag(ctx.Flags()).SetAssigned(true)
+	BodyFlag(ctx.Flags()).SetValue(`{"payload":true}`)
+	if err := validateLegacyDocRequired(ctx, api); err != nil {
+		t.Fatalf("raw body should satisfy body documentation requirements: %v", err)
+	}
+}
+
+func TestLegacyRepeatListAndInvokerHelpers(t *testing.T) {
+	assigned := map[string]bool{
+		"Tag.10.Key": true, "Tag.2.Value": true, "Tag.2.Key": true,
+		"Tag.bad.Key": true, "Tag.": true, "Other.1": true,
+	}
+	assertStringSliceEqual(t, []string{"Tag.10", "Tag.2"}, legacyRepeatListInstances("Tag", assigned))
+	for _, value := range []string{"0", "1", "123"} {
+		if !isDecimalIndex(value) {
+			t.Errorf("isDecimalIndex(%q) = false", value)
+		}
+	}
+	for _, value := range []string{"", "-1", "1a", "a"} {
+		if isDecimalIndex(value) {
+			t.Errorf("isDecimalIndex(%q) = true", value)
+		}
+	}
+
+	api := &canonicalmeta.API{Name: "Demo"}
+	if got := legacyAPIForInvoker(&RpcInvoker{api: api}); got != api {
+		t.Fatalf("RPC API = %#v", got)
+	}
+	if got := legacyAPIForInvoker(&RestfulInvoker{api: api}); got != api {
+		t.Fatalf("REST API = %#v", got)
+	}
+	if got := legacyAPIForInvoker(nil); got != nil {
+		t.Fatalf("unknown invoker API = %#v", got)
+	}
+
+	for _, name := range []string{"body", "BODY", "body-file", "BODY-FILE"} {
+		if !isRawBodyFlag(name) {
+			t.Errorf("isRawBodyFlag(%q) = false", name)
+		}
+	}
+	if isRawBodyFlag("payload") {
+		t.Fatal("payload must not be treated as raw body")
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, want, got []string) {
+	t.Helper()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("got %v, want %v", got, want)
 	}
 }

--- a/openapi/machine_help_additional_test.go
+++ b/openapi/machine_help_additional_test.go
@@ -1,0 +1,188 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMachineHelpErrorContractAndUnavailableCause(t *testing.T) {
+	err := newMachineHelpError("UNKNOWN", "unknown target", []string{"aliyun", "demo"}, []string{"inspect help"})
+	assert.Equal(t, "unknown target", err.Error())
+	assert.Nil(t, err.Unwrap())
+	assert.Equal(t, 2, err.ExitCode())
+
+	var output bytes.Buffer
+	require.NoError(t, err.RenderError(&output))
+	assert.JSONEq(t, `{"schemaVersion":"v1","error":{"code":"UNKNOWN","message":"unknown target","target":["aliyun","demo"],"suggestions":["inspect help"]}}`, output.String())
+
+	cause := errors.New("repository failed")
+	unavailable := newMachineHelpUnavailableError([]string{"aliyun"}, cause)
+	assert.ErrorIs(t, unavailable, cause)
+	assert.Contains(t, unavailable.Error(), "repository failed")
+	assert.Error(t, unavailable.RenderError(alwaysFailWriter{}))
+}
+
+func TestMachineHelpLocalizedTextUnmarshalForms(t *testing.T) {
+	previous := i18n.GetLanguage()
+	t.Cleanup(func() { i18n.SetLanguage(previous) })
+
+	i18n.SetLanguage("en")
+	var english machineHelpLocalizedText
+	require.NoError(t, json.Unmarshal([]byte(`"English"`), &english))
+	assert.Equal(t, "English", english.EN)
+
+	i18n.SetLanguage("zh")
+	var chinese machineHelpLocalizedText
+	require.NoError(t, json.Unmarshal([]byte(`"中文"`), &chinese))
+	assert.Equal(t, "中文", chinese.ZH)
+
+	var bilingual machineHelpLocalizedText
+	require.NoError(t, json.Unmarshal([]byte(`{"en":"English","zh":"中文"}`), &bilingual))
+	assert.Equal(t, machineHelpLocalizedText{EN: "English", ZH: "中文"}, bilingual)
+	assert.Error(t, json.Unmarshal([]byte(`42`), &bilingual))
+}
+
+func TestPrintMachineHelpRejectsInvalidRequests(t *testing.T) {
+	c, ctx, _, _ := newCanonicalHelpTestContext(t)
+	assertMachineHelpCode := func(err error, code string) {
+		t.Helper()
+		var structured *machineHelpError
+		require.ErrorAs(t, err, &structured)
+		assert.Equal(t, code, structured.document.Error.Code)
+	}
+
+	assertMachineHelpCode(c.printMachineHelp(ctx, nil, "yaml", helpOptions{}), "INVALID_FORMAT")
+	assertMachineHelpCode(c.printMachineHelp(ctx, []string{"demo", "CreateReport", "extra"}, "json", helpOptions{}), "INVALID_TARGET")
+
+	missing := &Commando{library: &Library{}}
+	assertMachineHelpCode(missing.printMachineHelp(ctx, nil, "json", helpOptions{}), "MACHINE_HELP_UNAVAILABLE")
+}
+
+func TestPrintMachineHelpAllTargetLevels(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		options helpOptions
+		kind    string
+	}{
+		{"root", nil, helpOptions{}, "root"},
+		{"product", []string{"demo"}, helpOptions{}, "product"},
+		{"request", []string{"demo", "CreateReport"}, helpOptions{}, "api"},
+		{"response", []string{"demo", "CreateReport"}, helpOptions{Section: helpSectionResponse, Search: "report-id"}, "api"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, ctx, stdout, _ := newCanonicalHelpTestContext(t)
+			require.NoError(t, c.printMachineHelp(ctx, test.args, "json", test.options))
+			assert.Contains(t, stdout.String(), `"kind": "`+test.kind+`"`)
+		})
+	}
+}
+
+func TestMachineHelpJSONPreparationAndPruning(t *testing.T) {
+	var nilDocument *machineHelpRootDocument
+	nilDocument.prepareJSONGroups()
+
+	document := &machineHelpRootDocument{Commands: []machineHelpCommandSummary{
+		{Name: "configure"},
+		{Group: "utils", Name: "utils tool", Aliases: []string{"tool"}},
+		{Group: "extension", Name: "completion"},
+	}}
+	document.prepareJSONGroups()
+	require.Len(t, document.CoreCommands, 1)
+	require.Len(t, document.Utilities, 1)
+	require.Len(t, document.Extensions, 1)
+	assert.Nil(t, document.Utilities[0].Aliases)
+
+	searchDocument := &machineHelpRootDocument{Query: "demo", Commands: []machineHelpCommandSummary{{Name: "configure"}}}
+	searchDocument.prepareJSONGroups()
+	assert.Nil(t, searchDocument.CoreCommands)
+
+	cleaned, keep := pruneMachineHelpEmpty(map[string]any{
+		"empty": "", "false": false, "zero": json.Number("0"),
+		"array": []any{"", nil, map[string]any{"value": "kept"}},
+	})
+	assert.True(t, keep)
+	encoded, err := json.Marshal(cleaned)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"false":false`)
+	assert.NotContains(t, string(encoded), `"empty"`)
+	assert.Contains(t, string(encoded), `"array":["",{"value":"kept"}]`)
+
+	_, keep = pruneMachineHelpEmpty([]any{})
+	assert.False(t, keep)
+	_, keep = pruneMachineHelpEmpty(map[string]any{})
+	assert.False(t, keep)
+	_, keep = pruneMachineHelpEmpty(nil)
+	assert.False(t, keep)
+}
+
+func TestPrintMachineHelpEncodingFailureIsStructured(t *testing.T) {
+	c, ctx, _, stderr := newCanonicalHelpTestContext(t)
+	ctx = cli.NewCommandContext(alwaysFailWriter{}, stderr)
+	ctx.EnterCommand(testMachineHelpRootCommand())
+	err := c.printMachineHelp(ctx, nil, "json", helpOptions{})
+	var structured *machineHelpError
+	require.ErrorAs(t, err, &structured)
+	assert.Equal(t, "MACHINE_HELP_UNAVAILABLE", structured.document.Error.Code)
+	assert.True(t, strings.Contains(structured.Error(), "write failed"))
+}
+
+func TestMachineHelpOperationAndVersionSelectionEdgeCases(t *testing.T) {
+	assert.Equal(t, machineHelpOperation{}, projectMachineHelpOperation(nil))
+	legacy := projectMachineHelpOperation(&canonicalmeta.API{Method: "GET", Protocol: "HTTPS", PathPattern: "/things"})
+	assert.Equal(t, "GET", legacy.Method)
+	assert.Equal(t, "HTTPS", legacy.Protocol)
+	assert.Equal(t, "/things", legacy.URL)
+
+	full := projectMachineHelpOperation(&canonicalmeta.API{Operation: &canonicalmeta.Operation{
+		Action: "CreateThing", APIStyle: "ROA", APIVersion: "v1", Method: "POST",
+		Protocol: "HTTPS", URL: "/things", IsSSE: true, ReqBodyType: "json",
+		ContentType: "application/json", HasWildcardPath: true,
+	}})
+	assert.Equal(t, "CreateThing", full.Action)
+	assert.True(t, full.IsSSE)
+	assert.True(t, full.HasWildcardPath)
+
+	product := canonicalmeta.ProductEntry{Code: "demo", PluginDefaultVersion: "v2", Version: "v1"}
+	version, err := selectProductVersion(product, []string{"v1", "v2"}, "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", version)
+	_, err = selectProductVersion(product, []string{"v1", "v2"}, "v3")
+	assert.Error(t, err)
+	version, err = selectProductVersion(product, []string{"v1", "v2"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", version)
+	product.PluginDefaultVersion = ""
+	version, err = selectProductVersion(product, []string{"v1"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", version)
+	product.Version = ""
+	version, err = selectProductVersion(product, []string{"v0"}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "v0", version)
+	_, err = selectProductVersion(product, nil, "")
+	assert.Error(t, err)
+}
+
+func TestUnknownRootOptionCoversLongShortAndKnownFlags(t *testing.T) {
+	assert.Empty(t, unknownRootOption(nil, []string{"--bad"}))
+	ctx := cli.NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+	root := &cli.Command{Name: "aliyun"}
+	root.Flags().Add(&cli.Flag{Name: "known", Shorthand: 'k'})
+	ctx.EnterCommand(root)
+
+	assert.Empty(t, unknownRootOption(ctx, []string{"--", "value", "--known", "-k"}))
+	assert.Equal(t, "--help=all", unknownRootOption(ctx, []string{"--help=all"}))
+	assert.Equal(t, "--missing", unknownRootOption(ctx, []string{"--missing=value"}))
+	assert.Equal(t, "-x", unknownRootOption(ctx, []string{"-x"}))
+}

--- a/openapi/plugin_help_repo_test.go
+++ b/openapi/plugin_help_repo_test.go
@@ -15,6 +15,7 @@
 package openapi
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -127,15 +128,176 @@ func TestPluginAwareHelpRepositoryRoutesByOwnership(t *testing.T) {
 	assert.NotContains(t, err.Error(), "stub")
 }
 
+func TestPluginAwareHelpRepositoryCatalogMergeAndErrors(t *testing.T) {
+	originalEntries := metaPluginCatalogEntries
+	t.Cleanup(func() { metaPluginCatalogEntries = originalEntries })
+	metaPluginCatalogEntries = func() []canonicalmeta.ProductEntry {
+		return []canonicalmeta.ProductEntry{
+			{Code: "ECS", Distribution: "meta", PluginDefaultVersion: "v2"},
+			{Code: "new", Distribution: "meta", PluginDefaultVersion: "v1"},
+		}
+	}
+
+	t.Run("nil baseline is preserved", func(t *testing.T) {
+		assert.Nil(t, newPluginAwareHelpRepository(nil))
+	})
+
+	t.Run("catalog entries replace case-insensitively and append", func(t *testing.T) {
+		baseline := &stubMachineHelpRepository{products: &canonicalmeta.ProductsIndex{
+			Products: []canonicalmeta.ProductEntry{{Code: "ecs", Distribution: "go"}},
+		}}
+		repo := newPluginAwareHelpRepository(baseline)
+		catalog, err := repo.GetProducts()
+		require.NoError(t, err)
+		require.Len(t, catalog.Products, 2)
+		assert.Equal(t, "ECS", catalog.Products[0].Code)
+		assert.Equal(t, "meta", catalog.Products[0].Distribution)
+		assert.Equal(t, "new", catalog.Products[1].Code)
+	})
+
+	t.Run("nil catalog is initialized", func(t *testing.T) {
+		repo := newPluginAwareHelpRepository(&stubMachineHelpRepository{returnNilProducts: true})
+		catalog, err := repo.GetProducts()
+		require.NoError(t, err)
+		require.Len(t, catalog.Products, 2)
+	})
+
+	t.Run("baseline errors are returned", func(t *testing.T) {
+		want := errors.New("products unavailable")
+		repo := newPluginAwareHelpRepository(&stubMachineHelpRepository{productsErr: want})
+		catalog, err := repo.GetProducts()
+		assert.Nil(t, catalog)
+		assert.ErrorIs(t, err, want)
+	})
+}
+
+func TestPluginAwareHelpRepositoryRoutesVersionIndexToBaseline(t *testing.T) {
+	originalOwns := metaPluginOwnsProduct
+	t.Cleanup(func() { metaPluginOwnsProduct = originalOwns })
+	metaPluginOwnsProduct = func(string) bool { return false }
+
+	baseline := &stubMachineHelpRepository{versionIndex: &canonicalmeta.VersionIndex{Version: "v1"}}
+	repo := newPluginAwareHelpRepository(baseline)
+	index, err := repo.GetVersionIndex("ecs", "v1")
+	require.NoError(t, err)
+	assert.Same(t, baseline.versionIndex, index)
+}
+
+func TestEngineMetadataConvertersCoverCompositeShapes(t *testing.T) {
+	parameter := meta.Parameter{
+		Name: "payload", RawName: "Payload", Type: meta.TypeObject, Position: meta.PosBody,
+		Required: true, DocRequired: true, ParamStyle: "json", IsWildcard: true,
+		Enum: []string{"one"}, Minimum: "1", Maximum: "9", MinLength: "2", MaxLength: "8",
+		Pattern: "^[a-z]+$", Example: "example", Options: []string{"--payload"},
+		Description: meta.Description{ZH: "中文", EN: "English"},
+		Fields: []meta.Parameter{
+			{Name: "name", RawName: "Name", Type: meta.TypeString, Required: true, DocRequired: true,
+				Enum: []string{"a"}, Minimum: "1", Maximum: "2", MinLength: "3", MaxLength: "4",
+				Pattern: "^a$", Example: "a", Description: meta.Description{ZH: "名称", EN: "name"}},
+			{Name: "items", RawName: "Items", Type: meta.TypeArray, ItemType: &meta.Parameter{
+				Type: meta.TypeObject, Fields: []meta.Parameter{{Name: "enabled", RawName: "Enabled", Type: meta.TypeBoolean}},
+			}},
+			{Name: "labels", RawName: "Labels", Type: meta.TypeMap, ValueType: &meta.Parameter{
+				Type: meta.TypeArray, ItemType: &meta.Parameter{Type: meta.TypeLong},
+			}},
+		},
+	}
+
+	converted := engineParameterToCanonical(&parameter)
+	assert.Equal(t, "object", converted.Type)
+	assert.Equal(t, "body", converted.Location)
+	assert.True(t, converted.Required)
+	assert.True(t, converted.DocRequired)
+	assert.True(t, converted.IsWildcard)
+	assert.Equal(t, "json", converted.ParamStyle)
+	assert.Equal(t, []string{"one"}, converted.Enum)
+	assert.Equal(t, "中文", converted.HelpZh)
+	assert.Equal(t, "English", converted.HelpEn)
+	require.Len(t, converted.Fields, 3)
+	assert.Equal(t, "string", converted.Fields[0].Type)
+	assert.Equal(t, []string{"a"}, converted.Fields[0].Enum)
+	assert.Equal(t, "名称", converted.Fields[0].HelpZh)
+	require.NotNil(t, converted.Fields[1].Element)
+	assert.Equal(t, "object", converted.Fields[1].Element.Type)
+	require.Len(t, converted.Fields[1].Element.Fields, 1)
+	assert.Equal(t, "bool", converted.Fields[1].Element.Fields[0].Type)
+	require.NotNil(t, converted.Fields[2].Value)
+	assert.Equal(t, "array", converted.Fields[2].Value.Type)
+	require.NotNil(t, converted.Fields[2].Value.Element)
+	assert.Equal(t, "long", converted.Fields[2].Value.Element.Type)
+
+	array := engineParameterToCanonical(&meta.Parameter{Type: meta.TypeArray, ItemType: &meta.Parameter{
+		Type: meta.TypeString, Enum: []string{"x"}, Minimum: "1", Maximum: "3",
+		MinLength: "1", MaxLength: "2", Pattern: "x+",
+	}})
+	require.NotNil(t, array.Element)
+	assert.Equal(t, []string{"x"}, array.Element.Enum)
+	assert.Equal(t, "x+", array.Element.Pattern)
+
+	mapParameter := engineParameterToCanonical(&meta.Parameter{Type: meta.TypeMap, ValueType: &meta.Parameter{Type: meta.TypeFloat}})
+	require.NotNil(t, mapParameter.Value)
+	assert.Equal(t, "float", mapParameter.Value.Type)
+
+	assert.Equal(t, canonicalmeta.Parameter{}, engineParameterToCanonical(nil))
+	assert.Nil(t, engineParametersToCanonical(nil))
+	assert.Nil(t, engineFieldsToCanonical(nil))
+	assert.Nil(t, engineShapeToCanonical(nil))
+}
+
+func TestEngineTypePositionAndStyleMappings(t *testing.T) {
+	types := []struct {
+		in   meta.DataType
+		want string
+	}{
+		{meta.TypeString, "string"}, {meta.TypeInteger, "int"}, {meta.TypeLong, "long"},
+		{meta.TypeFloat, "float"}, {meta.TypeBoolean, "bool"}, {meta.TypeObject, "object"},
+		{meta.TypeArray, "array"}, {meta.TypeMap, "map"}, {meta.TypeAny, "any"},
+		{meta.DataType("future"), "any"},
+	}
+	for _, test := range types {
+		assert.Equal(t, test.want, engineTypeName(test.in), string(test.in))
+	}
+
+	positions := []struct {
+		in   meta.Position
+		want string
+	}{
+		{meta.PosBody, "body"}, {meta.PosHeader, "header"}, {meta.PosPath, "path"},
+		{meta.PosFormData, "formData"}, {meta.PosHost, "host"}, {meta.PosQuery, "query"},
+		{meta.Position("future"), "query"},
+	}
+	for _, test := range positions {
+		assert.Equal(t, test.want, enginePositionName(test.in), string(test.in))
+	}
+	assert.Equal(t, "ROA", engineAPIStyle(meta.StyleROA))
+	assert.Equal(t, "RPC", engineAPIStyle(meta.StyleRPC))
+}
+
 type stubMachineHelpRepository struct {
-	apis map[string]*canonicalmeta.API
+	apis              map[string]*canonicalmeta.API
+	products          *canonicalmeta.ProductsIndex
+	productsErr       error
+	returnNilProducts bool
+	versionIndex      *canonicalmeta.VersionIndex
 }
 
 func (s *stubMachineHelpRepository) GetProducts() (*canonicalmeta.ProductsIndex, error) {
+	if s.productsErr != nil {
+		return nil, s.productsErr
+	}
+	if s.returnNilProducts {
+		return nil, nil
+	}
+	if s.products != nil {
+		return s.products, nil
+	}
 	return &canonicalmeta.ProductsIndex{Products: []canonicalmeta.ProductEntry{{Code: "baseline"}}}, nil
 }
 
 func (s *stubMachineHelpRepository) GetVersionIndex(product, version string) (*canonicalmeta.VersionIndex, error) {
+	if s.versionIndex != nil {
+		return s.versionIndex, nil
+	}
 	return &canonicalmeta.VersionIndex{Version: version}, nil
 }
 

--- a/openapi/runtimehost/runtimehost_test.go
+++ b/openapi/runtimehost/runtimehost_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aliyun/aliyun-openapi-runtime/meta"
 	"github.com/aliyun/aliyun-openapi-runtime/runtime"
 	"github.com/aliyun/aliyun-openapi-runtime/schema"
+	"github.com/aliyun/aliyun-openapi-runtime/source"
 )
 
 // captureExecutor records the ExecContext it receives instead of
@@ -304,6 +305,87 @@ func TestHelpLanguagePrefersCommandFlag(t *testing.T) {
 	if got := helpLanguage(ctx); got != "zh" {
 		t.Fatalf("help language = %q, want zh", got)
 	}
+}
+
+func TestRuntimeHostPublicRoutingWrappers(t *testing.T) {
+	t.Setenv(sysconfig.EnvPluginsDir, filepath.Join(t.TempDir(), "plugins"))
+	if got := userPluginsDir(); got != os.Getenv(sysconfig.EnvPluginsDir) {
+		t.Fatalf("userPluginsDir() = %q", got)
+	}
+
+	if HasProduct("") {
+		t.Fatal("empty product must not resolve")
+	}
+	if !HasProduct("ecs") {
+		t.Fatal("embedded ECS product did not resolve")
+	}
+	if ProductCommands("") != nil {
+		t.Fatal("empty product commands must be nil")
+	}
+	commands := ProductCommands("ecs")
+	if len(commands) == 0 || !containsString(commands, "describe-regions") {
+		t.Fatalf("ECS commands = %v", commands)
+	}
+	if MetaPluginProvenance("") != nil {
+		t.Fatal("empty product provenance must be nil")
+	}
+	if provenance := MetaPluginProvenance("ecs"); provenance == nil || provenance.Kind != source.KindBaseline {
+		t.Fatalf("ECS provenance = %#v", provenance)
+	}
+	if MetaPluginProvenance("definitely-missing") != nil {
+		t.Fatal("unknown product provenance must be nil")
+	}
+
+	stdout := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(stdout, new(bytes.Buffer))
+	if err := ProductHelp(ctx, "ecs"); err != nil {
+		t.Fatalf("ProductHelp(): %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Available APIs:") {
+		t.Fatalf("product help output = %s", stdout.String())
+	}
+
+	if handled, err := TryDispatch(ctx, []string{"ecs"}); handled || err != nil {
+		t.Fatalf("short TryDispatch = %v, %v", handled, err)
+	}
+	if handled, err := TryDispatch(ctx, []string{"ecs", "definitely-missing"}); handled || err != nil {
+		t.Fatalf("unknown TryDispatch = %v, %v", handled, err)
+	}
+	stdout.Reset()
+	handled, err := TryDispatch(ctx, []string{"ecs", "describe-regions", "--cli-dry-run"})
+	if err != nil || !handled {
+		t.Fatalf("resolvable TryDispatch = %v, %v", handled, err)
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("dry-run dispatch produced no output")
+	}
+}
+
+func TestRuntimeHostProfileLoadFailuresAreBestEffort(t *testing.T) {
+	ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+	ctx.Flags().Add(config.NewConfigurePathFlag())
+	config.ConfigurePathFlag(ctx.Flags()).SetAssigned(true)
+	config.ConfigurePathFlag(ctx.Flags()).SetValue(filepath.Join(t.TempDir(), "missing", "config.json"))
+	host := &cliHost{ctx: ctx}
+	if region := host.Region(); region != "" {
+		t.Fatalf("Region() = %q", region)
+	}
+	settings := host.Settings()
+	if settings.CLIVersion == "" {
+		t.Fatal("Settings() must retain CLI version on profile load failure")
+	}
+	if _, err := host.Credential(); err == nil {
+		t.Fatal("Credential() must return profile load error")
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 // TestHostSettingsAppliedToExecContext verifies the engine copies the

--- a/openapi/utility_help_test.go
+++ b/openapi/utility_help_test.go
@@ -1,0 +1,154 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func utilityHelpRoot() *cli.Command {
+	root := &cli.Command{Name: "aliyun"}
+	utils := &cli.Command{
+		Name: "utils", Short: i18n.T("Local utilities", "本地工具"),
+		Usage: "utils <command>", Sample: "aliyun utils doctor",
+	}
+	utils.AddSubCommand(&cli.Command{Name: "doctor", Short: i18n.T("Diagnose the CLI", "诊断 CLI")})
+	utils.AddSubCommand(&cli.Command{Name: "hidden", Hidden: true, Short: i18n.T("Hidden", "隐藏")})
+	utils.Flags().Add(&cli.Flag{
+		Name: "verbose", Shorthand: 'v', Aliases: []string{"debug"}, Category: "output",
+		Short: i18n.T("Show diagnostic details", "显示诊断详情"),
+	})
+	utils.Flags().Add(&cli.Flag{Name: "internal", Hidden: true, Short: i18n.T("Internal", "内部")})
+	root.AddSubCommand(utils)
+	return root
+}
+
+func TestBuildUtilityHelpDocumentValidatesTargetsAndProjectsVisibleEntries(t *testing.T) {
+	root := utilityHelpRoot()
+	for _, target := range [][]string{nil, {"plugin"}, {"utils", "doctor", "extra"}} {
+		if _, err := buildUtilityHelpDocument(root, target); err == nil {
+			t.Fatalf("target %#v unexpectedly succeeded", target)
+		}
+	}
+	if _, err := buildUtilityHelpDocument(nil, []string{"utils"}); err == nil {
+		t.Fatal("nil root unexpectedly succeeded")
+	}
+	if _, err := buildUtilityHelpDocument(&cli.Command{Name: "aliyun"}, []string{"utils"}); err == nil {
+		t.Fatal("missing utils command unexpectedly succeeded")
+	}
+	if _, err := buildUtilityHelpDocument(root, []string{"utils", "missing"}); err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("unknown utility error = %v", err)
+	}
+
+	document, err := buildUtilityHelpDocument(root, []string{"utils"})
+	require.NoError(t, err)
+	assert.Equal(t, "utility", document.Kind)
+	assert.Equal(t, []string{"aliyun", "utils"}, document.Target.Path)
+	assert.Equal(t, "utils <command>", document.Usage)
+	assert.Equal(t, "aliyun utils doctor", document.Sample)
+	require.Len(t, document.Commands, 1)
+	assert.Equal(t, "doctor", document.Commands[0].Name)
+	require.Len(t, document.Flags, 1)
+	assert.Equal(t, "--verbose", document.Flags[0].Name)
+	assert.Equal(t, "-v", document.Flags[0].Shorthand)
+	assert.Equal(t, []string{"debug"}, document.Flags[0].Aliases)
+	assert.Equal(t, HelpResult{Shown: 2, Total: 2}, document.Result)
+
+	child, err := buildUtilityHelpDocument(root, []string{"utils", "doctor"})
+	require.NoError(t, err)
+	assert.Equal(t, "utils doctor", child.Name)
+	assert.Equal(t, []string{"aliyun", "utils", "doctor"}, child.Target.Path)
+}
+
+func TestUtilityHelpSearchProjectsCommandsFlagsAndNoMatches(t *testing.T) {
+	build := func() *machineHelpUtilityDocument {
+		document, err := buildUtilityHelpDocument(utilityHelpRoot(), []string{"utils"})
+		require.NoError(t, err)
+		return document
+	}
+
+	command := build()
+	applyUtilityHelpOptions(command, cli.HelpOptions{Operation: cli.HelpOperationSearch, SearchQuery: "diagnose"})
+	assert.Equal(t, "diagnose", command.Query)
+	assert.Len(t, command.Commands, 1)
+	assert.Empty(t, command.Flags)
+	assert.Equal(t, HelpResult{Shown: 1, Total: 1}, command.Result)
+
+	flag := build()
+	applyUtilityHelpOptions(flag, cli.HelpOptions{Operation: cli.HelpOperationSearch, SearchQuery: "debug"})
+	assert.Empty(t, flag.Commands)
+	require.Len(t, flag.Flags, 1)
+	assert.Equal(t, "--verbose", flag.Flags[0].Name)
+
+	missing := build()
+	applyUtilityHelpOptions(missing, cli.HelpOptions{Operation: cli.HelpOperationSearch, SearchQuery: "absent"})
+	assert.Empty(t, missing.Commands)
+	assert.Empty(t, missing.Flags)
+	assert.Equal(t, HelpResult{}, missing.Result)
+
+	unchanged := build()
+	applyUtilityHelpOptions(unchanged, cli.HelpOptions{})
+	assert.Len(t, unchanged.Commands, 1)
+	applyUtilityHelpOptions(nil, cli.HelpOptions{Operation: cli.HelpOperationSearch, SearchQuery: "doctor"})
+}
+
+func TestRenderUtilityHelpTextAndJSON(t *testing.T) {
+	previousLanguage := i18n.GetLanguage()
+	i18n.SetLanguage("en")
+	t.Cleanup(func() { i18n.SetLanguage(previousLanguage) })
+
+	root := utilityHelpRoot()
+	commando, _, _ := newTestCommando()
+
+	t.Run("text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		ctx := cli.NewCommandContext(&stdout, &stderr)
+		ctx.EnterCommand(root)
+		require.NoError(t, commando.renderUtilityHelp(ctx, []string{"utils"}, cli.HelpOptions{}, false))
+		for _, want := range []string{
+			"Local utilities", "Usage:", "aliyun utils <command>", "Commands:", "doctor",
+			"Flags:", "--verbose, -v", "Example:", "aliyun utils doctor", cli.AIModeEnableCommand,
+		} {
+			assert.Contains(t, stdout.String(), want)
+		}
+		assert.Empty(t, stderr.String())
+	})
+
+	t.Run("search miss text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		ctx := cli.NewCommandContext(&stdout, &stderr)
+		ctx.EnterCommand(root)
+		require.NoError(t, commando.renderUtilityHelp(ctx, []string{"utils"}, cli.HelpOptions{
+			Operation: cli.HelpOperationSearch, SearchQuery: "absent",
+		}, false))
+		assert.Contains(t, stdout.String(), `No Help entries matched --help-search "absent".`)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		ctx := cli.NewCommandContext(&stdout, &stderr)
+		ctx.EnterCommand(root)
+		require.NoError(t, commando.renderUtilityHelp(ctx, []string{"utils"}, cli.HelpOptions{
+			Output: cli.HelpOutputJSON,
+		}, false))
+		var document map[string]any
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &document))
+		assert.Equal(t, "utility", document["kind"])
+		assert.Contains(t, document, "aiModeHint")
+	})
+
+	t.Run("AI JSON", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		ctx := cli.NewCommandContext(&stdout, &stderr)
+		ctx.EnterCommand(root)
+		require.NoError(t, commando.renderUtilityHelp(ctx, []string{"utils"}, cli.HelpOptions{}, true))
+		assert.Equal(t, 1, strings.Count(stdout.String(), "\n"))
+		assert.NotContains(t, stdout.String(), "aiModeHint")
+	})
+}

--- a/sysconfig/safety/check_test.go
+++ b/sysconfig/safety/check_test.go
@@ -1,0 +1,108 @@
+package safety
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/cli"
+)
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+
+func TestPromptConfirmAnswers(t *testing.T) {
+	original := stdinReader
+	t.Cleanup(func() { stdinReader = original })
+
+	for _, test := range []struct {
+		name   string
+		input  string
+		answer bool
+	}{
+		{"short yes", "y\n", true},
+		{"mixed case yes", "  YeS  \n", true},
+		{"no", "no\n", false},
+		{"empty", "\n", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stdinReader = strings.NewReader(test.input)
+			var output bytes.Buffer
+			if got := PromptConfirm(&output, "continue? "); got != test.answer {
+				t.Fatalf("PromptConfirm() = %v, want %v", got, test.answer)
+			}
+			if output.String() != "continue? " {
+				t.Fatalf("prompt output = %q", output.String())
+			}
+		})
+	}
+
+	stdinReader = failingReader{}
+	if PromptConfirm(&bytes.Buffer{}, "prompt") {
+		t.Fatal("read errors must reject confirmation")
+	}
+}
+
+func TestCheckAndConfirmActions(t *testing.T) {
+	original := stdinReader
+	t.Cleanup(func() { stdinReader = original })
+	ctx := cli.NewCommandContext(&bytes.Buffer{}, &bytes.Buffer{})
+	cmd := CommandInfo{Product: "ecs", ApiOrMethod: "DeleteInstance"}
+
+	if err := CheckAndConfirm(ctx, nil, cmd, false); err != nil {
+		t.Fatalf("default policy returned error: %v", err)
+	}
+	if err := CheckAndConfirm(ctx, &Policy{Enabled: true}, cmd, false); err != nil {
+		t.Fatalf("allow policy returned error: %v", err)
+	}
+
+	deny := &Policy{Enabled: true, Rules: []Rule{{Pattern: "ecs:Delete*", Action: ActionDeny}}}
+	if err := CheckAndConfirm(ctx, deny, cmd, false); err == nil || !strings.Contains(err.Error(), "DeleteInstance") || !strings.Contains(err.Error(), "ecs:Delete*") {
+		t.Fatalf("deny error = %v", err)
+	}
+
+	confirm := &Policy{Enabled: true, Rules: []Rule{{Pattern: "ecs:Delete*", Action: ActionConfirm}}}
+	if err := CheckAndConfirm(ctx, confirm, cmd, true); err != nil {
+		t.Fatalf("skip-confirm should approve operation: %v", err)
+	}
+	stdinReader = strings.NewReader("no\n")
+	err := CheckAndConfirm(ctx, confirm, cmd, false)
+	if err == nil {
+		t.Fatal("unapproved confirmation unexpectedly succeeded")
+	}
+	if IsInteractive() {
+		if !strings.Contains(err.Error(), "cancel") && !strings.Contains(err.Error(), "取消") {
+			t.Fatalf("interactive confirmation error = %v", err)
+		}
+	} else if !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("non-interactive confirmation error = %v", err)
+	}
+}
+
+func TestDisplayCommand(t *testing.T) {
+	if got := displayCommand(CommandInfo{ApiOrMethod: "DescribeInstances"}); got != "DescribeInstances" {
+		t.Fatalf("RPC display command = %q", got)
+	}
+	if got := displayCommand(CommandInfo{ApiOrMethod: "delete", Path: "/instances/i-1"}); got != "DELETE /instances/i-1" {
+		t.Fatalf("REST display command = %q", got)
+	}
+	_ = IsInteractive()
+}
+
+func TestInferOperationFromAPIName(t *testing.T) {
+	tests := map[string]string{
+		"DeleteInstance": "delete",
+		"UpdateInstance": "update",
+		"ModifyInstance": "update",
+		"CreateInstance": "create",
+		"AddTags":        "create",
+		"DescribeThings": "",
+	}
+	for apiName, expected := range tests {
+		if actual := InferOperationFromApiName(apiName); actual != expected {
+			t.Fatalf("InferOperationFromApiName(%q) = %q, want %q", apiName, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add unit coverage across Canonical readers and projections, CLI/plugin/config/meta helpers, Help/search/error rendering, runtime host, export, upgrade, safety, and main paths
- cover Runtime Help product, API, parameter, response, localization, version resolution, malformed metadata, and fallback behavior
- change tests and test fixtures only; production code remains untouched

## Coverage
- combined aliyun-cli and aliyun-openapi-runtime statement coverage: **90.02%** (17687/19647)
- aliyun-openapi-runtime/help: **86.5%**

## Verification
- `make test`
- `make test-runtime`
- `make test-release`
- `make check-fmt`
