### PR TITLE
fix: support RESTful PATCH and preserve complete dry-run bodies

### DIFF
--- a/aliyun-openapi-runtime/engine/builder.go
+++ b/aliyun-openapi-runtime/engine/builder.go
@@ -704,7 +704,7 @@ func dryRunBody(body any, reqBodyType string) (value, format string, err error) 
 		if strings.EqualFold(format, "formData") {
 			format = "form"
 		}
-		return redact.MaskBody(data), format, nil
+		return redact.MaskBodyFull(data), format, nil
 	}
 	if data, ok := body.([]byte); ok {
 		format = reqBodyType
@@ -714,7 +714,7 @@ func dryRunBody(body any, reqBodyType string) (value, format string, err error) 
 		if strings.EqualFold(format, "formData") {
 			format = "form"
 		}
-		return redact.MaskBody(string(data)), format, nil
+		return redact.MaskBodyFull(string(data)), format, nil
 	}
 	b, err := json.Marshal(redact.MaskAny(body))
 	if err != nil {
@@ -800,9 +800,9 @@ func renderDryRun(w io.Writer, product string, req *runtime.AssembledRequest, js
 		switch body := req.Body.(type) {
 		case string:
 			// Raw --body/--body-file strings are sent as-is by the SDK.
-			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBody(body))
+			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBodyFull(body))
 		case []byte:
-			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBody(string(body)))
+			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBodyFull(string(body)))
 		default:
 			b, _ := json.Marshal(redact.MaskAny(req.Body))
 			fmt.Fprintf(w, "Body:\n  %s\n", string(b))

--- a/aliyun-openapi-runtime/engine/builder_additional_test.go
+++ b/aliyun-openapi-runtime/engine/builder_additional_test.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -491,6 +492,35 @@ func TestBuilderOptionAndRenderingHelpers(t *testing.T) {
 	}
 	if _, _, err := dryRunBody(make(chan int), ""); err == nil {
 		t.Fatal("dryRunBody accepted channel")
+	}
+}
+
+func TestDryRunPreservesLongBodyAndRedaction(t *testing.T) {
+	text := strings.Repeat("流水线", 450) + "正文末尾"
+	for _, tc := range []struct{ body, want string }{
+		{"name=" + text + "&pipelineId=123", "name=" + text + "&pipelineId=123"},
+		{`{"content":"` + text + `","password":"secret-value"}`, `{"content":"` + text + `","password":"secr***"}`},
+	} {
+		for _, body := range []any{tc.body, []byte(tc.body)} {
+			value, _, err := dryRunBody(body, "raw")
+			if err != nil || value != tc.want {
+				t.Fatalf("dryRunBody(%T) lost body content or redaction: %v", body, err)
+			}
+			for _, jsonOutput := range []bool{false, true} {
+				var out bytes.Buffer
+				if err := renderDryRun(&out, "demo", &runtime.AssembledRequest{Body: body}, jsonOutput, false); err != nil {
+					t.Fatal(err)
+				}
+				if jsonOutput {
+					var decoded cliDryRunOutput
+					if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
+						t.Fatalf("JSON dry-run lost body content or redaction: %v", err)
+					}
+				} else if !strings.Contains(out.String(), tc.want) {
+					t.Fatal("text dry-run lost body content or redaction")
+				}
+			}
+		}
 	}
 }
 

--- a/aliyun-openapi-runtime/internal/redact.go
+++ b/aliyun-openapi-runtime/internal/redact.go
@@ -109,17 +109,22 @@ func MaskKV(key, value string) string {
 }
 
 func MaskBody(body string) string {
+	return truncate(MaskBodyFull(body))
+}
+
+// MaskBodyFull applies the same redaction policy without truncating dry-run output.
+func MaskBodyFull(body string) string {
 	var data any
 	if json.Valid([]byte(body)) {
 		decoder := json.NewDecoder(strings.NewReader(body))
 		decoder.UseNumber()
 		if err := decoder.Decode(&data); err == nil {
 			if masked, err := json.Marshal(maskJSON(data)); err == nil {
-				return truncate(string(masked))
+				return string(masked)
 			}
 		}
 	}
-	return truncate(body)
+	return body
 }
 
 func MaskAny(data any) any {

--- a/aliyun-openapi-runtime/redact/redact.go
+++ b/aliyun-openapi-runtime/redact/redact.go
@@ -27,4 +27,7 @@ func MaskKV(key, value string) string { return internal.MaskKV(key, value) }
 
 func MaskBody(body string) string { return internal.MaskBody(body) }
 
+// MaskBodyFull redacts the complete body for dry-run output without a size limit.
+func MaskBodyFull(body string) string { return internal.MaskBodyFull(body) }
+
 func MaskAny(data any) any { return internal.MaskAny(data) }

--- a/openapi/cli_dry_run.go
+++ b/openapi/cli_dry_run.go
@@ -72,12 +72,12 @@ func buildCliDryRunFromInvoker(inv Invoker) *CliDryRunOutput {
 	}
 
 	if len(req.Content) > 0 {
-		out.Body = runtimeredact.MaskBody(string(req.Content))
+		out.Body = runtimeredact.MaskBodyFull(string(req.Content))
 		out.BodyFormat = "raw"
 	} else if len(req.FormParams) > 0 {
 		out.Query = mergeInto(out.Query, nil)
 		formJSON, _ := json.Marshal(req.FormParams)
-		out.Body = runtimeredact.MaskBody(string(formJSON))
+		out.Body = runtimeredact.MaskBodyFull(string(formJSON))
 		out.BodyFormat = "form"
 	}
 
@@ -148,7 +148,7 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
 		bodyJSON, err := json.Marshal(oc.openapiRequest.Body)
 		if err == nil && string(bodyJSON) != "null" {
-			out.Body = runtimeredact.MaskBody(string(bodyJSON))
+			out.Body = runtimeredact.MaskBodyFull(string(bodyJSON))
 			// Reflect the request-body encoding resolved in Prepare/ProcessBody:
 			// RPC-style products send form fields (ReqBodyType=formData), which
 			// the classic dry-run reports as "form"; ROA keeps the JSON body.
@@ -182,7 +182,7 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 
 	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
 		if stream, ok := oc.openapiRequest.Body.([]byte); ok {
-			out.Body = runtimeredact.MaskBody(string(stream))
+			out.Body = runtimeredact.MaskBodyFull(string(stream))
 			if oc.openapiParams != nil && oc.openapiParams.ReqBodyType != nil {
 				out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
 			} else {

--- a/openapi/cli_dry_run_test.go
+++ b/openapi/cli_dry_run_test.go
@@ -194,6 +194,33 @@ func TestBuildCliDryRunFromInvoker_MasksPathSecret(t *testing.T) {
 	assert.NotContains(t, out.Pathname, "path-secret-value")
 }
 
+func TestCliDryRunPreservesLongBodyAndRedaction(t *testing.T) {
+	text := strings.Repeat("流水线", 450) + "正文末尾"
+	for _, tc := range []struct{ name, body, want string }{
+		{"raw", "name=" + text + "&pipelineId=123", "name=" + text + "&pipelineId=123"},
+		{"json", `{"content":"` + text + `","password":"secret-value"}`, `{"content":"` + text + `","password":"secr***"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := requests.NewCommonRequest()
+			req.SetContent([]byte(tc.body))
+			classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
+			openapi := buildCliDryRunFromOpenapi(&OpenapiContext{HttpContext: &HttpContext{
+				openapiRequest: &openapiutil.OpenApiRequest{Body: []byte(tc.body)},
+			}})
+			for _, out := range []*CliDryRunOutput{classic, openapi} {
+				assert.Equal(t, tc.want, out.Body)
+				assert.Contains(t, formatCliDryRunHuman(out), tc.want)
+				encoded, err := marshalCliDryRunOutput(out)
+				assert.NoError(t, err)
+				var decoded CliDryRunOutput
+				assert.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
+				assert.Equal(t, tc.want, decoded.Body)
+			}
+			assert.Equal(t, tc.body, string(req.Content), "dry-run must not mutate the request")
+		})
+	}
+}
+
 func TestBuildCliDryRunFromInvoker_WithBody(t *testing.T) {
 	req := requests.NewCommonRequest()
 	req.Domain = "ecs.cn-hangzhou.aliyuncs.com"
@@ -225,6 +252,7 @@ func TestBuildCliDryRunFromInvoker_WithFormParams(t *testing.T) {
 	req.FormParams["InstanceType"] = "ecs.g6.large"
 	req.FormParams["RegionId"] = "cn-hangzhou"
 	req.FormParams["Password"] = "form-secret-value"
+	req.FormParams["Description"] = strings.Repeat("中文", 600)
 
 	invoker := &ForceRpcInvoker{
 		BasicInvoker: &BasicInvoker{
@@ -235,6 +263,7 @@ func TestBuildCliDryRunFromInvoker_WithFormParams(t *testing.T) {
 
 	out := buildCliDryRunFromInvoker(invoker)
 	assert.Equal(t, "form", out.BodyFormat)
+	assert.Contains(t, out.Body, req.FormParams["Description"])
 	assert.Contains(t, out.Body, "InstanceType")
 	assert.Contains(t, out.Body, "ecs.g6.large")
 	assert.Contains(t, out.Body, `"Password":"form***"`)
@@ -417,6 +446,7 @@ func TestBuildCliDryRunFromOpenapi_WithBody(t *testing.T) {
 		"logstoreName": "test-store",
 		"ttl":          30,
 		"password":     "body-secret-value",
+		"description":  strings.Repeat("中文", 600),
 	}
 	oc := &OpenapiContext{
 		HttpContext: &HttpContext{
@@ -436,6 +466,7 @@ func TestBuildCliDryRunFromOpenapi_WithBody(t *testing.T) {
 
 	out := buildCliDryRunFromOpenapi(oc)
 	assert.Equal(t, "json", out.BodyFormat)
+	assert.Contains(t, out.Body, bodyContent["description"])
 	assert.Contains(t, out.Body, "logstoreName")
 	assert.Contains(t, out.Body, "test-store")
 	assert.Contains(t, out.Body, `"password":"body***"`)

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -796,7 +796,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		return c.processInvoke(ctx, productName, args[1], "")
 	} else if len(args) == 3 {
 		// restful call
-		// aliyun <productCode> {GET|PUT|POST|DELETE} <path> --
+		// aliyun <productCode> {GET|PUT|POST|DELETE|PATCH} <path> --
 		product, _ := c.library.GetProduct(productName)
 		api, find := c.library.GetApiByPath(product.Code, product.Version, args[1], args[2])
 		force := ForceFlag(ctx.Flags()).IsAssigned()
@@ -1252,7 +1252,7 @@ func (c *Commando) createInvoker(ctx *cli.Context, productCode string, apiOrMeth
 
 		if !ok {
 			return nil, cli.NewErrorWithTip(fmt.Errorf("product '%s' need restful call", product.GetLowerCode()),
-				"Use `aliyun %s {GET|PUT|POST|DELETE} <path> ...`", product.GetLowerCode())
+				"Use `aliyun %s {GET|PUT|POST|DELETE|PATCH} <path> ...`", product.GetLowerCode())
 		}
 
 		if api := c.library.GetCanonicalApi(product.Code, product.Version, ctx.Command().Name); api != nil {
@@ -1397,9 +1397,9 @@ func (c *Commando) createHttpContext(ctx *cli.Context, product *meta.Product, ap
 		return nil, err
 	}
 	if !ok {
-		return nil, cli.NewErrorWithTip(fmt.Errorf("product '%s' need proper restful call with ApiName or {GET|PUT|POST|DELETE} <path>",
+		return nil, cli.NewErrorWithTip(fmt.Errorf("product '%s' need proper restful call with ApiName or {GET|PUT|POST|DELETE|PATCH} <path>",
 			product.GetLowerCode()),
-			"Use `aliyun %s <ApiName> ...` or `aliyun %s {GET|PUT|POST|DELETE} <path> ...`",
+			"Use `aliyun %s <ApiName> ...` or `aliyun %s {GET|PUT|POST|DELETE|PATCH} <path> ...`",
 			product.GetLowerCode(),
 			product.GetLowerCode())
 	}

--- a/openapi/commando_help.go
+++ b/openapi/commando_help.go
@@ -389,7 +389,7 @@ func (c *Commando) printProductUsageForMode(ctx *cli.Context, productCode string
 	if product.ApiStyle == "rpc" {
 		cli.Printf(ctx.Stdout(), "\nUsage:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ...\n", strings.ToLower(product.Code))
 	} else {
-		cli.Printf(ctx.Stdout(), "\nUsage 1:\n  aliyun %s [GET|PUT|POST|DELETE] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
+		cli.Printf(ctx.Stdout(), "\nUsage 1:\n  aliyun %s [GET|PUT|POST|DELETE|PATCH] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
 		cli.Printf(ctx.Stdout(), "\nUsage 2 (For API with NO PARAMS in PathPattern only.):\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ... --body \"...\"\n", strings.ToLower(product.Code))
 	}
 	productName := getProductDisplayName(product)

--- a/openapi/commando_help_test.go
+++ b/openapi/commando_help_test.go
@@ -331,7 +331,7 @@ func TestPrintProductUsage_RestfulProduct(t *testing.T) {
 	assert.NoError(t, err)
 
 	output := stdout.String()
-	assert.Contains(t, output, "[GET|PUT|POST|DELETE]")
+	assert.Contains(t, output, "[GET|PUT|POST|DELETE|PATCH]")
 }
 
 func TestPrintProductUsage_RestfulProduct_ListShowsSummary(t *testing.T) {
@@ -1200,7 +1200,7 @@ func Test_tryDelegatePluginHelp_RefusesHTTPMethod(t *testing.T) {
 	profile := config.Profile{Language: "en", Mode: "AK", AccessKeyId: "x", AccessKeySecret: "y", RegionId: "cn-hangzhou"}
 	c := NewCommando(w, profile)
 
-	for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH"} {
 		t.Run("HTTP method "+method, func(t *testing.T) {
 			delegated, err := c.tryDelegatePluginHelp(ctx, []string{"ecs", method, "/path"})
 			assert.False(t, delegated, "RESTful shape must not be delegated to plugin")

--- a/openapi/help_dispatch.go
+++ b/openapi/help_dispatch.go
@@ -246,8 +246,7 @@ func (c *Commando) hostOwnsLegacyHelpCommand(args []string) bool {
 		return false
 	}
 	command := positionals[1]
-	switch strings.ToUpper(command) {
-	case "GET", "POST", "PUT", "DELETE":
+	if _, ok := checkHttpMethod(command); ok {
 		return false
 	}
 	if strings.ToLower(command) == command {

--- a/openapi/help_dispatch_test.go
+++ b/openapi/help_dispatch_test.go
@@ -397,6 +397,7 @@ func TestHostOwnsLegacyHelpCommand(t *testing.T) {
 	assert.False(t, c.hostOwnsLegacyHelpCommand([]string{"sts", "get-caller-identity"}), "kebab commands belong to the plugin chain")
 	assert.False(t, c.hostOwnsLegacyHelpCommand([]string{"cs", "GET", "/clusters"}), "HTTP verbs stay with the plugin (method+path exceeds the host Help model)")
 	assert.False(t, c.hostOwnsLegacyHelpCommand([]string{"cs", "get", "/clusters"}), "HTTP verbs are case-insensitive")
+	assert.False(t, c.hostOwnsLegacyHelpCommand([]string{"cs", "PATCH", "/clusters/1"}), "PATCH Help keeps the same ownership as other HTTP verbs")
 	assert.False(t, c.hostOwnsLegacyHelpCommand([]string{"sts", "--help"}), "product-level Help keeps plugin ownership")
 	assert.False(t, c.hostOwnsLegacyHelpCommand([]string{"demo", "CreateReport", "--help"}), "products unknown to the host stay plugin-owned")
 }

--- a/openapi/library.go
+++ b/openapi/library.go
@@ -185,7 +185,7 @@ func (a *Library) PrintProductUsage(productCode string, withApi bool) error {
 	if product.ApiStyle == "rpc" {
 		cli.Printf(a.writer, "\nUsage:\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ...\n", strings.ToLower(product.Code))
 	} else {
-		cli.Printf(a.writer, "\nUsage 1:\n  aliyun %s [GET|PUT|POST|DELETE] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
+		cli.Printf(a.writer, "\nUsage 1:\n  aliyun %s [GET|PUT|POST|DELETE|PATCH] <PathPattern> --body \"...\" \n", strings.ToLower(product.Code))
 		cli.Printf(a.writer, "\nUsage 2 (For API with NO PARAMS in PathPattern only.):\n  aliyun %s <ApiName> --parameter1 value1 --parameter2 value2 ... --body \"...\"\n", strings.ToLower(product.Code))
 	}
 	productName := getProductDisplayName(product)

--- a/openapi/restful.go
+++ b/openapi/restful.go
@@ -145,7 +145,7 @@ func checkRestfulMethod(ctx *cli.Context, methodOrPath string, pathPattern strin
 
 func checkHttpMethod(s string) (string, bool) {
 	m := strings.ToUpper(s)
-	if m == "GET" || m == "POST" || m == "PUT" || m == "DELETE" {
+	if m == "GET" || m == "POST" || m == "PUT" || m == "DELETE" || m == "PATCH" {
 		return m, true
 	}
 	return "", false

--- a/openapi/restful_test.go
+++ b/openapi/restful_test.go
@@ -15,7 +15,9 @@ package openapi
 
 import (
 	"bufio"
+	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/aliyun-cli/v3/canonicalmeta"
@@ -23,8 +25,67 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/aliyun-cli/v3/cli"
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/meta"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestRestfulMethodsCompatibility(t *testing.T) {
+	ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+	ctx.Flags().Add(NewRoaFlag())
+	for _, input := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "patch", "PaTcH"} {
+		t.Run(input, func(t *testing.T) {
+			ok, method, path, err := checkRestfulMethod(ctx, input, "/items/1")
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, strings.ToUpper(input), method)
+			assert.Equal(t, "/items/1", path)
+			_, _, _, err = checkRestfulMethod(ctx, input, "items/1")
+			assert.EqualError(t, err, "bad restful path items/1")
+			ok, _, _, err = checkRestfulMethod(ctx, input, "")
+			assert.NoError(t, err)
+			assert.False(t, ok)
+		})
+	}
+	for _, input := range []string{"HEAD", "OPTIONS", "TRACE", "GET|POST", "PATCH|PUT", "PATC", " PATCH "} {
+		_, ok := checkHttpMethod(input)
+		assert.False(t, ok, "%q must remain unsupported", input)
+	}
+}
+
+func TestCreateInvokerPatch(t *testing.T) {
+	for _, product := range []string{"restful-demo", "unknown-demo"} {
+		t.Run(product, func(t *testing.T) {
+			profile := config.Profile{Mode: "AK", AccessKeyId: "testid", AccessKeySecret: "testsecret", RegionId: "cn-hangzhou", Endpoint: "example.com"}
+			command := NewCommando(new(bytes.Buffer), profile)
+			repo, err := meta.MockLoadRepository([]meta.Product{{Code: "restful-demo", Version: "2026-01-01", ApiStyle: "restful"}})
+			require.NoError(t, err)
+			command.library.builtinRepo = repo
+			ctx := cli.NewCommandContext(new(bytes.Buffer), new(bytes.Buffer))
+			ctx.EnterCommand(&cli.Command{Name: "PATCH", EnableUnknownFlag: true})
+			config.AddFlags(ctx.Flags())
+			AddFlags(ctx.Flags())
+			ForceFlag(ctx.Flags()).SetAssigned(true)
+			DryRunJsonFlag(ctx.Flags()).SetAssigned(true)
+			if product == "unknown-demo" {
+				VersionFlag(ctx.Flags()).SetAssigned(true)
+				VersionFlag(ctx.Flags()).SetValue("2026-01-01")
+			}
+			BodyFlag(ctx.Flags()).SetAssigned(true)
+			BodyFlag(ctx.Flags()).SetValue(`{"name":"updated"}`)
+			invoker, err := command.createInvoker(ctx, product, "PATCH", "/items/1")
+			require.NoError(t, err)
+			roa, ok := invoker.(*RestfulInvoker)
+			require.True(t, ok, "PATCH must not fall back to an RPC action")
+			require.NoError(t, roa.Prepare(ctx))
+			assert.Equal(t, "PATCH", roa.request.Method)
+			assert.Equal(t, "/items/1", roa.request.PathPattern)
+			assert.Equal(t, `{"name":"updated"}`, string(roa.request.Content))
+			assert.Equal(t, "application/json", roa.request.Headers["Content-Type"])
+		})
+	}
+}
 
 func TestRestfulInvoker_Prepare(t *testing.T) {
 	a := &RestfulInvoker{


### PR DESCRIPTION
## Summary

- Support `PATCH` in legacy RESTful calls and route its Help consistently with GET/POST/PUT/DELETE.
- Remove the 1000-byte body limit from JSON and text dry-run output in both classic and Canonical runtime paths.
- Preserve existing body redaction, DEBUG log truncation, real request behavior, and the metadata submodule revision.

## Verification

- CLI: `go test ./openapi ./openapi/runtimehost ./canonicalmeta ./cli ./meta -count=1`.
- Nested runtime module: `go test ./engine ./internal ./redact ./runtime -count=1` (run as the first three packages plus runtime separately).
- Built the packed-meta executable and locally checked AgentCore/Bailian PATCH calls, existing GET/POST/PUT/DELETE behavior, and rejection of invalid methods.
- Local dry-run checks preserved a 4082-byte DevOps form body and 4062-byte Chinese JSON content in camel-case and built-in kebab-case paths; JSON passwords remained redacted. Text dry-run retained the body tail as well.
- All executable checks used dry-run mode; no real API requests were sent.
