### PR TITLE
fix(plugin): dispatch newly installed meta plugins in-process

### DIFF
--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -65,6 +65,12 @@ var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*respons
 
 var runtimeTryDispatch = runtimehost.TryDispatch
 
+var runtimeDispatch = runtimehost.Dispatch
+
+var installPluginForCommand = func(c *Commando, ctx *cli.Context, commandName, productCode string) (string, error) {
+	return c.findAndInstallPlugin(ctx, commandName, productCode)
+}
+
 var agentErrorNormalizer = normalizeAgentError
 
 var agentErrorNormalizerWithSearch = normalizeAgentErrorWithSearch
@@ -538,21 +544,8 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			//   - not installed but the engine resolves it (baseline / user meta plugin) -> aliyun-openapi-runtime engine.
 			//     Products marked distribution=="go" are abstained by the engine so they still reach auto-install.
 			if installed {
-				if ptype, ok := plugin.InstalledPluginType(args[0]); ok && ptype == plugin.PluginTypeMeta {
-					if err := plugin.ValidatePluginCliVersion(args[0]); err != nil {
-						return err
-					}
-					// Meta plugins have no executable in which to register the package-level version command.
-					// Read it from the installed manifest instead of forwarding "version" to the OpenAPI runtime as an API name.
-					if apiOrMethod == "version" {
-						name, version, err := plugin.InstalledPluginPackageVersion(args[0])
-						if err != nil {
-							return err
-						}
-						cli.Printf(ctx.Stdout(), "%s %s\n", name, version)
-						return nil
-					}
-					return c.adaptEngineUnknownCommand(runtimehost.Dispatch(ctx, pluginArgs))
+				if handled, dispatchErr := c.dispatchInstalledMetaPlugin(ctx, args[0], apiOrMethod, pluginArgs); handled {
+					return dispatchErr
 				}
 			} else {
 				if validationErr := c.validateCanonicalRuntimeCommand(args, ctx); validationErr != nil {
@@ -575,7 +568,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				commandName := buildCommandName(args)
 				// fmt.Println("commandName", commandName, pluginArgs)
 
-				foundPluginName, err := c.findAndInstallPlugin(ctx, commandName, args[0])
+				foundPluginName, err := installPluginForCommand(c, ctx, commandName, args[0])
 				if err != nil {
 					return err
 				}
@@ -605,6 +598,12 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 					return &InvalidProductOrPluginError{Code: args[0], library: c.library, plugins: plugins}
 				}
 				pluginName = foundPluginName
+
+				// Installation may have added a metadata-only plugin.
+				// Re-evaluate its type in the same invocation instead of falling through to the Go-plugin executor, which would look for a non-existent binary.
+				if handled, dispatchErr := c.dispatchInstalledMetaPlugin(ctx, args[0], apiOrMethod, pluginArgs); handled {
+					return dispatchErr
+				}
 			}
 
 			// Prepare config related env for plugin
@@ -831,6 +830,28 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		return cli.NewErrorWithTip(fmt.Errorf("too many arguments"),
 			"Use `aliyun --help` to show usage")
 	}
+}
+
+// dispatchInstalledMetaPlugin routes an installed metadata plugin through the in-process OpenAPI runtime.
+// It returns handled=false for Go plugins so the caller can continue to the external binary execution path.
+func (c *Commando) dispatchInstalledMetaPlugin(ctx *cli.Context, productCode, apiOrMethod string, pluginArgs []string) (bool, error) {
+	ptype, ok := plugin.InstalledPluginType(productCode)
+	if !ok || ptype != plugin.PluginTypeMeta {
+		return false, nil
+	}
+	if err := plugin.ValidatePluginCliVersion(productCode); err != nil {
+		return true, err
+	}
+	// Meta plugins have no executable in which to register the package-level version command. Read it from the installed manifest instead.
+	if apiOrMethod == "version" {
+		name, version, err := plugin.InstalledPluginPackageVersion(productCode)
+		if err != nil {
+			return true, err
+		}
+		cli.Printf(ctx.Stdout(), "%s %s\n", name, version)
+		return true, nil
+	}
+	return true, c.adaptEngineUnknownCommand(runtimeDispatch(ctx, pluginArgs))
 }
 
 func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api *canonicalmeta.API, method string, path string) error {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -2807,6 +2807,62 @@ func TestMain_UninstalledPluginAlwaysTriesBuiltInRuntime(t *testing.T) {
 	assert.ErrorIs(t, err, wantErr)
 }
 
+func TestMain_AutoInstalledMetaPluginDispatchesWithoutBinary(t *testing.T) {
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+	writeMinimalConfigJSON(t, testHome)
+	pluginRoot := filepath.Join(testHome, ".aliyun", "plugins")
+	assert.NoError(t, os.MkdirAll(pluginRoot, 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(pluginRoot, "manifest.json"), []byte(`{"plugins":{}}`), 0644))
+
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	repo, err := meta.MockLoadRepository(nil)
+	assert.NoError(t, err)
+	command := &Commando{library: &Library{builtinRepo: repo, writer: w}}
+	cmd := &cli.Command{EnableUnknownFlag: true}
+	command.InitWithCommand(cmd)
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	originalTryDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		return false, nil
+	}
+	t.Cleanup(func() { runtimeTryDispatch = originalTryDispatch })
+
+	originalInstall := installPluginForCommand
+	installPluginForCommand = func(_ *Commando, _ *cli.Context, commandName, productCode string) (string, error) {
+		assert.Equal(t, "bssopenapi create-instance", commandName)
+		assert.Equal(t, "bssopenapi", productCode)
+		pluginDir := filepath.Join(pluginRoot, "aliyun-cli-bssopenapi")
+		assert.NoError(t, os.MkdirAll(pluginDir, 0755))
+		manifest := fmt.Sprintf(`{"plugins":{"aliyun-cli-bssopenapi":{"name":"aliyun-cli-bssopenapi","version":"0.9.0","type":"meta","path":%q,"command":"bssopenapi"}}}`, pluginDir)
+		assert.NoError(t, os.WriteFile(filepath.Join(pluginRoot, "manifest.json"), []byte(manifest), 0644))
+		return "aliyun-cli-bssopenapi", nil
+	}
+	t.Cleanup(func() { installPluginForCommand = originalInstall })
+
+	wantErr := errors.New("metadata runtime invoked")
+	originalDispatch := runtimeDispatch
+	runtimeDispatch = func(_ *cli.Context, got []string) error {
+		assert.Equal(t, []string{"bssopenapi", "create-instance", "--product-code", "kms"}, got)
+		return wantErr
+	}
+	t.Cleanup(func() { runtimeDispatch = originalDispatch })
+
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"aliyun", "bssopenapi", "create-instance", "--product-code", "kms"}
+
+	err = command.main(ctx, []string{"bssopenapi", "create-instance"})
+	assert.ErrorIs(t, err, wantErr)
+	assert.NotContains(t, err.Error(), "plugin binary")
+}
+
 func TestMain_InstalledGoPluginOverridesBuiltInRuntime(t *testing.T) {
 	testHome := t.TempDir()
 	cleanup := setTestHomeDir(t, testHome)


### PR DESCRIPTION
Re-check the plugin type after auto-installing a plugin and route metadata plugins through aliyun-openapi-runtime in the same invocation.

This prevents metadata-only plugins from falling through to the Go plugin executor and failing with a missing binary error. Preserve the existing external binary path for Go plugins and add regression coverage for the first-run auto-install flow.