### PR TITLE
Fail closed when release asset download is incomplete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,7 @@ jobs:
         run: go generate ./bundledmeta
       - name: Download assets and compute shasum
         run: |
+          set -euo pipefail
           TAG=${{ github.ref_name }}
           VERSION=${TAG#v}
           bash tools/download_assets.sh ${VERSION}

--- a/tools/download_assets.sh
+++ b/tools/download_assets.sh
@@ -1,23 +1,17 @@
 #!/usr/bin/env bash
+# Download every release asset, then write a fresh SHASUMS256.txt.
+# Checksum is committed only after the full set is present and hashed.
+# A non-zero status must stop upload_asset.sh and finish_release.sh.
+set -euo pipefail
 
-VERSION=$1
+VERSION=${1:-}
+if [[ -z "${VERSION}" ]]; then
+  echo "download_assets: version is required" >&2
+  exit 1
+fi
 
-LIST=(
-    "aliyun-cli-macosx-$VERSION-amd64.tgz"
-    "aliyun-cli-macosx-$VERSION-arm64.tgz"
-    "aliyun-cli-$VERSION.pkg"
-    "aliyun-cli-macosx-$VERSION-universal.tgz"
-    "aliyun-cli-linux-$VERSION-amd64.tgz"
-    "aliyun-cli-linux-$VERSION-arm64.tgz"
-    "aliyun-cli-windows-$VERSION-amd64.zip"
-)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${REPO_ROOT}"
 
-for filename in "${LIST[@]}"
-do
-    curl -fsSL -O \
-        -H "Authorization: Bearer $GITHUB_TOKEN" \
-        https://github.com/aliyun/aliyun-cli/releases/download/v"$VERSION"/"$filename"
-    shasum -a 256 "$filename" >> SHASUMS256.txt
-done
-
-cat ./SHASUMS256.txt
+exec go run ./tools/downloadassets/cmd/downloadassets -- "${VERSION}"

--- a/tools/downloadassets/cli.go
+++ b/tools/downloadassets/cli.go
@@ -1,0 +1,67 @@
+package downloadassets
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Execute downloads release assets and prints the committed checksum file.
+// A non-zero status means no checksum was published by this run.
+func Execute(args []string, stdout, stderr io.Writer) int {
+	version, err := parseArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	workDir := os.Getenv("DOWNLOAD_ASSETS_WORKDIR")
+	if workDir == "" {
+		workDir = "."
+	}
+	opt := Options{
+		Version: version,
+		BaseURL: os.Getenv("DOWNLOAD_ASSETS_BASE_URL"),
+		Token:   os.Getenv("GITHUB_TOKEN"),
+		WorkDir: workDir,
+	}
+	if raw := os.Getenv("DOWNLOAD_ASSETS_TIMEOUT"); raw != "" {
+		timeout, err := time.ParseDuration(raw)
+		if err != nil {
+			fmt.Fprintf(stderr, "download assets: invalid timeout %q\n", raw)
+			return 1
+		}
+		opt.Timeout = timeout
+	}
+	if err := Download(context.Background(), opt); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	body, err := os.ReadFile(filepath.Join(workDir, checksumName))
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if _, err := io.WriteString(stdout, string(body)); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func parseArgs(args []string) (string, error) {
+	filtered := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "--" {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	if len(filtered) != 1 || strings.TrimSpace(filtered[0]) == "" {
+		return "", fmt.Errorf("usage: downloadassets <version>")
+	}
+	return filtered[0], nil
+}

--- a/tools/downloadassets/cli_test.go
+++ b/tools/downloadassets/cli_test.go
@@ -1,0 +1,106 @@
+package downloadassets
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecuteUsageAndTimeout(t *testing.T) {
+	var stderr bytes.Buffer
+	if code := Execute(nil, &bytes.Buffer{}, &stderr); code == 0 || !strings.Contains(stderr.String(), "usage:") {
+		t.Fatalf("usage code=%d stderr=%s", code, stderr.String())
+	}
+	stderr.Reset()
+	if code := Execute([]string{"--", ""}, &bytes.Buffer{}, &stderr); code == 0 {
+		t.Fatal("expected empty version to fail")
+	}
+
+	t.Setenv("DOWNLOAD_ASSETS_TIMEOUT", "not-a-duration")
+	stderr.Reset()
+	if code := Execute([]string{"1.2.3"}, &bytes.Buffer{}, &stderr); code == 0 || !strings.Contains(stderr.String(), "invalid timeout") {
+		t.Fatalf("timeout code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestExecuteSuccessAndHTTPFailure(t *testing.T) {
+	names := AssetNames("9.9.9")
+	fail := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail {
+			http.Error(w, "nope", http.StatusGatewayTimeout)
+			return
+		}
+		_, _ = w.Write([]byte("body-" + filepath.Base(r.URL.Path)))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("DOWNLOAD_ASSETS_WORKDIR", dir)
+	t.Setenv("DOWNLOAD_ASSETS_BASE_URL", srv.URL)
+	t.Setenv("DOWNLOAD_ASSETS_TIMEOUT", "5s")
+	t.Setenv("GITHUB_TOKEN", "cli-token")
+
+	var stdout, stderr bytes.Buffer
+	if code := Execute([]string{"--", "9.9.9"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("success code=%d stderr=%s", code, stderr.String())
+	}
+	if err := verifyChecksum(stdout.String(), names); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != mustRead(t, filepath.Join(dir, checksumName)) {
+		t.Fatal("stdout does not match committed checksum")
+	}
+	before := mustRead(t, filepath.Join(dir, checksumName))
+
+	fail = true
+	stderr.Reset()
+	var failed bytes.Buffer
+	if code := Execute([]string{"9.9.9"}, &failed, &stderr); code == 0 || !strings.Contains(stderr.String(), "HTTP 504") {
+		t.Fatalf("expected HTTP failure, code=%d stderr=%s", code, stderr.String())
+	}
+	if got := mustRead(t, filepath.Join(dir, checksumName)); got != before {
+		t.Fatal("failed run replaced the committed checksum")
+	}
+}
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestExecuteStdoutFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("DOWNLOAD_ASSETS_WORKDIR", dir)
+	t.Setenv("DOWNLOAD_ASSETS_BASE_URL", srv.URL)
+	t.Setenv("GITHUB_TOKEN", "")
+
+	var stderr bytes.Buffer
+	if code := Execute([]string{"1.2.3"}, failWriter{}, &stderr); code == 0 || !strings.Contains(stderr.String(), "write failed") {
+		t.Fatalf("expected stdout failure, code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, checksumName)); err != nil {
+		t.Fatal("checksum should already be committed before printing")
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	version, err := parseArgs([]string{"--", "3.5.1"})
+	if err != nil || version != "3.5.1" {
+		t.Fatalf("parse = %q %v", version, err)
+	}
+	if _, err := parseArgs([]string{"a", "b"}); err == nil {
+		t.Fatal("expected extra args to fail")
+	}
+}

--- a/tools/downloadassets/cmd/downloadassets/main.go
+++ b/tools/downloadassets/cmd/downloadassets/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/aliyun/aliyun-cli/v3/tools/downloadassets"
+)
+
+func main() {
+	os.Exit(downloadassets.Execute(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/tools/downloadassets/download.go
+++ b/tools/downloadassets/download.go
@@ -1,0 +1,269 @@
+package downloadassets
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	checksumName     = "SHASUMS256.txt"
+	defaultTimeout   = 10 * time.Minute
+	githubReleaseURL = "https://github.com/aliyun/aliyun-cli/releases/download/v"
+)
+
+// AssetNames is the release set finish_release.sh promotes. Order is stable
+// so a regenerated checksum file does not reshuffle on rerun.
+func AssetNames(version string) []string {
+	return []string{
+		fmt.Sprintf("aliyun-cli-macosx-%s-amd64.tgz", version),
+		fmt.Sprintf("aliyun-cli-macosx-%s-arm64.tgz", version),
+		fmt.Sprintf("aliyun-cli-%s.pkg", version),
+		fmt.Sprintf("aliyun-cli-macosx-%s-universal.tgz", version),
+		fmt.Sprintf("aliyun-cli-linux-%s-amd64.tgz", version),
+		fmt.Sprintf("aliyun-cli-linux-%s-arm64.tgz", version),
+		fmt.Sprintf("aliyun-cli-windows-%s-amd64.zip", version),
+	}
+}
+
+// Options controls a download. Tests inject Client and Summer so HTTP and
+// checksum failures never depend on the network or the shasum binary.
+type Options struct {
+	Version string
+	BaseURL string
+	Token   string
+	WorkDir string
+	Client  *http.Client
+	Summer  func(path string) (string, error)
+	Timeout time.Duration
+}
+
+// Download fetches every expected asset into a temp directory, writes a new
+// checksum file there, and replaces the workdir copies only after the set is
+// complete. A failure leaves any existing SHASUMS256.txt untouched.
+func Download(ctx context.Context, opt Options) error {
+	version, err := cleanVersion(opt.Version)
+	if err != nil {
+		return err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	workDir := opt.WorkDir
+	if workDir == "" {
+		workDir = "."
+	}
+	info, err := os.Stat(workDir)
+	if err != nil {
+		return fmt.Errorf("download assets: workdir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("download assets: workdir is not a directory: %s", workDir)
+	}
+
+	names := AssetNames(version)
+	base := strings.TrimRight(opt.BaseURL, "/")
+	if base == "" {
+		base = githubReleaseURL + version
+	}
+	timeout := opt.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	client := opt.Client
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	summer := opt.Summer
+	if summer == nil {
+		summer = sha256File
+	}
+
+	staging, err := os.MkdirTemp(workDir, ".download-assets-")
+	if err != nil {
+		return fmt.Errorf("download assets: temp dir: %w", err)
+	}
+	defer os.RemoveAll(staging)
+
+	sums := make([]string, 0, len(names))
+	for _, name := range names {
+		dest := filepath.Join(staging, name)
+		assetURL := base + "/" + name
+		if err := downloadFile(ctx, client, assetURL, opt.Token, dest, timeout); err != nil {
+			return fmt.Errorf("download assets: %s: %w", name, err)
+		}
+		if err := ensureAsset(dest); err != nil {
+			return fmt.Errorf("download assets: %s: %w", name, err)
+		}
+		digest, err := summer(dest)
+		if err != nil {
+			return fmt.Errorf("download assets: checksum %s: %w", name, err)
+		}
+		line, err := checksumLine(digest, name)
+		if err != nil {
+			return fmt.Errorf("download assets: checksum %s: %w", name, err)
+		}
+		sums = append(sums, line)
+	}
+
+	sumPath := filepath.Join(staging, checksumName)
+	body := strings.Join(sums, "\n") + "\n"
+	if err := os.WriteFile(sumPath, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("download assets: write checksum: %w", err)
+	}
+	if err := verifyChecksum(body, names); err != nil {
+		return err
+	}
+
+	if err := commitAssets(staging, workDir, names); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanVersion(version string) (string, error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "", fmt.Errorf("download assets: version is required")
+	}
+	if strings.Contains(version, "/") || strings.Contains(version, "\\") || strings.Contains(version, "..") {
+		return "", fmt.Errorf("download assets: invalid version %q", version)
+	}
+	return version, nil
+}
+
+func downloadFile(ctx context.Context, client *http.Client, assetURL, token, dest string, timeout time.Duration) error {
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, assetURL, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	n, copyErr := io.Copy(f, resp.Body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if n == 0 {
+		return fmt.Errorf("missing or empty asset")
+	}
+	return nil
+}
+
+func ensureAsset(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("missing asset")
+		}
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		return fmt.Errorf("missing or empty asset")
+	}
+	return nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func checksumLine(digest, name string) (string, error) {
+	digest = strings.TrimSpace(digest)
+	if len(digest) != 64 || !isHex(digest) {
+		return "", fmt.Errorf("invalid digest %q", digest)
+	}
+	if name == "" || strings.ContainsAny(name, "\r\n") {
+		return "", fmt.Errorf("invalid asset name %q", name)
+	}
+	// Two spaces matches `shasum -a 256`, so `shasum -c SHASUMS256.txt` works.
+	return digest + "  " + name, nil
+}
+
+func verifyChecksum(body string, names []string) error {
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	if len(lines) != len(names) {
+		return fmt.Errorf("download assets: checksum count %d != %d", len(lines), len(names))
+	}
+	seen := make(map[string]struct{}, len(names))
+	for i, line := range lines {
+		hash, name, ok := strings.Cut(line, "  ")
+		if !ok || len(hash) != 64 || !isHex(hash) || name != names[i] {
+			return fmt.Errorf("download assets: checksum line %d does not match %s", i+1, names[i])
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("download assets: duplicate checksum for %s", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+func commitAssets(staging, workDir string, names []string) error {
+	for _, name := range names {
+		if err := replaceFile(filepath.Join(staging, name), filepath.Join(workDir, name)); err != nil {
+			return fmt.Errorf("download assets: commit %s: %w", name, err)
+		}
+	}
+	if err := replaceFile(filepath.Join(staging, checksumName), filepath.Join(workDir, checksumName)); err != nil {
+		return fmt.Errorf("download assets: commit checksum: %w", err)
+	}
+	return nil
+}
+
+func replaceFile(src, dst string) error {
+	// Staging lives inside the workdir, so rename stays on one filesystem
+	// and replaces any previous asset without appending.
+	return os.Rename(src, dst)
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/tools/downloadassets/download_test.go
+++ b/tools/downloadassets/download_test.go
@@ -1,0 +1,356 @@
+package downloadassets
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestDownloadSuccessAndRerunReplacesChecksum(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		if !strings.Contains(name, "1.2.3") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("asset-" + filepath.Base(name)))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	stale := filepath.Join(dir, checksumName)
+	if err := os.WriteFile(stale, []byte("oldhash  leftover\noldhash  leftover\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opt := Options{
+		Version: "1.2.3",
+		BaseURL: srv.URL,
+		Token:   "test-token",
+		WorkDir: dir,
+	}
+	if err := Download(context.Background(), opt); err != nil {
+		t.Fatal(err)
+	}
+	if seenAuth != "Bearer test-token" {
+		t.Fatalf("auth header = %q", seenAuth)
+	}
+
+	first := mustRead(t, stale)
+	names := AssetNames("1.2.3")
+	assertFreshChecksum(t, dir, names, first)
+
+	if err := Download(context.Background(), opt); err != nil {
+		t.Fatal(err)
+	}
+	second := mustRead(t, stale)
+	if first != second {
+		t.Fatalf("rerun changed checksum\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if strings.Contains(second, "leftover") {
+		t.Fatalf("rerun kept stale checksum lines:\n%s", second)
+	}
+	if strings.Count(second, names[0]) != 1 {
+		t.Fatalf("rerun duplicated %s:\n%s", names[0], second)
+	}
+}
+
+func TestDownloadHTTP404DoesNotCommitChecksum(t *testing.T) {
+	names := AssetNames("1.2.3")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, names[2]) {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	stale := []byte("stale  keep-me\n")
+	if err := os.WriteFile(filepath.Join(dir, checksumName), stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Download(context.Background(), Options{Version: "1.2.3", BaseURL: srv.URL, WorkDir: dir})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 404") {
+		t.Fatalf("expected 404, got %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, checksumName)); got != string(stale) {
+		t.Fatalf("failure replaced checksum:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, names[0])); !os.IsNotExist(err) {
+		t.Fatal("partial asset was committed after 404")
+	}
+}
+
+func TestDownloadTimeoutDoesNotCommitChecksum(t *testing.T) {
+	dir := t.TempDir()
+	err := Download(context.Background(), Options{
+		Version: "1.2.3",
+		BaseURL: "http://download-assets.invalid",
+		WorkDir: dir,
+		Timeout: 30 * time.Millisecond,
+		Client: &http.Client{
+			Timeout: 30 * time.Millisecond,
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				<-r.Context().Done()
+				return nil, r.Context().Err()
+			}),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected timeout, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, checksumName)); !os.IsNotExist(statErr) {
+		t.Fatal("timeout wrote checksum")
+	}
+}
+
+func TestDownloadEmptyAssetIsMissing(t *testing.T) {
+	names := AssetNames("1.2.3")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, names[1]) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := Download(context.Background(), Options{Version: "1.2.3", BaseURL: srv.URL, WorkDir: dir})
+	if err == nil || !strings.Contains(err.Error(), "missing or empty") {
+		t.Fatalf("expected empty asset failure, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, checksumName)); !os.IsNotExist(statErr) {
+		t.Fatal("empty asset wrote checksum")
+	}
+}
+
+func TestDownloadChecksumFailureDoesNotCommit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := Download(context.Background(), Options{
+		Version: "1.2.3",
+		BaseURL: srv.URL,
+		WorkDir: dir,
+		Summer: func(path string) (string, error) {
+			return "", errors.New("shasum failed")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("expected checksum failure, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, checksumName)); !os.IsNotExist(statErr) {
+		t.Fatal("checksum tool failure wrote SHASUMS256.txt")
+	}
+}
+
+func TestDownloadDefaultsAndDirectFailures(t *testing.T) {
+	dir := t.TempDir()
+	var gotURL string
+	err := Download(nil, Options{
+		Version: "1.2.3",
+		WorkDir: dir,
+		Client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotURL = r.URL.String()
+			return nil, errors.New("stopped")
+		})},
+	})
+	if err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("expected default URL failure, got %v", err)
+	}
+	if !strings.Contains(gotURL, "https://github.com/aliyun/aliyun-cli/releases/download/v1.2.3/") {
+		t.Fatalf("default URL = %s", gotURL)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, checksumName)); !os.IsNotExist(statErr) {
+		t.Fatal("default URL failure wrote checksum")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	err = Download(nil, Options{
+		Version: " 1.2.3 ",
+		Client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, errors.New("stopped")
+		})},
+	})
+	if err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("expected empty workdir failure, got %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := downloadFile(context.Background(), http.DefaultClient, "://bad", "", filepath.Join(dir, "x"), time.Second); err == nil {
+		t.Fatal("expected invalid URL")
+	}
+	dest := filepath.Join(dir, "exists.tgz")
+	if err := os.WriteFile(dest, []byte("already"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("body")), Header: make(http.Header)}
+	err = downloadFile(context.Background(), &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return resp, nil
+	})}, "http://example.invalid/a.tgz", "", dest, time.Second)
+	if err == nil {
+		t.Fatal("expected existing dest to fail")
+	}
+
+	err = downloadFile(context.Background(), &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(errReader{}), Header: make(http.Header)}, nil
+	})}, "http://example.invalid/a.tgz", "", filepath.Join(dir, "copy-fail.tgz"), time.Second)
+	if err == nil || !strings.Contains(err.Error(), "read failed") {
+		t.Fatalf("expected copy failure, got %v", err)
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func TestDownloadRejectsBadInput(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cases := []Options{
+		{Version: ""},
+		{Version: "../1.2.3", WorkDir: dir},
+		{Version: "1.2.3/evil", WorkDir: dir},
+		{Version: `1.2.3\evil`, WorkDir: dir},
+		{Version: "1.2.3", WorkDir: filepath.Join(dir, "missing")},
+		{Version: "1.2.3", WorkDir: file},
+	}
+	for _, opt := range cases {
+		if err := Download(context.Background(), opt); err == nil {
+			t.Fatalf("expected error for %+v", opt)
+		}
+	}
+}
+
+func TestChecksumHelpers(t *testing.T) {
+	if _, err := checksumLine("abc", "a.tgz"); err == nil {
+		t.Fatal("expected invalid digest")
+	}
+	if _, err := checksumLine(strings.Repeat("AB", 32), "a.tgz"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := checksumLine(strings.Repeat("ab", 32), "bad\nname"); err == nil {
+		t.Fatal("expected newline in name to fail")
+	}
+	if _, err := checksumLine(strings.Repeat("ab", 32), ""); err == nil {
+		t.Fatal("expected invalid name")
+	}
+	names := AssetNames("1.2.3")
+	if err := verifyChecksum("", names); err == nil {
+		t.Fatal("expected empty checksum to fail")
+	}
+	line, err := checksumLine(strings.Repeat("ab", 32), names[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := line + "\n" + line + "\n"
+	if err := verifyChecksum(body, []string{names[0], names[0]}); err == nil {
+		t.Fatal("expected duplicate checksum to fail")
+	}
+	if err := verifyChecksum("not-a-digest  "+names[0]+"\n", []string{names[0]}); err == nil {
+		t.Fatal("expected malformed line to fail")
+	}
+
+	missing := filepath.Join(t.TempDir(), "gone.tgz")
+	if err := ensureAsset(missing); err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected missing asset, got %v", err)
+	}
+	dir := t.TempDir()
+	if err := ensureAsset(dir); err == nil {
+		t.Fatal("expected directory to be rejected")
+	}
+	empty := filepath.Join(t.TempDir(), "empty.tgz")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureAsset(empty); err == nil {
+		t.Fatal("expected empty file to be rejected")
+	}
+	if _, err := sha256File(missing); err == nil {
+		t.Fatal("expected sha256 of missing file to fail")
+	}
+	sum, err := sha256File(empty)
+	if err != nil || len(sum) != 64 {
+		t.Fatalf("empty file sum = %q err=%v", sum, err)
+	}
+}
+
+func TestDownloadInvalidDigestDoesNotCommit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := Download(context.Background(), Options{
+		Version: "1.2.3",
+		BaseURL: srv.URL,
+		WorkDir: dir,
+		Summer:  func(path string) (string, error) { return "nope", nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid digest") {
+		t.Fatalf("expected invalid digest, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, checksumName)); !os.IsNotExist(statErr) {
+		t.Fatal("invalid digest committed checksum")
+	}
+}
+
+func assertFreshChecksum(t *testing.T, dir string, names []string, body string) {
+	t.Helper()
+	if err := verifyChecksum(body, names); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil || info.Size() == 0 {
+			t.Fatalf("asset %s missing after success: %v", name, err)
+		}
+		if strings.Count(body, name) != 1 {
+			t.Fatalf("checksum listing for %s is not unique:\n%s", name, body)
+		}
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Summary

- Fail the release asset download if any fetch, empty file, or checksum step fails, instead of exiting 0.
- Write a new checksum file only after every expected asset is present, so a rerun does not keep stale or duplicate lines.
- Stop the finish-release job before upload and promotion when the download script exits non-zero.