### PR TITLE
fix: refine help search and AI error recovery

### DIFF
--- a/aliyun-openapi-runtime/engine/help_additional_test.go
+++ b/aliyun-openapi-runtime/engine/help_additional_test.go
@@ -47,6 +47,20 @@ func TestValidateReservedHelpPreservesSectionAllConflictForRecovery(t *testing.T
 	}
 }
 
+func TestHelpOptionsFromReservedMakesSearchImplicitlyUnlimited(t *testing.T) {
+	search := helpOptionsFromReserved(Request{}, argparser.Reserved{HelpSearch: "instance"})
+	searchAll := helpOptionsFromReserved(Request{}, argparser.Reserved{HelpSearch: "instance", HelpAll: true})
+	if !search.All || !reflect.DeepEqual(search, searchAll) {
+		t.Fatalf("search options = %#v, explicit search-all = %#v", search, searchAll)
+	}
+	if helpOptionsFromReserved(Request{}, argparser.Reserved{}).All {
+		t.Fatal("ordinary Help unexpectedly became all mode")
+	}
+	if !helpOptionsFromReserved(Request{}, argparser.Reserved{HelpAll: true}).All {
+		t.Fatal("independent --help-all stopped selecting all mode")
+	}
+}
+
 func TestHelpEntryValidation(t *testing.T) {
 	product := &meta.Product{}
 	index := &meta.APIIndex{}

--- a/aliyun-openapi-runtime/engine/help_v2.go
+++ b/aliyun-openapi-runtime/engine/help_v2.go
@@ -104,7 +104,7 @@ func requestHelpOptions(req Request, options HelpOptions) HelpOptions {
 func helpOptionsFromReserved(req Request, reserved argparser.Reserved) HelpOptions {
 	options := HelpOptions{
 		Search:   reserved.HelpSearch,
-		All:      reserved.HelpAll,
+		All:      reserved.HelpAll || reserved.HelpSearch != "",
 		AIMode:   req.AIMode,
 		Language: req.Lang,
 	}

--- a/aliyun-openapi-runtime/help/render.go
+++ b/aliyun-openapi-runtime/help/render.go
@@ -730,6 +730,11 @@ func renderResult(w io.Writer, result Result, language string, nextValues ...*Ne
 			fmt.Sprintf(label(language, "Showing %d of %d entries; use all mode for the complete document.", "显示 %d/%d 项；使用 all 模式查看完整文档。"), result.Shown, result.Total)); err != nil {
 			return err
 		}
+	} else if len(nextValues) > 0 && nextValues[0] != nil && nextValues[0].operation == "search" {
+		if _, err := fmt.Fprintf(w, "\n%s\n",
+			fmt.Sprintf(label(language, "Showing %d of %d entries.", "显示 %d/%d 项。"), result.Shown, result.Total)); err != nil {
+			return err
+		}
 	}
 	if len(nextValues) == 0 {
 		return nil

--- a/aliyun-openapi-runtime/help/render_text_contract_test.go
+++ b/aliyun-openapi-runtime/help/render_text_contract_test.go
@@ -350,3 +350,27 @@ func TestTextRendererOptionalBranchesAndErrors(t *testing.T) {
 		t.Fatal("writePrettyJSON accepted malformed JSON")
 	}
 }
+
+func TestRenderSearchResultKeepsCompleteStatisticsWithoutSearchAllHint(t *testing.T) {
+	var output bytes.Buffer
+	next := &Next{Search: "aliyun demo --help-search <keyword>", operation: "search"}
+	if err := renderResult(&output, Result{Shown: 17, Total: 17}, "en", next); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Showing 17 of 17 entries.", "Try another keyword:"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("search output missing %q:\n%s", want, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "Show all matches") || strings.Contains(output.String(), "--help-all") {
+		t.Fatalf("search output retained search-all hint:\n%s", output.String())
+	}
+
+	output.Reset()
+	if err := renderResult(&output, Result{Shown: 17, Total: 17}, "en"); err != nil {
+		t.Fatal(err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("ordinary complete Help output changed: %q", output.String())
+	}
+}

--- a/cli/context.go
+++ b/cli/context.go
@@ -203,7 +203,11 @@ func (ctx *Context) CheckFlags() error {
 			if len(f.ExcludeWith) > 0 {
 				for _, es := range f.ExcludeWith {
 					if _, ok := ctx.flags.GetValue(es); ok {
-						return fmt.Errorf("flag --%s is exclusive with --%s", f.Name, es)
+						cause := fmt.Errorf("flag --%s is exclusive with --%s", f.Name, es)
+						return &InvalidOptionCombinationError{
+							Options: []string{"--" + f.Name, "--" + es},
+							Err:     cause,
+						}
 					}
 				}
 			}

--- a/cli/context_test.go
+++ b/cli/context_test.go
@@ -129,7 +129,9 @@ func TestCheckFlags(t *testing.T) {
 	ctx.flags.flags[0].Fields[0].Required = false
 	ctx.flags.flags[0].ExcludeWith = []string{"MrX"}
 	ctx.flags.flags[0].value = "M"
-	assert.EqualError(t, ctx.CheckFlags(), "flag --MrX is exclusive with --MrX")
+	conflict := ctx.CheckFlags()
+	assert.EqualError(t, conflict, "flag --MrX is exclusive with --MrX")
+	assert.True(t, IsAIRecoveryEligible(conflict))
 }
 
 func TestDetectFlag(t *testing.T) {

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -27,6 +27,29 @@ type StructuredError interface {
 	ExitCode() int
 }
 
+// InvalidOptionCombinationError identifies flags that cannot be used together
+// while preserving the existing human-readable error text.
+type InvalidOptionCombinationError struct {
+	Options []string
+	Err     error
+}
+
+func (e *InvalidOptionCombinationError) Error() string {
+	if e == nil || e.Err == nil {
+		return "invalid option combination"
+	}
+	return e.Err.Error()
+}
+
+func (e *InvalidOptionCombinationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (*InvalidOptionCombinationError) AIRecoveryEligible() {}
+
 // If command.Execute return Noticeable error, print i18n Notice under error information
 type ErrorWithTip interface {
 	GetTip(lang string) string

--- a/cli/help_options.go
+++ b/cli/help_options.go
@@ -41,8 +41,8 @@ type HelpOptions struct {
 	Requested   bool
 	Operation   HelpOperation
 	SearchQuery string
-	// SearchAll reports the --help-all modifier combined with --help-search:
-	// the keyword still filters, but the result cap is removed.
+	// SearchAll reports that a search is uncapped. Every public
+	// --help-search is uncapped; an explicit --help-all remains accepted.
 	SearchAll       bool
 	Output          HelpOutput
 	Section         HelpSection
@@ -173,6 +173,9 @@ func ParseHelpOptions(args []string) (HelpOptions, error) {
 				return HelpOptions{}, &HelpOptionError{Code: HelpOptionInvalidSection, Option: "--" + CLISectionFlagName, Value: value}
 			}
 		}
+	}
+	if opts.Operation == HelpOperationSearch {
+		opts.SearchAll = true
 	}
 	return opts, nil
 }

--- a/cli/help_options_test.go
+++ b/cli/help_options_test.go
@@ -61,6 +61,7 @@ func TestParseHelpOptionsRecognizesFinalSurface(t *testing.T) {
 				Requested:       true,
 				Operation:       HelpOperationSearch,
 				SearchQuery:     "instance id",
+				SearchAll:       true,
 				Output:          HelpOutputText,
 				Section:         HelpSectionResponse,
 				SectionExplicit: true,
@@ -92,6 +93,14 @@ func TestParseHelpOptionsComposesSearchWithAll(t *testing.T) {
 			assert.True(t, opts.Requested)
 		})
 	}
+}
+
+func TestParseHelpOptionsSearchIsEquivalentToSearchAll(t *testing.T) {
+	search, err := ParseHelpOptions([]string{"--help-search", "instance"})
+	require.NoError(t, err)
+	searchAll, err := ParseHelpOptions([]string{"--help-search", "instance", "--help-all"})
+	require.NoError(t, err)
+	assert.Equal(t, searchAll, search)
 }
 
 func TestParseHelpOptionsRejectsInvalidCombinations(t *testing.T) {

--- a/config/configure.go
+++ b/config/configure.go
@@ -126,8 +126,8 @@ func NewConfigureCommand() *cli.Command {
 	c := &cli.Command{
 		Name: "configure",
 		Short: i18n.T(
-			"configure credential and settings",
-			"配置身份认证和其他信息"),
+			"configure credential, AI Mode and settings",
+			"配置身份认证、AI 模式和其他信息"),
 		Usage:  "configure --mode {AK|RamRoleArn|EcsRamRole|OIDC|External|CredentialsURI|ChainableRamRoleArn|CloudSSO|OAuth|BearerToken} --profile <profileName> [--config-path <configPath>]",
 		Sample: "aliyun configure --mode OAuth  (Recommended)",
 		Run: func(ctx *cli.Context, args []string) error {

--- a/config/configure_test.go
+++ b/config/configure_test.go
@@ -57,8 +57,8 @@ func TestNewConfigureCommand(t *testing.T) {
 	excmd := &cli.Command{
 		Name: "configure",
 		Short: i18n.T(
-			"configure credential and settings",
-			"配置身份认证和其他信息"),
+			"configure credential, AI Mode and settings",
+			"配置身份认证、AI 模式和其他信息"),
 		Usage: "configure --mode <AuthenticateMode> --profile <profileName>",
 	}
 	configureGet := NewConfigureGetCommand()
@@ -123,6 +123,8 @@ func TestNewConfigureCommand(t *testing.T) {
 
 	//testcase
 	cmd := NewConfigureCommand()
+	assert.Equal(t, "configure credential, AI Mode and settings", cmd.Short.Get("en"))
+	assert.Equal(t, "配置身份认证、AI 模式和其他信息", cmd.Short.Get("zh"))
 	excmd.Run = cmd.Run
 	assert.ObjectsAreEqualValues(excmd, cmd)
 

--- a/openapi/agent_error.go
+++ b/openapi/agent_error.go
@@ -84,17 +84,17 @@ func normalizeAgentErrorWithSearch(err error, args []string, validate RecoverySe
 
 	var missing *runtime.MissingRequiredError
 	if errors.As(err, &missing) {
-		return missingRequiredAgentError(err, missingRequiredAgentMessage(missing), missing.Flags, context, validate)
+		return missingRequiredAgentError(err, missingRequiredAgentMessage(missing), context)
 	}
 
 	var legacyDocRequired *LegacyDocRequiredError
 	if errors.As(err, &legacyDocRequired) {
-		return missingRequiredAgentError(err, legacyDocRequired.Error(), legacyDocRequired.Flags, context, validate)
+		return missingRequiredAgentError(err, legacyDocRequired.Error(), context)
 	}
 
 	var legacyMissingRequired *LegacyMissingRequiredError
 	if errors.As(err, &legacyMissingRequired) {
-		return missingRequiredAgentError(err, legacyMissingRequired.Error(), legacyMissingRequiredFlagNames(legacyMissingRequired), context, validate)
+		return missingRequiredAgentError(err, legacyMissingRequired.Error(), context)
 	}
 
 	var runtimeConstraint *runtime.ConstraintViolationError
@@ -167,7 +167,7 @@ func normalizeAgentErrorWithSearch(err error, args []string, validate RecoverySe
 
 	var invalidCommand *cli.InvalidCommandError
 	if errors.As(err, &invalidCommand) {
-		return unknownCommandAgentError(err, invalidCommand.Error(), invalidCommand.GetSuggestions(), invalidCommand.Name, context, validate)
+		return unknownCommandAgentError(err, invalidCommand.Error(), invalidCommand.GetSuggestions(), invalidCommand.Name, context)
 	}
 
 	var invalidArgument *argparser.InvalidArgumentError
@@ -185,6 +185,11 @@ func normalizeAgentErrorWithSearch(err error, args []string, validate RecoverySe
 	var invalidHelpOptions *cli.HelpOptionError
 	if errors.As(err, &invalidHelpOptions) {
 		return helpOptionAgentError(err, invalidHelpOptions)
+	}
+
+	var hostInvalidOptions *cli.InvalidOptionCombinationError
+	if errors.As(err, &hostInvalidOptions) {
+		return optionCombinationAgentError(err, hostInvalidOptions.Error(), hostInvalidOptions.Options, context)
 	}
 
 	var invalidOptions *engine.InvalidOptionCombinationError
@@ -211,13 +216,13 @@ func normalizeAgentErrorWithSearch(err error, args []string, validate RecoverySe
 
 	var invalidBodyFile *engine.InvalidBodyFileError
 	if errors.As(err, &invalidBodyFile) {
-		return fixedParameterHelpAgentError(err, "unable to read --body-file", "fix_body_file", "body-file",
+		return fixedParameterHelpAgentError(err, bodyFileAgentMessage(invalidBodyFile.Path, invalidBodyFile.Err), "fix_body_file", "body-file",
 			"Check that --body-file points to a readable file.", context)
 	}
 
 	var legacyInvalidBodyFile *InvalidBodyFileError
 	if errors.As(err, &legacyInvalidBodyFile) {
-		return fixedParameterHelpAgentError(err, "unable to read --body-file", "fix_body_file", "body-file",
+		return fixedParameterHelpAgentError(err, bodyFileAgentMessage(legacyInvalidBodyFile.Path, legacyInvalidBodyFile.Err), "fix_body_file", "body-file",
 			"Check that --body-file points to a readable file.", context)
 	}
 
@@ -619,24 +624,12 @@ func unknownProductAgentError(cause error, message string, suggestions []string,
 }
 
 func unknownCommandAgentError(cause error, message string, suggestions []string, invalidName string,
-	context recoveryContext, validate RecoverySearchValidator) error {
-	suggestions = stableStrings(suggestions)
-	recovery := cli.AgentErrorRecovery{
-		Action:  "inspect_parent_help",
+	context recoveryContext) error {
+	return newLocalAgentError(cause, message, suggestions, cli.AgentErrorRecovery{
+		Action:  "inspect_command_help",
 		Command: context.parentHelpCommand(invalidName),
 		Hint:    "Inspect commands under the current parent.",
-	}
-	seeds := append(append([]string(nil), suggestions...), invalidName)
-	for _, candidate := range orderedSearchCandidates(seeds...) {
-		request := context.parentSearchRequest(invalidName, candidate)
-		if validate != nil && validate(request) {
-			recovery.Action = "search_command"
-			recovery.Command = context.parentSearchCommand(invalidName, candidate)
-			recovery.Hint = fmt.Sprintf("Search commands under the current parent related to %s.", candidate)
-			break
-		}
-	}
-	return newLocalAgentError(cause, message, suggestions, recovery)
+	})
 }
 
 func unknownHostFlagAgentError(cause error, message string, suggestions []string, invalidName, helpCommand string,
@@ -739,41 +732,12 @@ func missingRequiredAgentMessage(err *runtime.MissingRequiredError) string {
 	return "missing required parameter(s): " + strings.Join(err.Flags, ", ")
 }
 
-// legacyMissingRequiredFlagNames extracts the --Flag tokens from the wrapped
-// legacy error text, which formats them one per line.
-func legacyMissingRequiredFlagNames(err *LegacyMissingRequiredError) []string {
-	matches := missingRequiredFlagPattern.FindAllStringSubmatch(err.Error(), -1)
-	names := make([]string, 0, len(matches))
-	for _, match := range matches {
-		if match[1] != "" {
-			names = append(names, "--"+match[1])
-		}
-	}
-	return names
-}
-
-var missingRequiredFlagPattern = regexp.MustCompile(`--([A-Za-z0-9_.-]+)`)
-
-// missingRequiredAgentError upgrades the recovery command from the full
-// request Help to a targeted parameter search whenever the validator confirms
-// the missing flag would be found — the search returns the parameter's schema
-// alone instead of the complete request document.
-func missingRequiredAgentError(cause error, message string, flags []string,
-	context recoveryContext, validate RecoverySearchValidator) error {
-	recovery := cli.AgentErrorRecovery{
+func missingRequiredAgentError(cause error, message string, context recoveryContext) error {
+	return newLocalAgentError(cause, message, nil, cli.AgentErrorRecovery{
 		Action:  "inspect_request_help",
-		Command: context.requestHelpCommand(),
-		Hint:    "Inspect the complete request help and provide every required parameter.",
-	}
-	for _, keyword := range parameterSearchKeywordCandidates(context.style, flags...) {
-		if validate != nil && validate(context.searchRequest("request", context.api, keyword)) {
-			recovery.Action = "search_parameter"
-			recovery.Command = context.actionSearchCommand(keyword)
-			recovery.Hint = fmt.Sprintf("Search request parameters related to %s and provide the required value.", keyword)
-			break
-		}
-	}
-	return newLocalAgentError(cause, message, nil, recovery)
+		Command: context.actionHelpCommand(),
+		Hint:    "Inspect the API help for request parameters and provide every required value.",
+	})
 }
 
 func runtimeConstraintFacts(e *runtime.ConstraintViolationError) constraintFacts {
@@ -891,9 +855,27 @@ func optionCombinationAgentError(cause error, message string, options []string, 
 		hint = fmt.Sprintf("Remove one of the conflicting options: %s.", strings.Join(options, ", "))
 	}
 	return newLocalAgentError(cause, message, nil, cli.AgentErrorRecovery{
-		Action: "fix_option_combination",
-		Hint:   hint,
+		Action:  "fix_option_combination",
+		Command: context.actionHelpCommand(),
+		Hint:    hint,
 	})
+}
+
+func bodyFileAgentMessage(path string, cause error) string {
+	message := explicitLocalErrorText(cause, "unable to read --body-file")
+	path = strings.TrimSpace(path)
+	if path == "" || strings.Contains(message, path) {
+		return message
+	}
+	const prefix = "--body-file:"
+	if strings.HasPrefix(message, prefix) {
+		detail := strings.TrimSpace(strings.TrimPrefix(message, prefix))
+		if detail == "" {
+			return prefix + " " + path
+		}
+		return prefix + " " + path + ": " + detail
+	}
+	return prefix + " " + path + ": " + message
 }
 
 func containsString(values []string, target string) bool {
@@ -1129,30 +1111,6 @@ func (c recoveryContext) parentHelpCommand(invalidName string) string {
 		return "aliyun --help"
 	}
 	return "aliyun " + strings.Join(parts, " ") + " --help"
-}
-
-func (c recoveryContext) parentSearchCommand(invalidName, keyword string) string {
-	if !safeCommandToken(keyword) {
-		return c.parentHelpCommand(invalidName)
-	}
-	parts := c.parentCommandParts(invalidName)
-	if len(parts) == 0 {
-		return "aliyun --help-search " + keyword
-	}
-	return "aliyun " + strings.Join(parts, " ") + " --help-search " + keyword
-}
-
-func (c recoveryContext) parentSearchRequest(invalidName, keyword string) RecoverySearchRequest {
-	request := RecoverySearchRequest{Keyword: keyword}
-	parts := c.parentCommandParts(invalidName)
-	if len(parts) > 0 {
-		request.Product = parts[0]
-	}
-	if len(parts) > 1 {
-		request.API = parts[1]
-		request.Style = commandStyle(parts[1])
-	}
-	return request
 }
 
 func (c recoveryContext) parentCommandParts(invalidName string) []string {

--- a/openapi/agent_error_additional_test.go
+++ b/openapi/agent_error_additional_test.go
@@ -123,7 +123,6 @@ func TestRecoveryContextFallbackAndSuffixCommands(t *testing.T) {
 	assert.Equal(t, context.actionHelpCommand(), context.actionSearchCommand("bad token"))
 	parent := newRecoveryContext([]string{"ecs", "DescribeInstances"})
 	assert.Equal(t, "aliyun ecs --help", parent.parentHelpCommand("DescribeInstances"))
-	assert.Equal(t, "aliyun ecs --help", parent.parentSearchCommand("DescribeInstances", "bad token"))
 
 	assert.Equal(t, "aliyun --help", suffixHelpCommand("not-aliyun command"))
 	assert.Equal(t, "aliyun --help-search profile", suffixSearchCommand("not-aliyun command", "profile"))

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -170,25 +170,25 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		cause := cli.NewInvalidCommandError("profiel", ctx)
 
 		envelope := requireAgentEnvelope(t, cause, []string{"configure", "profiel"}, nil)
-		assert.Equal(t, "inspect_parent_help", envelope.Recovery.Action)
+		assert.Equal(t, "inspect_command_help", envelope.Recovery.Action)
 		assert.Equal(t, "aliyun configure --help", envelope.Recovery.Command)
 		assert.Equal(t, "Inspect commands under the current parent.", envelope.Recovery.Hint)
 	})
 
-	t.Run("unknown CLI subcommand publishes only validated current-level search", func(t *testing.T) {
+	t.Run("unknown CLI subcommand keeps suggestions but never changes help into search", func(t *testing.T) {
 		ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
 		parent := &cli.Command{Name: "configure"}
 		parent.AddSubCommand(&cli.Command{Name: "profile"})
 		ctx.EnterCommand(parent)
 		cause := cli.NewInvalidCommandError("profiel", ctx)
 
-		envelope := requireAgentEnvelope(t, cause, []string{"configure", "profiel"}, func(request RecoverySearchRequest) bool {
-			assert.Equal(t, RecoverySearchRequest{Product: "configure", Keyword: "profile"}, request)
-			return true
+		envelope := requireAgentEnvelope(t, cause, []string{"configure", "profiel"}, func(RecoverySearchRequest) bool {
+			t.Fatal("UNKNOWN_COMMAND recovery must not validate a search command")
+			return false
 		})
-		assert.Equal(t, "search_command", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun configure --help-search profile", envelope.Recovery.Command)
-		assert.Equal(t, "Search commands under the current parent related to profile.", envelope.Recovery.Hint)
+		assert.Equal(t, []string{"profile"}, envelope.DidYouMean)
+		assert.Equal(t, "inspect_command_help", envelope.Recovery.Action)
+		assert.Equal(t, "aliyun configure --help", envelope.Recovery.Command)
 	})
 
 	t.Run("unknown host flag publishes only validated current-level search", func(t *testing.T) {
@@ -254,8 +254,8 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 
 		assert.Empty(t, envelope.DidYouMean)
 		assert.Equal(t, "inspect_request_help", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun help ecs run-instances --cli-section request", envelope.Recovery.Command)
-		assert.Equal(t, "Inspect the complete request help and provide every required parameter.", envelope.Recovery.Hint)
+		assert.Equal(t, "aliyun ecs run-instances --help", envelope.Recovery.Command)
+		assert.Equal(t, "Inspect the API help for request parameters and provide every required value.", envelope.Recovery.Hint)
 	})
 
 	t.Run("missing required parameter hides PascalCase wire paths", func(t *testing.T) {
@@ -277,8 +277,8 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		assert.Empty(t, envelope.DidYouMean)
 		assert.Equal(t, "required parameters not assigned: --InstanceId", envelope.Message)
 		assert.Equal(t, "inspect_request_help", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun help ecs DescribeInstanceAttribute --cli-section request", envelope.Recovery.Command)
-		assert.Equal(t, "Inspect the complete request help and provide every required parameter.", envelope.Recovery.Hint)
+		assert.Equal(t, "aliyun ecs DescribeInstanceAttribute --help", envelope.Recovery.Command)
+		assert.Equal(t, "Inspect the API help for request parameters and provide every required value.", envelope.Recovery.Hint)
 	})
 
 	t.Run("invalid argument preserves typed parameter context", func(t *testing.T) {
@@ -323,8 +323,27 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 
 		assert.Equal(t, text, envelope.Message)
 		assert.Equal(t, "fix_option_combination", envelope.Recovery.Action)
-		assert.Empty(t, envelope.Recovery.Command)
+		assert.Equal(t, "aliyun ecs describe-instances --help", envelope.Recovery.Command)
+		var agentErr *cli.AgentError
+		require.ErrorAs(t, normalizeAgentError(cause, []string{"ecs", "describe-instances"}), &agentErr)
+		assert.Equal(t, 2, agentErr.ExitCode())
 		assert.Equal(t, "Remove one of the conflicting options: --cli-dry-run-json, --pager.", envelope.Recovery.Hint)
+	})
+
+	t.Run("host CheckFlags option conflict is normalized", func(t *testing.T) {
+		command := &cli.Command{Name: "aliyun"}
+		command.Flags().Add(&cli.Flag{Name: "cli-dry-run-json", AssignedMode: cli.AssignedNone, ExcludeWith: []string{"pager"}})
+		command.Flags().Add(&cli.Flag{Name: "pager", AssignedMode: cli.AssignedNone})
+		ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+		ctx.EnterCommand(command)
+		ctx.Flags().Get("cli-dry-run-json").SetAssigned(true)
+		ctx.Flags().Get("pager").SetAssigned(true)
+
+		cause := ctx.CheckFlags()
+		envelope := requireAgentEnvelope(t, cause, []string{"ecs", "DescribeInstances", "--cli-dry-run-json", "--pager"}, nil)
+		assert.Equal(t, "flag --cli-dry-run-json is exclusive with --pager", envelope.Message)
+		assert.Equal(t, "fix_option_combination", envelope.Recovery.Action)
+		assert.Equal(t, "aliyun ecs DescribeInstances --help", envelope.Recovery.Command)
 	})
 
 	t.Run("section all conflict recovers with same section search", func(t *testing.T) {
@@ -371,13 +390,15 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		})
 
 		assert.Equal(t, "fix_body_file", envelope.Recovery.Action)
+		assert.Equal(t, "--body-file: /private/secret/request.json: permission denied", envelope.Message)
 		assert.Equal(t, "aliyun ecs run-instances --body-file --help", envelope.Recovery.Command)
 		assert.NotContains(t, envelope.Recovery.Command, "/private/secret")
+		assert.NotContains(t, envelope.Recovery.Hint, "/private/secret")
 		assert.Equal(t, "Check that --body-file points to a readable file.", envelope.Recovery.Hint)
 	})
 }
 
-func TestNormalizeAgentErrorRedactsHeaderValuesAndBodyFilePaths(t *testing.T) {
+func TestNormalizeAgentErrorRedactsHeaderValuesButKeepsBodyFilePathsOnlyInMessage(t *testing.T) {
 	tests := []struct {
 		name      string
 		cause     error
@@ -398,25 +419,31 @@ func TestNormalizeAgentErrorRedactsHeaderValuesAndBodyFilePaths(t *testing.T) {
 		},
 		{
 			name:      "runtime body file",
-			cause:     &engine.InvalidBodyFileError{Err: errors.New("open /private/customer/request.json: permission denied")},
+			cause:     &engine.InvalidBodyFileError{Path: "/private/customer/request.json", Err: errors.New("--body-file: open /private/customer/request.json: permission denied")},
 			sensitive: "/private/customer/request.json",
-			message:   "unable to read --body-file",
+			message:   "--body-file: open /private/customer/request.json: permission denied",
 		},
 		{
 			name:      "legacy body file",
-			cause:     &InvalidBodyFileError{Err: errors.New("open /tmp/customer-body.json: no such file")},
+			cause:     &InvalidBodyFileError{Path: "/tmp/customer-body.json", Err: errors.New("--body-file: open /tmp/customer-body.json: no such file")},
 			sensitive: "/tmp/customer-body.json",
-			message:   "unable to read --body-file",
+			message:   "--body-file: open /tmp/customer-body.json: no such file",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			envelope := requireAgentEnvelope(t, tt.cause, []string{"ecs", "DescribeInstances"}, nil)
-			encoded, err := json.Marshal(envelope)
-			require.NoError(t, err)
 			assert.Equal(t, tt.message, envelope.Message)
-			assert.NotContains(t, string(encoded), tt.sensitive)
+			if strings.Contains(tt.name, "body file") {
+				assert.Contains(t, envelope.Message, tt.sensitive)
+				assert.NotContains(t, envelope.Recovery.Command, tt.sensitive)
+				assert.NotContains(t, envelope.Recovery.Hint, tt.sensitive)
+			} else {
+				encoded, err := json.Marshal(envelope)
+				require.NoError(t, err)
+				assert.NotContains(t, string(encoded), tt.sensitive)
+			}
 		})
 	}
 }
@@ -578,13 +605,13 @@ func TestNormalizeAgentErrorSearchValidationFallbackAndCommandStyle(t *testing.T
 		assert.Equal(t, "2014-05-26", request.Version)
 	})
 
-	t.Run("required recovery keeps prefix Section form and explicit API version", func(t *testing.T) {
+	t.Run("required recovery keeps API help and explicit API version", func(t *testing.T) {
 		cause := &runtime.MissingRequiredError{Flags: []string{"--instance-id"}}
 		envelope := requireAgentEnvelope(t, cause,
 			[]string{"ecs", "describe-instance-attribute", "--api-version=2014-05-26"}, nil)
 
 		assert.Equal(t, "inspect_request_help", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun help ecs describe-instance-attribute --api-version 2014-05-26 --cli-section request", envelope.Recovery.Command)
+		assert.Equal(t, "aliyun ecs describe-instance-attribute --api-version 2014-05-26 --help", envelope.Recovery.Command)
 	})
 }
 
@@ -1230,7 +1257,7 @@ func TestBuiltInSubcommandErrorUsesRootAIModeAdapter(t *testing.T) {
 	var envelope cli.AgentErrorEnvelope
 	require.NoError(t, json.Unmarshal(stderr.Bytes(), &envelope))
 	assert.Equal(t, []string{"profile"}, envelope.DidYouMean)
-	assert.Equal(t, "inspect_parent_help", envelope.Recovery.Action)
+	assert.Equal(t, "inspect_command_help", envelope.Recovery.Action)
 	assert.Equal(t, "aliyun configure --help", envelope.Recovery.Command)
 	assert.Equal(t, "\x1b[0;31mtext\x1b[0m", cli.Colorized(cli.Red, "text"), "AI no-color override must be restored after Execute")
 }
@@ -1352,30 +1379,28 @@ func TestTypedLocalErrorsPreserveHumanText(t *testing.T) {
 	}
 }
 
-func TestNormalizeAgentErrorMissingRequiredUpgradesToTargetedSearch(t *testing.T) {
-	t.Run("runtime missing required validates into parameter search", func(t *testing.T) {
+func TestNormalizeAgentErrorMissingRequiredAlwaysUsesAPIHelp(t *testing.T) {
+	t.Run("runtime missing required ignores parameter search", func(t *testing.T) {
 		cause := &engine.UsageError{Code: "MISSING_REQUIRED_PARAMETER", Err: &runtime.MissingRequiredError{
 			Flags: []string{"--image-id", "--instance-type"},
 		}}
-		envelope := requireAgentEnvelope(t, cause, []string{"ecs", "run-instances"}, func(request RecoverySearchRequest) bool {
-			assert.Equal(t, "request", request.Section)
-			assert.Equal(t, "run-instances", request.API)
-			return request.Keyword == "image-id"
+		envelope := requireAgentEnvelope(t, cause, []string{"ecs", "run-instances"}, func(RecoverySearchRequest) bool {
+			t.Fatal("missing required recovery must not validate a single-parameter search")
+			return false
 		})
 
-		assert.Equal(t, "search_parameter", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun ecs run-instances --help-search image-id", envelope.Recovery.Command)
+		assert.Empty(t, envelope.DidYouMean)
+		assert.Equal(t, "inspect_request_help", envelope.Recovery.Action)
+		assert.Equal(t, "aliyun ecs run-instances --help", envelope.Recovery.Command)
 	})
 
-	t.Run("legacy doc required validates into parameter search", func(t *testing.T) {
+	t.Run("legacy doc required uses API help", func(t *testing.T) {
 		cause := &LegacyDocRequiredError{Flags: []string{"--RegionId"}}
-		envelope := requireAgentEnvelope(t, cause, []string{"ecs", "DescribeInstances"}, func(request RecoverySearchRequest) bool {
-			return request.Keyword == "RegionId"
-		})
+		envelope := requireAgentEnvelope(t, cause, []string{"ecs", "DescribeInstances"}, nil)
 
 		assert.Equal(t, "missing required parameter(s): --RegionId", envelope.Message)
-		assert.Equal(t, "search_parameter", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun ecs DescribeInstances --help-search RegionId", envelope.Recovery.Command)
+		assert.Equal(t, "inspect_request_help", envelope.Recovery.Action)
+		assert.Equal(t, "aliyun ecs DescribeInstances --help", envelope.Recovery.Command)
 	})
 
 	t.Run("validator rejection falls back to complete request help", func(t *testing.T) {
@@ -1385,7 +1410,7 @@ func TestNormalizeAgentErrorMissingRequiredUpgradesToTargetedSearch(t *testing.T
 		})
 
 		assert.Equal(t, "inspect_request_help", envelope.Recovery.Action)
-		assert.Equal(t, "aliyun help ecs DescribeInstances --cli-section request", envelope.Recovery.Command)
+		assert.Equal(t, "aliyun ecs DescribeInstances --help", envelope.Recovery.Command)
 	})
 }
 

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -48,6 +48,57 @@ func requireAgentEnvelope(t *testing.T, err error, args []string, validator Reco
 	return agentErr.Envelope()
 }
 
+func TestKebabProfileCaseMismatchSuggestsLowercaseProfile(t *testing.T) {
+	args := []string{"ecs", "describe-instances", "--Profile", "default"}
+	newCause := func() error {
+		unknown := &argparser.UnknownFlagError{Flag: "Profile", Known: []string{"instance-type"}}
+		return &engine.UsageError{
+			Code: "UNKNOWN_FLAG",
+			Err:  fmt.Errorf("%w (run `aliyun ecs describe-instances --help` for accepted flags)", unknown),
+		}
+	}
+
+	newContext := func() (*Commando, *cli.Context) {
+		ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+		cmd := &cli.Command{Name: "aliyun", EnableUnknownFlag: true}
+		config.AddFlags(cmd.Flags())
+		AddFlags(cmd.Flags())
+		ctx.EnterCommand(cmd)
+		commando := &Commando{
+			profile:                 config.Profile{Language: "en"},
+			recoverySearchValidator: func(RecoverySearchRequest) bool { return false },
+		}
+		return commando, ctx
+	}
+
+	t.Run("text", func(t *testing.T) {
+		t.Setenv(aimode.EnvAIMode, "false")
+		commando, ctx := newContext()
+		got := commando.finishCommandRun(ctx, args, newCause())
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "unknown flag --Profile, did you mean --profile?")
+	})
+
+	t.Run("AI JSON", func(t *testing.T) {
+		t.Setenv(aimode.EnvAIMode, "true")
+		commando, ctx := newContext()
+		got := commando.finishCommandRun(ctx, args, newCause())
+		var agentErr *cli.AgentError
+		require.ErrorAs(t, got, &agentErr)
+		encoded, err := json.Marshal(agentErr.Envelope())
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"message":"unknown flag --Profile",
+			"did_you_mean":["--profile"],
+			"recovery":{
+				"action":"inspect_action_help",
+				"command":"aliyun ecs describe-instances --help",
+				"hint":"Inspect the action help and correct the parameter or flag."
+			}
+		}`, string(encoded))
+	})
+}
+
 func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 	t.Run("unknown product uses validated product search", func(t *testing.T) {
 		repo, err := meta.MockLoadRepository([]meta.Product{{Code: "Ecs"}})

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/safety"
 	"github.com/aliyun/aliyun-cli/v3/sysconfig/throttlingretry"
 	"github.com/aliyun/aliyun-cli/v3/util"
+	"github.com/aliyun/aliyun-openapi-runtime/argparser"
 	"github.com/aliyun/aliyun-openapi-runtime/engine"
 
 	"encoding/json"
@@ -182,6 +183,7 @@ func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) 
 	// chain), which must never reach stderr, logs, or models. Sanitize before
 	// the AI gate so non-AI output is protected too.
 	err = sanitizeNetworkTransportError(err)
+	err = suggestKebabProfileFlagCase(err, args)
 
 	enabled := c.applyEffectiveAIModeForArgs(ctx, args)
 
@@ -205,6 +207,37 @@ func (c *Commando) finishCommandRun(ctx *cli.Context, args []string, err error) 
 		})
 	}
 	return agentErrorNormalizer(err, normalizationArgs)
+}
+
+type kebabProfileFlagCaseError struct {
+	cause   error
+	product string
+	command string
+}
+
+func (e *kebabProfileFlagCaseError) Error() string {
+	return fmt.Sprintf("unknown flag --Profile, did you mean --profile? (run `aliyun %s %s --help` for accepted flags)",
+		e.product, e.command)
+}
+
+func (e *kebabProfileFlagCaseError) Unwrap() error { return e.cause }
+
+func (*kebabProfileFlagCaseError) AIRecoveryEligible() {}
+
+// suggestKebabProfileFlagCase preserves case-sensitive rejection while adding
+// the one host-flag correction approved for kebab OpenAPI commands.
+func suggestKebabProfileFlagCase(err error, args []string) error {
+	if len(args) < 2 || commandStyle(args[1]) != "kebab" {
+		return err
+	}
+	var unknown *argparser.UnknownFlagError
+	if !errors.As(err, &unknown) || unknown.Flag != "Profile" {
+		return err
+	}
+	if !containsString(unknown.Known, "profile") {
+		unknown.Known = append(append([]string(nil), unknown.Known...), "profile")
+	}
+	return &kebabProfileFlagCaseError{cause: err, product: args[0], command: args[1]}
 }
 
 type sectionHelpAllRecoveryError struct {

--- a/openapi/help_options.go
+++ b/openapi/help_options.go
@@ -16,8 +16,8 @@ type helpOptions struct {
 	Section         string
 	SectionExplicit bool
 	Search          string
-	// SearchAll removes the search result cap when --help-all accompanies
-	// --help-search. All alone keeps the complete-document meaning.
+	// SearchAll removes the search result cap. Every public search enables it;
+	// an explicit --help-all remains accepted for compatibility.
 	SearchAll bool
 	All       bool
 	Output    cli.HelpOutput
@@ -80,6 +80,9 @@ func parseHelpOptions(ctx *cli.Context, target []string) (helpOptions, error) {
 		} else {
 			opts.All = true
 		}
+	}
+	if opts.Search != "" {
+		opts.SearchAll = true
 	}
 
 	if flag := CliOutputFlag(ctx.Flags()); flag != nil && flag.IsAssigned() {

--- a/openapi/help_options_test.go
+++ b/openapi/help_options_test.go
@@ -42,6 +42,7 @@ func TestParseHelpOptionsAcceptsResponseSearch(t *testing.T) {
 	assert.Equal(t, helpSectionResponse, opts.Section)
 	assert.True(t, opts.SectionExplicit)
 	assert.Equal(t, "instance-id", opts.Search)
+	assert.True(t, opts.SearchAll)
 }
 
 func TestParseHelpOptionsValidatesScopeAndValues(t *testing.T) {

--- a/openapi/help_projection.go
+++ b/openapi/help_projection.go
@@ -1308,6 +1308,11 @@ func renderTextListing(w io.Writer, noun string, listing *machineHelpListing) er
 }
 
 func renderHelpProjectionResult(w io.Writer, noun string, result HelpResult, next *HelpNext) error {
+	if !result.Truncated && next != nil && next.operation == HelpOperationSearch {
+		if _, err := fmt.Fprintf(w, "\nShowing %d of %d %s.\n", result.Shown, result.Total, noun); err != nil {
+			return err
+		}
+	}
 	if err := renderHelpProjectionStatistics(w, noun, result, next != nil); err != nil {
 		return err
 	}

--- a/openapi/help_projection_additional_test.go
+++ b/openapi/help_projection_additional_test.go
@@ -174,6 +174,20 @@ func TestHelpProjectionSmallHelpers(t *testing.T) {
 	require.NoError(t, renderRequestQueryExampleText(&output, nil))
 }
 
+func TestSearchTextKeepsCompleteResultStatisticsWithoutSearchAllHint(t *testing.T) {
+	var output bytes.Buffer
+	next := &HelpNext{Search: "aliyun ecs --help-search <keyword>", operation: HelpOperationSearch}
+	require.NoError(t, renderHelpProjectionResult(&output, "matches", HelpResult{Shown: 17, Total: 17}, next))
+	assert.Contains(t, output.String(), "Showing 17 of 17 matches.")
+	assert.Contains(t, output.String(), "Try another keyword:")
+	assert.NotContains(t, output.String(), "Show all matches")
+	assert.NotContains(t, output.String(), "--help-all")
+
+	output.Reset()
+	require.NoError(t, renderHelpProjectionResult(&output, "matches", HelpResult{Shown: 17, Total: 17}, nil))
+	assert.Empty(t, output.String(), "ordinary complete Help must keep its existing output")
+}
+
 func TestMachineHelpMaxLineLengthUsesTerminalWidthWithCap(t *testing.T) {
 	t.Setenv("ALIBABA_CLOUD_CLI_MAX_LINE_LENGTH", "")
 	originalIsTerminal, originalGetSize := machineHelpIsTerminal, machineHelpGetSize


### PR DESCRIPTION
## Summary

- keep default Help and standalone `--help-all` behavior unchanged while making `--help-search` return every match with complete shown/total statistics
- suggest lowercase `--profile` for the specific kebab `--Profile` error without broadening other global flag suggestions
- align client-side AI recovery actions for unknown commands, missing required parameters, conflicting options, and invalid body files

## Verification

- `make test` with a clean credential/agent environment (overall coverage: 90.1%)
- `make test-runtime`
- real 5.0.0 binary checks for all changed error and recovery cases
- complete Help behavior matrix: 84/84 cases passed across Default/All/Search, AI/non-AI, Text/JSON, and seven Help levels
