### PR TITLE
test: make CI fixtures portable on Windows

### DIFF
--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -3480,6 +3480,7 @@ func TestValidateAndResolvePackageTypeBranches(t *testing.T) {
 func TestExpandPluginSourcePathHomeAndEmpty(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	path, err := expandPluginSourcePath("~/package.tgz")
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(home, "package.tgz"), path)

--- a/cli/upgrade/upgrade_test.go
+++ b/cli/upgrade/upgrade_test.go
@@ -225,7 +225,7 @@ func TestDoUpgrade_DirectWhenNotBrew(t *testing.T) {
 
 func TestUpgradeViaDirect_FullFlow(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
-	archive := createTarGzInMemory(t, "aliyun", binaryContent)
+	_, binaryName, archive := createUpgradeArchiveInMemory(t, "99.0.0", binaryContent)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
@@ -256,7 +256,7 @@ func TestUpgradeViaDirect_FullFlow(t *testing.T) {
 	ossVersionURL = server.URL + "/version"
 	stdin = strings.NewReader("y\n")
 
-	targetBinary := filepath.Join(t.TempDir(), "aliyun")
+	targetBinary := filepath.Join(t.TempDir(), binaryName)
 	os.WriteFile(targetBinary, []byte("old"), 0755)
 	resolveExecPathFunc = func() (string, error) { return targetBinary, nil }
 
@@ -374,7 +374,7 @@ func TestConfirmUpgrade_StdinEmpty(t *testing.T) {
 
 func TestDownloadAndExtract_Success(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho upgraded\n")
-	archiveBuf := createTarGzInMemory(t, "aliyun", binaryContent)
+	assetName, _, archiveBuf := createUpgradeArchiveInMemory(t, "3.4.0", binaryContent)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", archiveBuf.Len()))
@@ -387,7 +387,7 @@ func TestDownloadAndExtract_Success(t *testing.T) {
 	defer func() { httpClient = origClient }()
 
 	var out bytes.Buffer
-	binaryPath, cleanup, err := downloadAndExtract(&out, server.URL+"/aliyun-cli-linux-3.4.0-amd64.tgz", "aliyun-cli-linux-3.4.0-amd64.tgz")
+	binaryPath, cleanup, err := downloadAndExtract(&out, server.URL+"/"+assetName, assetName)
 	assert.NoError(t, err)
 	assert.NotNil(t, cleanup)
 	defer cleanup()
@@ -910,6 +910,37 @@ func createTarGzInMemory(t *testing.T, fileName string, content []byte) *bytes.B
 	tw.Close()
 	gw.Close()
 	return &buf
+}
+
+func createZipInMemory(t *testing.T, fileName string, content []byte) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func createUpgradeArchiveInMemory(t *testing.T, version string, content []byte) (assetName, binaryName string, archive *bytes.Buffer) {
+	t.Helper()
+	assetName, err := buildAssetName(version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryName = "aliyun"
+	if runtime.GOOS == "windows" {
+		binaryName = "aliyun.exe"
+		return assetName, binaryName, createZipInMemory(t, binaryName, content)
+	}
+	return assetName, binaryName, createTarGzInMemory(t, binaryName, content)
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -21,19 +21,18 @@ func TestDumpFilesCopiesEmbeddedTree(t *testing.T) {
 	output := t.TempDir()
 	dumpFiles(testDumpFS, "./testdata/dump", output)
 
-	root, err := os.ReadFile(filepath.Join(output, "testdata", "dump", "root.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(root) != "root fixture\n" {
-		t.Fatalf("root fixture = %q", root)
-	}
-	child, err := os.ReadFile(filepath.Join(output, "testdata", "dump", "nested", "child.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(child) != "child fixture\n" {
-		t.Fatalf("child fixture = %q", child)
+	for _, name := range []string{"testdata/dump/root.txt", "testdata/dump/nested/child.txt"} {
+		want, err := testDumpFS.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(filepath.Join(output, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s = %q, want embedded bytes %q", name, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- fix the Windows unit-test failures exposed by #1411 without changing production behavior or skipping platform coverage
- make home-directory expansion tests set both Unix and Windows home environment variables
- build upgrade test archives in the platform's real release format instead of skipping non-Linux coverage
- compare dumped fixture bytes with their embedded source so Git checkout line-ending policy cannot break the copy test

## Test plan

- `make check-fmt`
- `make test`
- `make check-runtime`
- `make test-release`
- cross-compile `cli/plugin`, `cli/upgrade`, and `main` test binaries with `GOOS=windows GOARCH=amd64`
