### PR TITLE
Slim product context from search Help JSON

### DIFF
--- a/openapi/machine_help_slim.go
+++ b/openapi/machine_help_slim.go
@@ -108,6 +108,9 @@ var machineHelpFalseDefaultBools = map[string]bool{
 }
 
 func omitMachineHelpJSONField(key string, item any, parent map[string]any) bool {
+	if key == "product" && machineHelpSearchOmitsProductContext(parent) {
+		return true
+	}
 	if machineHelpFalseDefaultBools[key] {
 		if flag, ok := item.(bool); ok && !flag {
 			return true
@@ -118,6 +121,22 @@ func omitMachineHelpJSONField(key string, item any, parent map[string]any) bool 
 		return machineHelpOptionsRepeatName(item, parent)
 	}
 	return false
+}
+
+// machineHelpSearchOmitsProductContext keeps search JSON focused on matches.
+// The invocation already identifies the product, while ordinary Product and
+// Request Help retain this context outside search.
+func machineHelpSearchOmitsProductContext(parent map[string]any) bool {
+	query, _ := parent["query"].(string)
+	if query == "" {
+		return false
+	}
+	helpLevel, _ := parent["helpLevel"].(string)
+	if helpLevel == "product" {
+		return true
+	}
+	section, _ := parent["section"].(string)
+	return helpLevel == "api" && section == helpSectionRequest
 }
 
 // machineHelpOptionsRepeatName reports whether options holds exactly the

--- a/openapi/machine_help_slim_test.go
+++ b/openapi/machine_help_slim_test.go
@@ -123,6 +123,70 @@ func TestMachineHelpJSONOmitsDefaultAnnotationsAndRepeatedIdentity(t *testing.T)
 	assert.Equal(t, false, result["truncated"], "decision-relevant booleans stay explicit")
 }
 
+func TestMachineHelpSearchJSONOmitsProductContext(t *testing.T) {
+	product := machineHelpProduct{
+		Code:                 "demo",
+		Name:                 machineHelpLocalizedText{EN: "Demo Service"},
+		APIStyle:             "rpc",
+		LegacyDefaultVersion: "2026-01-01",
+		SelectedVersion:      "2026-01-01",
+	}
+	documents := []any{
+		&machineHelpProductDocument{
+			SchemaVersion: machineHelpSchemaVersion,
+			Kind:          "product",
+			Query:         "report",
+			Product:       product,
+			APIs:          []machineHelpAPISummary{{DisplayName: "CreateReport"}},
+			Result:        HelpResult{Shown: 1, Total: 1},
+		},
+		&machineHelpAPIDocument{
+			SchemaVersion:      machineHelpSchemaVersion,
+			Kind:               "api",
+			Section:            helpSectionRequest,
+			Query:              "report-id",
+			Product:            product,
+			ActiveParameterSet: "camel",
+			ParameterSets: machineHelpParameterSets{Camel: []machineHelpParameter{{
+				Name: "ReportId", Type: "string",
+			}}},
+			Result: HelpResult{Shown: 1, Total: 1},
+		},
+	}
+
+	for _, document := range documents {
+		var output bytes.Buffer
+		require.NoError(t, encodeMachineHelpJSON(&output, document, false))
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+		assert.NotContains(t, raw, "product")
+	}
+}
+
+func TestMachineHelpJSONKeepsProductContextOutsideSearch(t *testing.T) {
+	documents := []any{
+		&machineHelpProductDocument{
+			SchemaVersion: machineHelpSchemaVersion,
+			Kind:          "product",
+			Product:       machineHelpProduct{Code: "demo"},
+		},
+		&machineHelpAPIDocument{
+			SchemaVersion: machineHelpSchemaVersion,
+			Kind:          "api",
+			Section:       helpSectionRequest,
+			Product:       machineHelpProduct{Code: "demo"},
+		},
+	}
+
+	for _, document := range documents {
+		var output bytes.Buffer
+		require.NoError(t, encodeMachineHelpJSON(&output, document, false))
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(output.Bytes(), &raw))
+		assert.Contains(t, raw, "product")
+	}
+}
+
 func TestMachineHelpJSONOmitsDerivableOptionsAndRawName(t *testing.T) {
 	doc := &machineHelpAPIDocument{
 		SchemaVersion:      machineHelpSchemaVersion,


### PR DESCRIPTION
## Summary
- omit redundant product context from product-level API search JSON
- omit redundant product context from API request parameter search JSON
- preserve product context for non-search Help and text output

## Verification
- go test ./openapi -count=1
- make build
- E2E verified AI and non-AI JSON search plus ordinary product Help