### PR TITLE
fix: resolve explicit API version styles from Canonical metadata

### DIFF
--- a/openapi/library.go
+++ b/openapi/library.go
@@ -96,6 +96,11 @@ func (a *Library) GetApiByPath(productCode string, version string, method string
 }
 
 func (a *Library) GetStyle(productCode string, version string) (string, bool) {
+	if a.canonicalRepo != nil {
+		if index, err := a.canonicalRepo.GetVersionIndex(productCode, version); err == nil && index != nil && index.Style != "" {
+			return index.Style, true
+		}
+	}
 	return a.builtinRepo.GetStyle(productCode, version)
 }
 

--- a/openapi/library_test.go
+++ b/openapi/library_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"testing/fstest"
 
 	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
 	"github.com/aliyun/aliyun-cli/v3/meta"
@@ -25,6 +26,46 @@ import (
 	"bytes"
 	"testing"
 )
+
+func TestLibrary_GetStyle_PrefersCanonicalVersionIndex(t *testing.T) {
+	library := &Library{
+		builtinRepo: &meta.Repository{},
+		canonicalRepo: canonicalmeta.NewRepository(fstest.MapFS{
+			"canonical/accessanalyzer/2024-02-01/version.json": {Data: []byte(`{"style":"rpc","version":"2024-02-01"}`)},
+			"canonical/accessanalyzer/2025-01-01/version.json": {Data: []byte(`{"style":"restful","version":"2025-01-01"}`)},
+			"canonical/aegis/2016-11-11/version.json":          {Data: []byte(`{"style":"restful","version":"2016-11-11"}`)},
+			"canonical/empty/2024-02-01/version.json":          {Data: []byte(`{"version":"2024-02-01"}`)},
+		}),
+	}
+	for _, tc := range []struct {
+		product, version, style string
+		ok                      bool
+	}{
+		{"accessanalyzer", "2024-02-01", "rpc", true},
+		{"AccessAnalyzer", "2024-02-01", "rpc", true},
+		{"accessanalyzer", "2025-01-01", "restful", true},
+		{"aegis", "2016-11-11", "restful", true},
+		{"accessanalyzer", "1999-01-01", "", false},
+		{"missing", "2024-02-01", "", false},
+		{"empty", "2024-02-01", "", false},
+	} {
+		t.Run(tc.product+"/"+tc.version, func(t *testing.T) {
+			style, ok := library.GetStyle(tc.product, tc.version)
+			assert.Equal(t, tc.style, style)
+			assert.Equal(t, tc.ok, ok)
+		})
+	}
+
+	// Preserve the existing lookup when Canonical metadata is unavailable.
+	library.canonicalRepo = canonicalmeta.NewRepository(fstest.MapFS{})
+	style, ok := library.GetStyle("aegis", "2016-11-11")
+	assert.True(t, ok)
+	assert.Equal(t, "RPC", style)
+	library.canonicalRepo = nil
+	style, ok = library.GetStyle("aegis", "2016-11-11")
+	assert.True(t, ok)
+	assert.Equal(t, "RPC", style)
+}
 
 func TestLibrary_PrintProducts(t *testing.T) {
 	w := new(bytes.Buffer)


### PR DESCRIPTION
## Summary

Fix explicit `--version` validation for products supported by Canonical metadata but absent from the old embedded `meta/versions.json` (for example, AccessAnalyzer).

- Read the requested version's `style` from `canonical/<product>/<version>/version.json` in the shared `Library.GetStyle` lookup.
- Keep the existing legacy lookup as a fallback when a Canonical version index/style is unavailable.
- Cover Canonical-only products, case-insensitive product codes, per-version styles, Canonical precedence, unknown versions, and legacy fallback.

The metadata submodule remains at `96914d57f79fe2228efe501bc40148715fcb1f77`; no generated metadata or Generator changes.

## Verification

- Confirmed the regression test fails before the fix and passes after it.
- `go test ./openapi ./canonicalmeta ./meta -count=1` passed.
- Built a macOS ARM64 executable with `aliyun_cli_packed_meta` and ran these local dry-run checks using dummy credentials and `example.com` (no cloud API calls):
  - AccessAnalyzer `ApplyArchiveRule` with explicit `--version 2024-02-01` and `--force`: exit 0, RPC request with the correct version and parameters.
  - Same command without `--version`: exit 0, same request.
  - Same command with explicit version but without `--force`: exit 0.
  - Nonexistent version `1999-01-01`: exit 3, still reports `unchecked version`.
  - `cs GET /clusters --version 2015-12-15 --force`: exit 0, ROA request.
