### PR TITLE
fix: prefer user input for API recovery search

### DIFF
--- a/openapi/agent_error.go
+++ b/openapi/agent_error.go
@@ -659,7 +659,7 @@ func unknownAPIAgentError(cause error, message string, suggestions []string, con
 		Command: context.productHelpCommand(),
 		Hint:    "Inspect the available APIs for this product.",
 	}
-	seeds := append(append([]string(nil), suggestions...), context.api)
+	seeds := append([]string{context.api}, suggestions...)
 	for _, keyword := range apiSearchKeywordCandidates(context.style, seeds...) {
 		request := context.searchRequest("", "", keyword)
 		if validate != nil && validate(request) {

--- a/openapi/agent_error_test.go
+++ b/openapi/agent_error_test.go
@@ -137,8 +137,31 @@ func TestNormalizeAgentErrorSupportedLocalRecoveries(t *testing.T) {
 		assert.Equal(t, "aliyun ecs --help-search Instance", envelope.Recovery.Command)
 		assert.Equal(t, "Search APIs related to Instance.", envelope.Recovery.Hint)
 		assert.Equal(t, []RecoverySearchRequest{
+			{Product: "ecs", Style: "pascal", Keyword: "Instnace"},
+			{Product: "ecs", Style: "pascal", Keyword: "Instnaces"},
 			{Product: "ecs", Style: "pascal", Keyword: "Instance"},
 		}, requests)
+	})
+
+	t.Run("unknown API prefers a validated keyword from the user input", func(t *testing.T) {
+		cause := &InvalidApiError{
+			Name: "DescribeResource",
+			product: &meta.Product{
+				Code: "tag", ApiNames: []string{
+					"DeleteAssociatedResourceRule", "ListResourcesByTag", "ListTagResources", "TagResources", "UntagResources",
+				},
+			},
+		}
+		var requests []RecoverySearchRequest
+		envelope := requireAgentEnvelope(t, cause, []string{"tag", "DescribeResource"}, func(got RecoverySearchRequest) bool {
+			requests = append(requests, got)
+			return got.Keyword == "Resource" || got.Keyword == "Rule"
+		})
+
+		assert.Equal(t, "aliyun tag --help-search Resource", envelope.Recovery.Command)
+		assert.Equal(t, "Search APIs related to Resource.", envelope.Recovery.Hint)
+		require.NotEmpty(t, requests)
+		assert.Equal(t, "Resource", requests[0].Keyword)
 	})
 
 	t.Run("short unknown API still uses validated product search", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- prioritize keywords derived from the invalid API name when building recovery search commands
- retain did-you-mean-derived keywords as a fallback when user-input keywords produce no results
- add regression coverage for `DescribeResource` selecting `Resource` instead of `Rule`

## Verification
- `go test ./openapi -run 'TestNormalizeAgentError(SupportedLocalRecoveries|SearchValidationFallbackAndCommandStyle)$' -count=1`\n- `go test ./openapi -run 'Test(NormalizeAgentError|ServerAgentError|ServerErrorCode)' -count=1`\n- `make build`\n- local binary: `tag DescribeResource` recovers with `aliyun tag --help-search Resource`; typo fallback still recovers `DescribeInstnaces` with `Instance`