### PR TITLE
Fix dry-run body redaction

### DIFF
--- a/aliyun-openapi-runtime/engine/builder.go
+++ b/aliyun-openapi-runtime/engine/builder.go
@@ -709,25 +709,21 @@ func dryRunBody(body any, reqBodyType string, formatHints ...string) (value, for
 	if len(formatHints) > 0 {
 		declaredFormat = formatHints[0]
 	}
-	rawFormats := append([]string{reqBodyType}, formatHints...)
+	formats := append([]string{reqBodyType}, formatHints...)
 	if data, ok := body.(string); ok {
 		format = dryRunBodyFormat(reqBodyType, declaredFormat, "raw")
-		return redact.MaskBodyForDryRun(data, rawFormats...), format, nil
+		return redact.MaskBodyFull(data, formats...), format, nil
 	}
 	if data, ok := body.([]byte); ok {
 		format = dryRunBodyFormat(reqBodyType, declaredFormat, "binary")
-		return redact.MaskBodyForDryRun(string(data), rawFormats...), format, nil
+		return redact.MaskBodyFull(string(data), formats...), format, nil
 	}
 	b, err := json.Marshal(body)
 	if err != nil {
 		return "", "", err
 	}
-	structuredFormats := []string{reqBodyType}
-	if declaredFormat != "" {
-		structuredFormats = append(structuredFormats, declaredFormat)
-	}
 	format = dryRunBodyFormat(reqBodyType, declaredFormat, "json")
-	return redact.MaskBodyForDryRun(string(b), structuredFormats...), format, nil
+	return redact.MaskBodyFull(string(b), formats...), format, nil
 }
 
 func dryRunBodyFormat(reqBodyType, declaredFormat, fallback string) string {
@@ -789,11 +785,11 @@ func renderDryRun(w io.Writer, product string, req *runtime.AssembledRequest, js
 	if req == nil {
 		return fmt.Errorf("dry-run produced no request")
 	}
+	output, err := buildCliDryRunOutput(product, req)
+	if err != nil {
+		return err
+	}
 	if jsonMeta {
-		output, err := buildCliDryRunOutput(product, req)
-		if err != nil {
-			return err
-		}
 		b, err := json.Marshal(output)
 		if err != nil {
 			return err
@@ -824,17 +820,7 @@ func renderDryRun(w io.Writer, product string, req *runtime.AssembledRequest, js
 	printSortedKV(w, "Headers", req.Headers)
 	printSortedKV(w, "Query Parameters", req.Query)
 	if req.Body != nil {
-		body, _, err := dryRunBody(
-			req.Body,
-			req.ReqBodyType,
-			req.DeclaredReqBodyType,
-			req.DeclaredContentType,
-			dryRunHeaderValue(req.Headers, "Content-Type"),
-		)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(w, "Body:\n  %s\n", body)
+		fmt.Fprintf(w, "Body:\n  %s\n", output.Body)
 	}
 	fmt.Fprintf(w, "%s\nRequest NOT sent (dry-run mode)\n%s\n", bar, bar)
 	fmt.Fprintln(w, "{")

--- a/aliyun-openapi-runtime/engine/builder.go
+++ b/aliyun-openapi-runtime/engine/builder.go
@@ -692,43 +692,70 @@ func sanitizeDryRunValues(values map[string]string) map[string]string {
 	return out
 }
 
-func dryRunBody(body any, reqBodyType string) (value, format string, err error) {
+func dryRunHeaderValue(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}
+
+func dryRunBody(body any, reqBodyType string, formatHints ...string) (value, format string, err error) {
 	if body == nil {
 		return "", "", nil
 	}
+	declaredFormat := ""
+	if len(formatHints) > 0 {
+		declaredFormat = formatHints[0]
+	}
+	rawFormats := append([]string{reqBodyType}, formatHints...)
 	if data, ok := body.(string); ok {
-		format = reqBodyType
-		if format == "" {
-			format = "raw"
-		}
-		if strings.EqualFold(format, "formData") {
-			format = "form"
-		}
-		return redact.MaskBodyFull(data), format, nil
+		format = dryRunBodyFormat(reqBodyType, declaredFormat, "raw")
+		return redact.MaskBodyForDryRun(data, rawFormats...), format, nil
 	}
 	if data, ok := body.([]byte); ok {
-		format = reqBodyType
-		if format == "" {
-			format = "binary"
-		}
-		if strings.EqualFold(format, "formData") {
-			format = "form"
-		}
-		return redact.MaskBodyFull(string(data)), format, nil
+		format = dryRunBodyFormat(reqBodyType, declaredFormat, "binary")
+		return redact.MaskBodyForDryRun(string(data), rawFormats...), format, nil
 	}
-	b, err := json.Marshal(redact.MaskAny(body))
+	b, err := json.Marshal(body)
 	if err != nil {
 		return "", "", err
 	}
-	format = "json"
-	if strings.EqualFold(reqBodyType, "formData") {
-		format = "form"
+	structuredFormats := []string{reqBodyType}
+	if declaredFormat != "" {
+		structuredFormats = append(structuredFormats, declaredFormat)
 	}
-	return string(b), format, nil
+	format = dryRunBodyFormat(reqBodyType, declaredFormat, "json")
+	return redact.MaskBodyForDryRun(string(b), structuredFormats...), format, nil
+}
+
+func dryRunBodyFormat(reqBodyType, declaredFormat, fallback string) string {
+	format := strings.TrimSpace(declaredFormat)
+	if format == "" {
+		format = strings.TrimSpace(reqBodyType)
+	}
+	if format == "" {
+		format = fallback
+	}
+	switch {
+	case strings.EqualFold(format, "formData"):
+		return "form"
+	case strings.EqualFold(format, "byte"), strings.EqualFold(format, "bytes"), strings.EqualFold(format, "binary"):
+		return "binary"
+	default:
+		return format
+	}
 }
 
 func buildCliDryRunOutput(product string, req *runtime.AssembledRequest) (*cliDryRunOutput, error) {
-	body, bodyFormat, err := dryRunBody(req.Body, req.ReqBodyType)
+	body, bodyFormat, err := dryRunBody(
+		req.Body,
+		req.ReqBodyType,
+		req.DeclaredReqBodyType,
+		req.DeclaredContentType,
+		dryRunHeaderValue(req.Headers, "Content-Type"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -797,16 +824,17 @@ func renderDryRun(w io.Writer, product string, req *runtime.AssembledRequest, js
 	printSortedKV(w, "Headers", req.Headers)
 	printSortedKV(w, "Query Parameters", req.Query)
 	if req.Body != nil {
-		switch body := req.Body.(type) {
-		case string:
-			// Raw --body/--body-file strings are sent as-is by the SDK.
-			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBodyFull(body))
-		case []byte:
-			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBodyFull(string(body)))
-		default:
-			b, _ := json.Marshal(redact.MaskAny(req.Body))
-			fmt.Fprintf(w, "Body:\n  %s\n", string(b))
+		body, _, err := dryRunBody(
+			req.Body,
+			req.ReqBodyType,
+			req.DeclaredReqBodyType,
+			req.DeclaredContentType,
+			dryRunHeaderValue(req.Headers, "Content-Type"),
+		)
+		if err != nil {
+			return err
 		}
+		fmt.Fprintf(w, "Body:\n  %s\n", body)
 	}
 	fmt.Fprintf(w, "%s\nRequest NOT sent (dry-run mode)\n%s\n", bar, bar)
 	fmt.Fprintln(w, "{")

--- a/aliyun-openapi-runtime/engine/builder_additional_test.go
+++ b/aliyun-openapi-runtime/engine/builder_additional_test.go
@@ -496,7 +496,7 @@ func TestBuilderOptionAndRenderingHelpers(t *testing.T) {
 	}
 }
 
-func TestDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
+func TestDryRunPreservesLongBodyAndRedaction(t *testing.T) {
 	const secret = "FAKE_SECRET_123"
 	text := strings.Repeat("流水线", 450) + "正文末尾"
 	for _, tc := range []struct {
@@ -507,13 +507,14 @@ func TestDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
 		{
 			"form",
 			"name=" + text + "&password=" + secret,
-			fmt.Sprintf("[body omitted: %d bytes]", len("name="+text+"&password="+secret)),
+			"name=" + text + "&password=FAKE%2A%2A%2A",
 		},
 		{
 			"xml",
 			"<Name>" + text + "</Name><Password>" + secret + "</Password>",
 			fmt.Sprintf("[body omitted: %d bytes]", len("<Name>"+text+"</Name><Password>"+secret+"</Password>")),
 		},
+		{"raw", "name: " + text + "\npassword: " + secret, "name: " + text + "\npassword: ***"},
 		{
 			"json",
 			`{"content":"` + text + `","password":"` + secret + `"}`,
@@ -591,6 +592,46 @@ func TestDryRunOmitsExplicitBinaryEvenWhenBodyIsJSON(t *testing.T) {
 				t.Fatal("dry-run mutated binary request body")
 			}
 		})
+	}
+}
+
+func TestDryRunNestedForm(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	req, err := runtime.Assemble(&runtime.ExecContext{
+		API: &meta.API{Name: "Submit", ReqBodyType: "formData", Parameters: []meta.Parameter{
+			{Name: "config", RawName: "config", Type: meta.TypeObject, Position: meta.PosFormData, ParamStyle: "json"},
+		}},
+		Args: map[string]any{"config": map[string]any{"name": "alice", "password": secret}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range []any{req.Body, map[string]any{"user.password.1": secret, "user.name": "alice"}} {
+		req.Body = body
+		before, _ := json.Marshal(body)
+		for _, jsonOutput := range []bool{false, true} {
+			var out bytes.Buffer
+			if err := renderDryRun(&out, "demo", req, jsonOutput, false); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(out.String(), secret) || !strings.Contains(out.String(), "alice") || !strings.Contains(out.String(), "FAKE***") {
+				t.Fatalf("incorrect nested form redaction: %s", out.String())
+			}
+			if strings.Contains(out.String(), "DeclaredReqBodyType") || strings.Contains(out.String(), "DeclaredContentType") {
+				t.Fatal("internal format hints must not be printed")
+			}
+		}
+		after, _ := json.Marshal(body)
+		if !bytes.Equal(before, after) {
+			t.Fatal("dry-run mutated the form request")
+		}
+	}
+	// Structured bodies must also honor all declared formats, not just ReqBodyType.
+	req.DeclaredContentType = "application/octet-stream"
+	bodyJSON, _ := json.Marshal(req.Body)
+	out, err := buildCliDryRunOutput("demo", req)
+	if err != nil || out.Body != fmt.Sprintf("[body omitted: %d bytes]", len(bodyJSON)) {
+		t.Fatalf("lost binary format hint for structured body: %+v, %v", out, err)
 	}
 }
 
@@ -684,5 +725,42 @@ func TestBuilderErrorAndRenderBranches(t *testing.T) {
 	}
 	if err := writeJSON(io.Discard, make(chan int), nil, "filtered", false); err == nil {
 		t.Fatal("writeJSON accepted channel")
+	}
+}
+
+func TestDryRunExplicitBodyFormats(t *testing.T) {
+	const body = `<Request><Name>visible</Name><Password>FAKE_SECRET_123</Password></Request>`
+	for _, tc := range []struct {
+		name string
+		req  runtime.AssembledRequest
+		want string
+	}{
+		{"XML", runtime.AssembledRequest{Headers: map[string]string{"Content-Type": "application/xml"}}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"binary", runtime.AssembledRequest{ReqBodyType: "binary"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"declared binary", runtime.AssembledRequest{ReqBodyType: "json", DeclaredReqBodyType: "byte"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"declared content type", runtime.AssembledRequest{DeclaredContentType: "application/octet-stream"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"unknown content type", runtime.AssembledRequest{ReqBodyType: "json", DeclaredContentType: "application/x-custom-format"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"header", runtime.AssembledRequest{Headers: map[string]string{"cOnTeNt-TyPe": "application/octet-stream"}}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.req.Body = []byte(body)
+			for _, jsonOutput := range []bool{false, true} {
+				var out bytes.Buffer
+				if err := renderDryRun(&out, "demo", &tc.req, jsonOutput, false); err != nil {
+					t.Fatal(err)
+				}
+				if jsonOutput {
+					var decoded cliDryRunOutput
+					if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
+						t.Fatalf("body = %q, err = %v", decoded.Body, err)
+					}
+				} else if !strings.Contains(out.String(), tc.want) {
+					t.Fatalf("unexpected text output: %s", &out)
+				}
+				if strings.Contains(out.String(), "FAKE_SECRET_123") || string(tc.req.Body.([]byte)) != body {
+					t.Fatal("dry-run leaked a secret or changed the request body")
+				}
+			}
+		})
 	}
 }

--- a/aliyun-openapi-runtime/engine/builder_additional_test.go
+++ b/aliyun-openapi-runtime/engine/builder_additional_test.go
@@ -507,7 +507,7 @@ func TestDryRunPreservesLongBodyAndRedaction(t *testing.T) {
 		{
 			"form",
 			"name=" + text + "&password=" + secret,
-			"name=" + text + "&password=FAKE%2A%2A%2A",
+			"name=" + text + "&password=FAKE***",
 		},
 		{
 			"xml",

--- a/aliyun-openapi-runtime/engine/builder_additional_test.go
+++ b/aliyun-openapi-runtime/engine/builder_additional_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -495,32 +496,101 @@ func TestBuilderOptionAndRenderingHelpers(t *testing.T) {
 	}
 }
 
-func TestDryRunPreservesLongBodyAndRedaction(t *testing.T) {
+func TestDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
 	text := strings.Repeat("流水线", 450) + "正文末尾"
-	for _, tc := range []struct{ body, want string }{
-		{"name=" + text + "&pipelineId=123", "name=" + text + "&pipelineId=123"},
-		{`{"content":"` + text + `","password":"secret-value"}`, `{"content":"` + text + `","password":"secr***"}`},
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"form",
+			"name=" + text + "&password=" + secret,
+			fmt.Sprintf("[body omitted: %d bytes]", len("name="+text+"&password="+secret)),
+		},
+		{
+			"xml",
+			"<Name>" + text + "</Name><Password>" + secret + "</Password>",
+			fmt.Sprintf("[body omitted: %d bytes]", len("<Name>"+text+"</Name><Password>"+secret+"</Password>")),
+		},
+		{
+			"json",
+			`{"content":"` + text + `","password":"` + secret + `"}`,
+			`{"content":"` + text + `","password":"FAKE***"}`,
+		},
 	} {
-		for _, body := range []any{tc.body, []byte(tc.body)} {
-			value, _, err := dryRunBody(body, "raw")
-			if err != nil || value != tc.want {
-				t.Fatalf("dryRunBody(%T) lost body content or redaction: %v", body, err)
+		t.Run(tc.name, func(t *testing.T) {
+			for _, body := range []any{tc.body, []byte(tc.body)} {
+				value, _, err := dryRunBody(body, "raw")
+				if err != nil || value != tc.want {
+					t.Fatalf("dryRunBody(%T) = %q, %v; want %q", body, value, err, tc.want)
+				}
+				for _, jsonOutput := range []bool{false, true} {
+					var out bytes.Buffer
+					if err := renderDryRun(&out, "demo", &runtime.AssembledRequest{Body: body}, jsonOutput, false); err != nil {
+						t.Fatal(err)
+					}
+					if strings.Contains(out.String(), secret) {
+						t.Fatalf("secret leaked from %T dry-run output: %s", body, out.String())
+					}
+					if jsonOutput {
+						var decoded cliDryRunOutput
+						if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
+							t.Fatalf("JSON dry-run body = %q, %v; want %q", decoded.Body, err, tc.want)
+						}
+					} else if !strings.Contains(out.String(), tc.want) {
+						t.Fatalf("text dry-run body missing %q", tc.want)
+					}
+				}
+				if data, ok := body.([]byte); ok && string(data) != tc.body {
+					t.Fatal("dry-run mutated byte body")
+				}
+			}
+		})
+	}
+}
+
+func TestDryRunOmitsExplicitBinaryEvenWhenBodyIsJSON(t *testing.T) {
+	const body = `{"password":"FAKE_SECRET_123"}`
+	want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+	for name, req := range map[string]*runtime.AssembledRequest{
+		"metadata": {
+			Body:                []byte(body),
+			ReqBodyType:         "json",
+			DeclaredReqBodyType: "byte",
+			DeclaredContentType: "application/octet-stream",
+		},
+		"header": {
+			Body:        []byte(body),
+			ReqBodyType: "json",
+			Headers:     map[string]string{"Content-Type": "application/octet-stream"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			value, _, err := dryRunBody(
+				req.Body,
+				req.ReqBodyType,
+				req.DeclaredReqBodyType,
+				req.DeclaredContentType,
+				dryRunHeaderValue(req.Headers, "Content-Type"),
+			)
+			if err != nil || value != want {
+				t.Fatalf("dryRunBody(binary) = %q, %v; want %q", value, err, want)
 			}
 			for _, jsonOutput := range []bool{false, true} {
 				var out bytes.Buffer
-				if err := renderDryRun(&out, "demo", &runtime.AssembledRequest{Body: body}, jsonOutput, false); err != nil {
+				if err := renderDryRun(&out, "demo", req, jsonOutput, false); err != nil {
 					t.Fatal(err)
 				}
-				if jsonOutput {
-					var decoded cliDryRunOutput
-					if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
-						t.Fatalf("JSON dry-run lost body content or redaction: %v", err)
-					}
-				} else if !strings.Contains(out.String(), tc.want) {
-					t.Fatal("text dry-run lost body content or redaction")
+				if strings.Contains(out.String(), "FAKE_SECRET_123") || !strings.Contains(out.String(), want) {
+					t.Fatalf("unsafe binary dry-run output: %s", out.String())
 				}
 			}
-		}
+			if string(req.Body.([]byte)) != body {
+				t.Fatal("dry-run mutated binary request body")
+			}
+		})
 	}
 }
 

--- a/aliyun-openapi-runtime/internal/redact.go
+++ b/aliyun-openapi-runtime/internal/redact.go
@@ -18,9 +18,14 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"reflect"
+	"regexp"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -102,77 +107,159 @@ func MaskValue(value string) string {
 	return value[:4] + "***"
 }
 
+// Form/RPC serializers flatten objects and arrays into keys such as
+// user.password.1 and user.1.password. Match whole path components only.
+func isSensitivePath(field string) bool {
+	if IsSensitive(field) {
+		return true
+	}
+	for _, part := range strings.FieldsFunc(field, func(r rune) bool { return r == '.' || r == '[' || r == ']' }) {
+		if IsSensitive(part) {
+			return true
+		}
+	}
+	return false
+}
+
 func MaskKV(key, value string) string {
-	if IsSensitive(key) {
+	if isSensitivePath(key) {
 		return MaskValue(value)
 	}
-	return value
+	return maskEmbeddedJSON(value)
 }
 
 func MaskBody(body string) string {
-	if masked, ok := maskJSONBody(body); ok {
-		return truncate(masked)
-	}
-	return truncate(body)
+	return truncate(MaskBodyFull(body))
 }
 
-// MaskBodyFull returns a complete, redacted JSON body for dry-run output.
-// Content that cannot be parsed and redacted as JSON is omitted rather than
-// echoed because it may contain secrets in an unknown representation.
-func MaskBodyFull(body string) string {
-	return MaskBodyForDryRun(body)
-}
-
-// MaskBodyForDryRun applies the full-body dry-run policy. Explicit opaque
-// formats take precedence over JSON sniffing so binary content is never
-// exposed merely because its bytes happen to form valid JSON.
-func MaskBodyForDryRun(body string, formats ...string) string {
+// MaskBodyFull redacts text without truncation. Only supported format declarations
+// enter text redaction; unknown declarations are omitted even if the body is JSON.
+func MaskBodyFull(body string, formats ...string) string {
 	if body == "" {
 		return ""
 	}
+	form := false
 	for _, format := range formats {
-		if isOpaqueBodyFormat(format) {
-			return omittedBody(body)
+		format = strings.ToLower(strings.TrimSpace(strings.SplitN(format, ";", 2)[0]))
+		switch format {
+		case "", "raw", "json", "application/json", "text/json":
+		case "form", "formdata", "application/x-www-form-urlencoded":
+			form = true
+		default:
+			if !strings.Contains(format, "/") || !strings.HasSuffix(format, "+json") {
+				return fmt.Sprintf("[body omitted: %d bytes]", len(body))
+			}
 		}
 	}
-	if masked, ok := maskJSONBody(body); ok {
-		return masked
+	if !utf8.ValidString(body) || strings.ContainsFunc(body, func(r rune) bool {
+		return unicode.IsControl(r) && r != '\n' && r != '\r' && r != '\t'
+	}) {
+		return fmt.Sprintf("[body omitted: %d bytes]", len(body))
 	}
-	return omittedBody(body)
-}
-
-func maskJSONBody(body string) (string, bool) {
 	var data any
 	if json.Valid([]byte(body)) {
 		decoder := json.NewDecoder(strings.NewReader(body))
 		decoder.UseNumber()
 		if err := decoder.Decode(&data); err == nil {
 			if masked, err := json.Marshal(maskJSON(data)); err == nil {
-				return string(masked), true
+				return string(masked)
 			}
 		}
 	}
-	return "", false
+	trimmed := strings.TrimSpace(body)
+	if strings.HasPrefix(trimmed, "<") {
+		return fmt.Sprintf("[body omitted: %d bytes]", len(body))
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return redactedText(body)
+	}
+	if form || (strings.Contains(body, "=") && !strings.ContainsAny(body, ",;\"'")) {
+		if _, err := url.ParseQuery(body); err != nil {
+			return redactedText(body)
+		}
+		parts := strings.Split(body, "&")
+		isForm := true
+		for i, part := range parts {
+			key, value, found := strings.Cut(part, "=")
+			name, _ := url.QueryUnescape(key)
+			if strings.ContainsAny(name, " \t:\"'") {
+				isForm = false
+			}
+			if found && isSensitivePath(name) {
+				decoded, _ := url.QueryUnescape(value)
+				parts[i] = key + "=" + url.QueryEscape(MaskValue(decoded))
+			} else {
+				decoded, _ := url.QueryUnescape(value)
+				if masked := maskEmbeddedJSON(decoded); found && masked != decoded {
+					parts[i] = key + "=" + url.QueryEscape(masked)
+				} else {
+					parts[i] = maskTextFields(part)
+				}
+			}
+		}
+		if isForm {
+			return strings.Join(parts, "&")
+		}
+	}
+	return maskTextFields(body)
 }
 
-func isOpaqueBodyFormat(format string) bool {
-	format = strings.ToLower(strings.TrimSpace(format))
-	if mediaType, _, found := strings.Cut(format, ";"); found {
-		format = strings.TrimSpace(mediaType)
-	}
-	// Empty/raw formats have no trustworthy declaration, so JSON sniffing is
-	// still useful for --body '{...}'. Structured form maps are projected as
-	// JSON by callers before reaching this helper. Every other explicit format
-	// fails closed unless it is a JSON media type.
-	switch format {
-	case "", "raw", "form", "formdata", "json", "application/json", "text/json":
-		return false
-	}
-	return !strings.HasSuffix(format, "+json")
+func redactedText(body string) string {
+	return fmt.Sprintf("[body redacted: %d bytes]", len(body))
 }
 
-func omittedBody(body string) string {
-	return fmt.Sprintf("[body omitted: %d bytes]", len(body))
+// ParamStyle=json puts serialized JSON inside a form field's string value.
+// Retain its string type, and preserve the original spelling when unchanged.
+func maskEmbeddedJSON(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, `"`) {
+		return value
+	}
+	var data any
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+	if !json.Valid([]byte(value)) || decoder.Decode(&data) != nil {
+		return redactedText(value)
+	}
+	masked := maskJSON(data)
+	if reflect.DeepEqual(data, masked) {
+		return value
+	}
+	b, err := json.Marshal(masked)
+	if err != nil {
+		return redactedText(value)
+	}
+	return string(b)
+}
+
+// ponytail: raw text supports named key/value pairs, not secrets in arbitrary
+// prose; add a format parser when another structured text format is supported.
+var textField = regexp.MustCompile(`([\w.\[\]-]+|"[\w.\[\]-]+"|'[\w.\[\]-]+')([ \t]*[:=][ \t]*)`)
+var textValue = regexp.MustCompile(`^("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\r\n&,;]+)`)
+
+func maskTextFields(body string) string {
+	var out strings.Builder
+	last := 0
+	for _, match := range textField.FindAllStringSubmatchIndex(body, -1) {
+		if match[0] < last || !isSensitivePath(strings.Trim(body[match[2]:match[3]], `"'`)) {
+			continue
+		}
+		value := textValue.FindString(body[match[1]:])
+		if value == "" {
+			if strings.TrimSpace(body[match[1]:]) != "" && strings.ContainsAny(body[match[1]:match[1]+1], "\r\n") {
+				return redactedText(body)
+			}
+			continue
+		}
+		if (value[0] == '"' || value[0] == '\'') && (len(value) == 1 || value[len(value)-1] != value[0]) {
+			return redactedText(body)
+		}
+		out.WriteString(body[last:match[1]])
+		out.WriteString("***")
+		last = match[1] + len(value)
+	}
+	out.WriteString(body[last:])
+	return out.String()
 }
 
 func MaskAny(data any) any {
@@ -184,7 +271,7 @@ func maskJSON(data any) any {
 	case map[string]any:
 		out := make(map[string]any, len(value))
 		for key, item := range value {
-			if IsSensitive(key) {
+			if isSensitivePath(key) {
 				if text, ok := item.(string); ok {
 					out[key] = MaskValue(text)
 				} else {
@@ -201,6 +288,8 @@ func maskJSON(data any) any {
 			out[i] = maskJSON(item)
 		}
 		return out
+	case string:
+		return maskEmbeddedJSON(value)
 	default:
 		return data
 	}

--- a/aliyun-openapi-runtime/internal/redact.go
+++ b/aliyun-openapi-runtime/internal/redact.go
@@ -125,7 +125,7 @@ func MaskKV(key, value string) string {
 	if isSensitivePath(key) {
 		return MaskValue(value)
 	}
-	return maskEmbeddedJSON(value)
+	return maskEmbeddedJSON(value, "***")
 }
 
 func MaskBody(body string) string {
@@ -161,7 +161,7 @@ func MaskBodyFull(body string, formats ...string) string {
 		decoder := json.NewDecoder(strings.NewReader(body))
 		decoder.UseNumber()
 		if err := decoder.Decode(&data); err == nil {
-			if masked, err := json.Marshal(maskJSON(data)); err == nil {
+			if masked, err := json.Marshal(maskJSON(data, "***")); err == nil {
 				return string(masked)
 			}
 		}
@@ -180,6 +180,8 @@ func MaskBodyFull(body string, formats ...string) string {
 		parts := strings.Split(body, "&")
 		isForm := true
 		for i, part := range parts {
+			part = strings.ReplaceAll(part, "*", "%2A")
+			parts[i] = part
 			key, value, found := strings.Cut(part, "=")
 			name, _ := url.QueryUnescape(key)
 			if strings.ContainsAny(name, " \t:\"'") {
@@ -187,11 +189,21 @@ func MaskBodyFull(body string, formats ...string) string {
 			}
 			if found && isSensitivePath(name) {
 				decoded, _ := url.QueryUnescape(value)
-				parts[i] = key + "=" + strings.ReplaceAll(url.QueryEscape(MaskValue(decoded)), "%2A", "*")
+				if decoded != "" {
+					prefix := strings.TrimSuffix(MaskValue(decoded), "***")
+					parts[i] = key + "=" + url.QueryEscape(prefix) + "***"
+				}
 			} else {
 				decoded, _ := url.QueryUnescape(value)
-				if masked := maskEmbeddedJSON(decoded); found && masked != decoded {
-					parts[i] = key + "=" + strings.ReplaceAll(url.QueryEscape(masked), "%2A", "*")
+				if masked := maskEmbeddedJSON(decoded, "***"); found && masked != decoded {
+					// Pick a marker absent from the normal output, including decoded
+					// nested JSON, so original stars and marker-like text stay encoded.
+					marker := "__REDACTED__"
+					for strings.Contains(masked, marker) {
+						marker += "_"
+					}
+					marked := maskEmbeddedJSON(decoded, marker)
+					parts[i] = key + "=" + strings.ReplaceAll(url.QueryEscape(marked), marker, "***")
 				} else {
 					parts[i] = maskTextFields(part)
 				}
@@ -210,7 +222,7 @@ func redactedText(body string) string {
 
 // ParamStyle=json puts serialized JSON inside a form field's string value.
 // Retain its string type, and preserve the original spelling when unchanged.
-func maskEmbeddedJSON(value string) string {
+func maskEmbeddedJSON(value, marker string) string {
 	trimmed := strings.TrimSpace(value)
 	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, `"`) {
 		return value
@@ -221,7 +233,7 @@ func maskEmbeddedJSON(value string) string {
 	if !json.Valid([]byte(value)) || decoder.Decode(&data) != nil {
 		return redactedText(value)
 	}
-	masked := maskJSON(data)
+	masked := maskJSON(data, marker)
 	if reflect.DeepEqual(data, masked) {
 		return value
 	}
@@ -263,33 +275,37 @@ func maskTextFields(body string) string {
 }
 
 func MaskAny(data any) any {
-	return maskJSON(data)
+	return maskJSON(data, "***")
 }
 
-func maskJSON(data any) any {
+func maskJSON(data any, marker string) any {
 	switch value := data.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(value))
 		for key, item := range value {
 			if isSensitivePath(key) {
 				if text, ok := item.(string); ok {
-					out[key] = MaskValue(text)
+					masked := MaskValue(text)
+					if text != "" {
+						masked = strings.TrimSuffix(masked, "***") + marker
+					}
+					out[key] = masked
 				} else {
-					out[key] = "***"
+					out[key] = marker
 				}
 				continue
 			}
-			out[key] = maskJSON(item)
+			out[key] = maskJSON(item, marker)
 		}
 		return out
 	case []any:
 		out := make([]any, len(value))
 		for i, item := range value {
-			out[i] = maskJSON(item)
+			out[i] = maskJSON(item, marker)
 		}
 		return out
 	case string:
-		return maskEmbeddedJSON(value)
+		return maskEmbeddedJSON(value, marker)
 	default:
 		return data
 	}

--- a/aliyun-openapi-runtime/internal/redact.go
+++ b/aliyun-openapi-runtime/internal/redact.go
@@ -187,11 +187,11 @@ func MaskBodyFull(body string, formats ...string) string {
 			}
 			if found && isSensitivePath(name) {
 				decoded, _ := url.QueryUnescape(value)
-				parts[i] = key + "=" + url.QueryEscape(MaskValue(decoded))
+				parts[i] = key + "=" + strings.ReplaceAll(url.QueryEscape(MaskValue(decoded)), "%2A", "*")
 			} else {
 				decoded, _ := url.QueryUnescape(value)
 				if masked := maskEmbeddedJSON(decoded); found && masked != decoded {
-					parts[i] = key + "=" + url.QueryEscape(masked)
+					parts[i] = key + "=" + strings.ReplaceAll(url.QueryEscape(masked), "%2A", "*")
 				} else {
 					parts[i] = maskTextFields(part)
 				}

--- a/aliyun-openapi-runtime/internal/redact.go
+++ b/aliyun-openapi-runtime/internal/redact.go
@@ -17,6 +17,7 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -109,22 +110,69 @@ func MaskKV(key, value string) string {
 }
 
 func MaskBody(body string) string {
-	return truncate(MaskBodyFull(body))
+	if masked, ok := maskJSONBody(body); ok {
+		return truncate(masked)
+	}
+	return truncate(body)
 }
 
-// MaskBodyFull applies the same redaction policy without truncating dry-run output.
+// MaskBodyFull returns a complete, redacted JSON body for dry-run output.
+// Content that cannot be parsed and redacted as JSON is omitted rather than
+// echoed because it may contain secrets in an unknown representation.
 func MaskBodyFull(body string) string {
+	return MaskBodyForDryRun(body)
+}
+
+// MaskBodyForDryRun applies the full-body dry-run policy. Explicit opaque
+// formats take precedence over JSON sniffing so binary content is never
+// exposed merely because its bytes happen to form valid JSON.
+func MaskBodyForDryRun(body string, formats ...string) string {
+	if body == "" {
+		return ""
+	}
+	for _, format := range formats {
+		if isOpaqueBodyFormat(format) {
+			return omittedBody(body)
+		}
+	}
+	if masked, ok := maskJSONBody(body); ok {
+		return masked
+	}
+	return omittedBody(body)
+}
+
+func maskJSONBody(body string) (string, bool) {
 	var data any
 	if json.Valid([]byte(body)) {
 		decoder := json.NewDecoder(strings.NewReader(body))
 		decoder.UseNumber()
 		if err := decoder.Decode(&data); err == nil {
 			if masked, err := json.Marshal(maskJSON(data)); err == nil {
-				return string(masked)
+				return string(masked), true
 			}
 		}
 	}
-	return body
+	return "", false
+}
+
+func isOpaqueBodyFormat(format string) bool {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if mediaType, _, found := strings.Cut(format, ";"); found {
+		format = strings.TrimSpace(mediaType)
+	}
+	// Empty/raw formats have no trustworthy declaration, so JSON sniffing is
+	// still useful for --body '{...}'. Structured form maps are projected as
+	// JSON by callers before reaching this helper. Every other explicit format
+	// fails closed unless it is a JSON media type.
+	switch format {
+	case "", "raw", "form", "formdata", "json", "application/json", "text/json":
+		return false
+	}
+	return !strings.HasSuffix(format, "+json")
+}
+
+func omittedBody(body string) string {
+	return fmt.Sprintf("[body omitted: %d bytes]", len(body))
 }
 
 func MaskAny(data any) any {

--- a/aliyun-openapi-runtime/internal/redact_test.go
+++ b/aliyun-openapi-runtime/internal/redact_test.go
@@ -102,12 +102,14 @@ func TestMaskBodyTextFormats(t *testing.T) {
 		hints            []string
 	}{
 		{"empty", "", "", []string{"binary"}},
-		{"form", "name=visible&Password=" + secret, "name=visible&Password=FAKE%2A%2A%2A", []string{"formData"}},
-		{"encoded form keys", "%50assword=" + secret + "&Password=another-secret&name=%E4%B8%AD", "%50assword=FAKE%2A%2A%2A&Password=anot%2A%2A%2A&name=%E4%B8%AD", nil},
+		{"form", "name=visible&Password=" + secret, "name=visible&Password=FAKE***", []string{"formData"}},
+		{"encoded form keys", "%50assword=" + secret + "&Password=another-secret&name=%E4%B8%AD", "%50assword=FAKE***&Password=anot***&name=%E4%B8%AD", nil},
+		{"form escaped delimiters", "password=a%26%3D%2BSECRET&name=alice", "password=a%26%3D%2B***&name=alice", []string{"formData"}},
+		{"form empty and short secrets", "password=&token=x&name=alice", "password=&token=***&name=alice", []string{"formData"}},
 		{"raw lines", "name: visible\nPassword: " + secret + "\nregion: cn-hangzhou", "name: visible\nPassword: ***\nregion: cn-hangzhou", []string{"raw"}},
 		{"raw assignments", "name=visible, password=" + secret + ", region=cn-hangzhou", "name=visible, password=***, region=cn-hangzhou", []string{"raw"}},
 		{"raw space separated fields", "name=visible password=" + secret, "name=visible password=***", []string{"raw"}},
-		{"form literal newline", "%50assword=" + secret + "\ncontinued&name=visible", "%50assword=FAKE%2A%2A%2A&name=visible", []string{"formData"}},
+		{"form literal newline", "%50assword=" + secret + "\ncontinued&name=visible", "%50assword=FAKE***&name=visible", []string{"formData"}},
 		{"raw quoted values", `name: visible, token: "` + secret + `, with spaces", region: cn-hangzhou`, `name: visible, token: ***, region: cn-hangzhou`, nil},
 		{"raw quoted assignment", `name=visible password="` + secret + `&continued-secret"`, `name=visible password=***`, []string{"raw"}},
 		{"plain text", "ordinary text 正文末尾", "ordinary text 正文末尾", []string{"raw"}},
@@ -133,15 +135,15 @@ func TestMaskBodyNestedForm(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			body := key + "=" + secret + "&user.name=alice"
 			got := MaskBodyFull(body, "formData")
-			if want := key + "=FAKE%2A%2A%2A&user.name=alice"; got != want {
+			if want := key + "=FAKE***&user.name=alice"; got != want {
 				t.Fatalf("got %q, want %q", got, want)
 			}
 		})
 	}
 	for _, tc := range []struct{ name, body, want string }{
-		{"embedded JSON", "config=" + url.QueryEscape(nested), "config=" + url.QueryEscape(maskedNested)},
-		{"embedded JSON array", "config=" + url.QueryEscape("["+nested+"]"), "config=" + url.QueryEscape("["+maskedNested+"]")},
-		{"repeated JSON fields", "config=" + url.QueryEscape(nested) + "&config=" + url.QueryEscape(nested), "config=" + url.QueryEscape(maskedNested) + "&config=" + url.QueryEscape(maskedNested)},
+		{"embedded JSON", "config=" + url.QueryEscape(nested), "config=" + strings.ReplaceAll(url.QueryEscape(maskedNested), "%2A", "*")},
+		{"embedded JSON array", "config=" + url.QueryEscape("["+nested+"]"), "config=" + strings.ReplaceAll(url.QueryEscape("["+maskedNested+"]"), "%2A", "*")},
+		{"repeated JSON fields", "config=" + url.QueryEscape(nested) + "&config=" + url.QueryEscape(nested), "config=" + strings.ReplaceAll(url.QueryEscape(maskedNested), "%2A", "*") + "&config=" + strings.ReplaceAll(url.QueryEscape(maskedNested), "%2A", "*")},
 		{"ordinary encoded value", "name=%E4%B8%AD&note=hello%20world", "name=%E4%B8%AD&note=hello%20world"},
 		{"non-sensitive JSON spelling", "config=" + url.QueryEscape(`{ "name": "alice", "id": 1 }`), "config=" + url.QueryEscape(`{ "name": "alice", "id": 1 }`)},
 		{"flat form map", `{"user.password.1":"FAKE_SECRET_123","user.name":"alice"}`, `{"user.name":"alice","user.password.1":"FAKE***"}`},

--- a/aliyun-openapi-runtime/internal/redact_test.go
+++ b/aliyun-openapi-runtime/internal/redact_test.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -90,6 +91,94 @@ func TestMaskBodyMasksBeforeTruncating(t *testing.T) {
 	}
 	if !strings.HasSuffix(output, "... (truncated)") {
 		t.Fatalf("long body was not truncated: %q", output)
+	}
+}
+
+func TestMaskBodyFullOmitsNonJSON(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	cases := map[string]string{
+		"form":        "password=" + secret + "&name=test",
+		"xml":         "<Password>" + secret + "</Password>",
+		"raw":         "prefix:" + secret,
+		"long-tail":   strings.Repeat("x", 1100) + secret,
+		"binary":      string(append([]byte{0x00, 0xff, 0x01}, []byte(secret)...)),
+		"json-prefix": "payload=" + `{"password":"` + secret + `"}`,
+	}
+
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			want := fmt.Sprintf("[body omitted: %d bytes]", len(input))
+			if got := MaskBodyFull(input); got != want {
+				t.Fatalf("MaskBodyFull() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestMaskBodyForDryRunHonorsOpaqueFormat(t *testing.T) {
+	const body = `{"password":"FAKE_SECRET_123"}`
+	for _, format := range []string{
+		"byte",
+		"binary",
+		"application/octet-stream",
+		"application/x-protobuf",
+		"application/xml; charset=utf-8",
+		"application/example+xml",
+		"multipart/form-data; boundary=example",
+		"application/x-www-form-urlencoded",
+		"text/plain",
+		"application/pdf",
+		"application/zip",
+		"application/cbor",
+		"application/msgpack",
+		"yaml",
+	} {
+		t.Run(format, func(t *testing.T) {
+			want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+			if got := MaskBodyForDryRun(body, format); got != want {
+				t.Fatalf("MaskBodyForDryRun(%q) = %q, want %q", format, got, want)
+			}
+		})
+	}
+}
+
+func TestMaskBodyForDryRunAllowsDeclaredJSONAndRawJSON(t *testing.T) {
+	const body = `{"password":"FAKE_SECRET_123","name":"visible"}`
+	for _, format := range []string{
+		"",
+		"raw",
+		"json",
+		"application/json; charset=utf-8",
+		"application/problem+json",
+	} {
+		t.Run(format, func(t *testing.T) {
+			got := MaskBodyForDryRun(body, format)
+			if got != `{"password":"FAKE***","name":"visible"}` && got != `{"name":"visible","password":"FAKE***"}` {
+				t.Fatalf("MaskBodyForDryRun(%q) = %q", format, got)
+			}
+		})
+	}
+}
+
+func TestMaskBodyFullPreservesCompleteRedactedJSON(t *testing.T) {
+	padding := strings.Repeat("x", 1200)
+	input := `{"content":"` + padding + `","password":"FAKE_SECRET_123"}`
+	output := MaskBodyFull(input)
+
+	if strings.Contains(output, "FAKE_SECRET_123") {
+		t.Fatalf("secret leaked from JSON body: %s", output)
+	}
+	if !strings.Contains(output, padding) {
+		t.Fatal("dry-run JSON body was truncated")
+	}
+	if !strings.Contains(output, `"password":"FAKE***"`) {
+		t.Fatalf("JSON secret was not masked: %s", output)
+	}
+}
+
+func TestMaskBodyFullEmpty(t *testing.T) {
+	if got := MaskBodyFull(""); got != "" {
+		t.Fatalf("MaskBodyFull(empty) = %q", got)
 	}
 }
 

--- a/aliyun-openapi-runtime/internal/redact_test.go
+++ b/aliyun-openapi-runtime/internal/redact_test.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -94,67 +95,182 @@ func TestMaskBodyMasksBeforeTruncating(t *testing.T) {
 	}
 }
 
-func TestMaskBodyFullOmitsNonJSON(t *testing.T) {
+func TestMaskBodyTextFormats(t *testing.T) {
 	const secret = "FAKE_SECRET_123"
-	cases := map[string]string{
-		"form":        "password=" + secret + "&name=test",
-		"xml":         "<Password>" + secret + "</Password>",
-		"raw":         "prefix:" + secret,
-		"long-tail":   strings.Repeat("x", 1100) + secret,
-		"binary":      string(append([]byte{0x00, 0xff, 0x01}, []byte(secret)...)),
-		"json-prefix": "payload=" + `{"password":"` + secret + `"}`,
-	}
-
-	for name, input := range cases {
-		t.Run(name, func(t *testing.T) {
-			want := fmt.Sprintf("[body omitted: %d bytes]", len(input))
-			if got := MaskBodyFull(input); got != want {
-				t.Fatalf("MaskBodyFull() = %q, want %q", got, want)
+	for _, tc := range []struct {
+		name, body, want string
+		hints            []string
+	}{
+		{"empty", "", "", []string{"binary"}},
+		{"form", "name=visible&Password=" + secret, "name=visible&Password=FAKE%2A%2A%2A", []string{"formData"}},
+		{"encoded form keys", "%50assword=" + secret + "&Password=another-secret&name=%E4%B8%AD", "%50assword=FAKE%2A%2A%2A&Password=anot%2A%2A%2A&name=%E4%B8%AD", nil},
+		{"raw lines", "name: visible\nPassword: " + secret + "\nregion: cn-hangzhou", "name: visible\nPassword: ***\nregion: cn-hangzhou", []string{"raw"}},
+		{"raw assignments", "name=visible, password=" + secret + ", region=cn-hangzhou", "name=visible, password=***, region=cn-hangzhou", []string{"raw"}},
+		{"raw space separated fields", "name=visible password=" + secret, "name=visible password=***", []string{"raw"}},
+		{"form literal newline", "%50assword=" + secret + "\ncontinued&name=visible", "%50assword=FAKE%2A%2A%2A&name=visible", []string{"formData"}},
+		{"raw quoted values", `name: visible, token: "` + secret + `, with spaces", region: cn-hangzhou`, `name: visible, token: ***, region: cn-hangzhou`, nil},
+		{"raw quoted assignment", `name=visible password="` + secret + `&continued-secret"`, `name=visible password=***`, []string{"raw"}},
+		{"plain text", "ordinary text 正文末尾", "ordinary text 正文末尾", []string{"raw"}},
+		{"JSON without declaration", `{"name":"visible","password":"` + secret + `"}`, `{"name":"visible","password":"FAKE***"}`, nil},
+		{"JSON with raw declaration", `{"name":"visible","password":"` + secret + `"}`, `{"name":"visible","password":"FAKE***"}`, []string{"raw"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskBodyFull(tc.body, tc.hints...); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			if got := MaskBody(tc.body); strings.Contains(got, secret) {
+				t.Errorf("log body leaked secret: %q", got)
 			}
 		})
 	}
 }
 
-func TestMaskBodyForDryRunHonorsOpaqueFormat(t *testing.T) {
+func TestMaskBodyNestedForm(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	const nested = `{"name":"alice","password":"FAKE_SECRET_123","id":3460000290000487710}`
+	const maskedNested = `{"id":3460000290000487710,"name":"alice","password":"FAKE***"}`
+	for _, key := range []string{"user.password", "user.password.1", "user.password.2", "user.1.password", "user[password]", "user[1][password]", "user.%70assword.1"} {
+		t.Run(key, func(t *testing.T) {
+			body := key + "=" + secret + "&user.name=alice"
+			got := MaskBodyFull(body, "formData")
+			if want := key + "=FAKE%2A%2A%2A&user.name=alice"; got != want {
+				t.Fatalf("got %q, want %q", got, want)
+			}
+		})
+	}
+	for _, tc := range []struct{ name, body, want string }{
+		{"embedded JSON", "config=" + url.QueryEscape(nested), "config=" + url.QueryEscape(maskedNested)},
+		{"embedded JSON array", "config=" + url.QueryEscape("["+nested+"]"), "config=" + url.QueryEscape("["+maskedNested+"]")},
+		{"repeated JSON fields", "config=" + url.QueryEscape(nested) + "&config=" + url.QueryEscape(nested), "config=" + url.QueryEscape(maskedNested) + "&config=" + url.QueryEscape(maskedNested)},
+		{"ordinary encoded value", "name=%E4%B8%AD&note=hello%20world", "name=%E4%B8%AD&note=hello%20world"},
+		{"non-sensitive JSON spelling", "config=" + url.QueryEscape(`{ "name": "alice", "id": 1 }`), "config=" + url.QueryEscape(`{ "name": "alice", "id": 1 }`)},
+		{"flat form map", `{"user.password.1":"FAKE_SECRET_123","user.name":"alice"}`, `{"user.name":"alice","user.password.1":"FAKE***"}`},
+		{"non-sensitive similar names", "user.passwordHint=visible&tokenizer.1=visible", "user.passwordHint=visible&tokenizer.1=visible"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskBodyFull(tc.body, "formData"); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+	// ParamStyle=json stores JSON inside a string in the form map.
+	body, _ := json.Marshal(map[string]any{"config": nested})
+	got := MaskBodyFull(string(body), "formData")
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil || decoded["config"] != maskedNested {
+		t.Fatalf("JSON string field = %s, error = %v", got, err)
+	}
+	// A JSON-valued form field can itself contain another JSON string field.
+	inner, _ := json.Marshal(map[string]string{"inner": nested})
+	body = []byte("config=" + url.QueryEscape(string(inner)))
+	form, err := url.ParseQuery(MaskBodyFull(string(body), "formData"))
+	if err != nil || json.Unmarshal([]byte(form.Get("config")), &decoded) != nil || decoded["inner"] != maskedNested {
+		t.Fatalf("nested JSON string field = %v, error = %v", form, err)
+	}
+	// Damaged nested JSON must not escape via a non-sensitive outer field.
+	broken := `{"password":"FAKE_SECRET_123`
+	body = []byte("config=" + url.QueryEscape(broken) + "&name=alice")
+	if got := MaskBodyFull(string(body), "formData"); strings.Contains(got, secret) || !strings.Contains(got, "name=alice") {
+		t.Fatalf("unsafe malformed JSON value: %s", got)
+	}
+}
+
+func TestMaskBodyFullOmitsXML(t *testing.T) {
+	for _, body := range []string{
+		`<Request><Password>FAKE_SECRET_123</Password></Request>`,
+		" \n<?xml version=\"1.0\"?><credentials><User>中文</User><Password>FAKE_SECRET_123</Password></credentials>",
+		`<Request><Password>FAKE_SECRET_123</Request>`,
+	} {
+		for _, format := range []string{"", "raw", "application/xml"} {
+			want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+			if got := MaskBodyFull(body, format); got != want {
+				t.Errorf("MaskBodyFull(%q, %q) = %q, want %q", body, format, got, want)
+			}
+		}
+	}
+}
+
+func TestMaskBodyUnsafeFormats(t *testing.T) {
+	for _, body := range []string{
+		`{"password":"FAKE_SECRET_123`,
+		`%50assword=FAKE_SECRET_123&name=%zz`,
+		"password: \"FAKE_SECRET_123\ncontinued-secret",
+		"password:\n  FAKE_SECRET_123",
+	} {
+		if got, want := MaskBodyFull(body), fmt.Sprintf("[body redacted: %d bytes]", len(body)); got != want {
+			t.Errorf("malformed text: got %q, want %q", got, want)
+		}
+	}
+	for _, tc := range []struct{ body, format string }{
+		{"\x00FAKE_SECRET_123", "raw"},
+		{"\xffFAKE_SECRET_123", ""},
+		{`{"password":"FAKE_SECRET_123"}`, "binary"},
+		{"Password=FAKE_SECRET_123", "Application/Octet-Stream; charset=utf-8"},
+	} {
+		if got, want := MaskBodyFull(tc.body, tc.format), fmt.Sprintf("[body omitted: %d bytes]", len(tc.body)); got != want {
+			t.Errorf("binary: got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestMaskBodyFullOmitsUnsupportedFormats(t *testing.T) {
 	const body = `{"password":"FAKE_SECRET_123"}`
 	for _, format := range []string{
 		"byte",
 		"binary",
 		"application/octet-stream",
 		"application/x-protobuf",
-		"application/xml; charset=utf-8",
-		"application/example+xml",
-		"multipart/form-data; boundary=example",
-		"application/x-www-form-urlencoded",
-		"text/plain",
 		"application/pdf",
 		"application/zip",
 		"application/cbor",
 		"application/msgpack",
+		"application/x-custom-format",
+		" FutureFormat ; version=2",
 		"yaml",
+		"text/yaml",
+		"text/csv",
+		"multipart/form-data; boundary=example",
+		"image/png",
+		"audio/ogg",
+		"video/webm",
+		"not-a-media-type+json",
+		"text/plain",
+		"text/xml",
+		"application/xml; charset=utf-8",
+		"text",
+		"xml",
+		"application/example+xml; charset=utf-8",
+		"image/svg+xml",
 	} {
 		t.Run(format, func(t *testing.T) {
 			want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
-			if got := MaskBodyForDryRun(body, format); got != want {
-				t.Fatalf("MaskBodyForDryRun(%q) = %q, want %q", format, got, want)
+			for _, hints := range [][]string{{format}, {"json", format}, {format, "application/json"}} {
+				if got := MaskBodyFull(body, hints...); got != want {
+					t.Fatalf("MaskBodyFull(%q) = %q, want %q", hints, got, want)
+				}
 			}
 		})
 	}
 }
 
-func TestMaskBodyForDryRunAllowsDeclaredJSONAndRawJSON(t *testing.T) {
+func TestMaskBodyFullAllowsSupportedTextFormats(t *testing.T) {
 	const body = `{"password":"FAKE_SECRET_123","name":"visible"}`
 	for _, format := range []string{
 		"",
 		"raw",
 		"json",
+		"form",
+		"formData",
+		" Application/JSON ; charset=utf-8",
 		"application/json; charset=utf-8",
 		"application/problem+json",
+		"text/json",
+		"application/x-www-form-urlencoded",
 	} {
 		t.Run(format, func(t *testing.T) {
-			got := MaskBodyForDryRun(body, format)
+			got := MaskBodyFull(body, format)
 			if got != `{"password":"FAKE***","name":"visible"}` && got != `{"name":"visible","password":"FAKE***"}` {
-				t.Fatalf("MaskBodyForDryRun(%q) = %q", format, got)
+				t.Fatalf("MaskBodyFull(%q) = %q", format, got)
 			}
 		})
 	}

--- a/aliyun-openapi-runtime/internal/redact_test.go
+++ b/aliyun-openapi-runtime/internal/redact_test.go
@@ -127,6 +127,24 @@ func TestMaskBodyTextFormats(t *testing.T) {
 	}
 }
 
+func TestMaskBodyFormKeepsOriginalStarsEncoded(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{"password prefix", "password=*abcSECRET&note=***", "password=%2Aabc***&note=%2A%2A%2A"},
+		{"star-only prefix", "password=****SECRET", "password=%2A%2A%2A%2A***"},
+		{"already encoded stars", "password=%2AabcSECRET&note=%2A%2A%2A", "password=%2Aabc***&note=%2A%2A%2A"},
+		{"ordinary field", "note=***", "note=%2A%2A%2A"},
+		{"embedded JSON", "config=" + url.QueryEscape(`{"note":"***","password":"*abcSECRET"}`), "config=%7B%22note%22%3A%22%2A%2A%2A%22%2C%22password%22%3A%22%2Aabc***%22%7D"},
+		{"embedded JSON array", "config=" + url.QueryEscape(`[{"note":"*","token":123}]`), "config=%5B%7B%22note%22%3A%22%2A%22%2C%22token%22%3A%22***%22%7D%5D"},
+		{"nested JSON string and marker collision", "config=" + url.QueryEscape(`{"inner":"{\"note\":\"\\u005f_REDACTED__***\",\"password\":\"*abcSECRET\"}"}`), "config=%7B%22inner%22%3A%22%7B%5C%22note%5C%22%3A%5C%22__REDACTED__%2A%2A%2A%5C%22%2C%5C%22password%5C%22%3A%5C%22%2Aabc***%5C%22%7D%22%7D"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskBodyFull(tc.body, "formData"); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMaskBodyNestedForm(t *testing.T) {
 	const secret = "FAKE_SECRET_123"
 	const nested = `{"name":"alice","password":"FAKE_SECRET_123","id":3460000290000487710}`

--- a/aliyun-openapi-runtime/redact/redact.go
+++ b/aliyun-openapi-runtime/redact/redact.go
@@ -27,7 +27,13 @@ func MaskKV(key, value string) string { return internal.MaskKV(key, value) }
 
 func MaskBody(body string) string { return internal.MaskBody(body) }
 
-// MaskBodyFull redacts the complete body for dry-run output without a size limit.
+// MaskBodyFull redacts complete JSON bodies for dry-run output without a size
+// limit and replaces other representations with a content-free summary.
 func MaskBodyFull(body string) string { return internal.MaskBodyFull(body) }
+
+// MaskBodyForDryRun also honors explicit opaque request-body formats.
+func MaskBodyForDryRun(body string, formats ...string) string {
+	return internal.MaskBodyForDryRun(body, formats...)
+}
 
 func MaskAny(data any) any { return internal.MaskAny(data) }

--- a/aliyun-openapi-runtime/redact/redact.go
+++ b/aliyun-openapi-runtime/redact/redact.go
@@ -27,13 +27,9 @@ func MaskKV(key, value string) string { return internal.MaskKV(key, value) }
 
 func MaskBody(body string) string { return internal.MaskBody(body) }
 
-// MaskBodyFull redacts complete JSON bodies for dry-run output without a size
-// limit and replaces other representations with a content-free summary.
-func MaskBodyFull(body string) string { return internal.MaskBodyFull(body) }
-
-// MaskBodyForDryRun also honors explicit opaque request-body formats.
-func MaskBodyForDryRun(body string, formats ...string) string {
-	return internal.MaskBodyForDryRun(body, formats...)
+// MaskBodyFull redacts the complete body for dry-run output without a size limit.
+func MaskBodyFull(body string, formats ...string) string {
+	return internal.MaskBodyFull(body, formats...)
 }
 
 func MaskAny(data any) any { return internal.MaskAny(data) }

--- a/aliyun-openapi-runtime/redact/redact_test.go
+++ b/aliyun-openapi-runtime/redact/redact_test.go
@@ -29,7 +29,7 @@ func TestPublicRedactionContract(t *testing.T) {
 	if got := MaskBody(`{"password":"secret-value"}`); got != `{"password":"secr***"}` {
 		t.Fatalf("MaskBody = %q", got)
 	}
-	if got := MaskBodyFull("password=secret-value"); got != "password=secr%2A%2A%2A" {
+	if got := MaskBodyFull("password=secret-value"); got != "password=secr***" {
 		t.Fatalf("MaskBodyFull = %q", got)
 	}
 	if got := MaskBodyFull(`{"name":"visible"}`, "binary"); got != "[body omitted: 18 bytes]" {

--- a/aliyun-openapi-runtime/redact/redact_test.go
+++ b/aliyun-openapi-runtime/redact/redact_test.go
@@ -29,11 +29,11 @@ func TestPublicRedactionContract(t *testing.T) {
 	if got := MaskBody(`{"password":"secret-value"}`); got != `{"password":"secr***"}` {
 		t.Fatalf("MaskBody = %q", got)
 	}
-	if got := MaskBodyFull("password=secret-value"); got != "[body omitted: 21 bytes]" {
+	if got := MaskBodyFull("password=secret-value"); got != "password=secr%2A%2A%2A" {
 		t.Fatalf("MaskBodyFull = %q", got)
 	}
-	if got := MaskBodyForDryRun(`{"name":"visible"}`, "binary"); got != "[body omitted: 18 bytes]" {
-		t.Fatalf("MaskBodyForDryRun = %q", got)
+	if got := MaskBodyFull(`{"name":"visible"}`, "binary"); got != "[body omitted: 18 bytes]" {
+		t.Fatalf("MaskBodyFull = %q", got)
 	}
 	masked := MaskAny(map[string]any{"token": "secret-value"}).(map[string]any)
 	if masked["token"] != "secr***" {

--- a/aliyun-openapi-runtime/redact/redact_test.go
+++ b/aliyun-openapi-runtime/redact/redact_test.go
@@ -29,6 +29,12 @@ func TestPublicRedactionContract(t *testing.T) {
 	if got := MaskBody(`{"password":"secret-value"}`); got != `{"password":"secr***"}` {
 		t.Fatalf("MaskBody = %q", got)
 	}
+	if got := MaskBodyFull("password=secret-value"); got != "[body omitted: 21 bytes]" {
+		t.Fatalf("MaskBodyFull = %q", got)
+	}
+	if got := MaskBodyForDryRun(`{"name":"visible"}`, "binary"); got != "[body omitted: 18 bytes]" {
+		t.Fatalf("MaskBodyForDryRun = %q", got)
+	}
 	masked := MaskAny(map[string]any{"token": "secret-value"}).(map[string]any)
 	if masked["token"] != "secr***" {
 		t.Fatalf("MaskAny = %#v", masked)

--- a/aliyun-openapi-runtime/runtime/executor.go
+++ b/aliyun-openapi-runtime/runtime/executor.go
@@ -132,8 +132,12 @@ type AssembledRequest struct {
 	// ReqBodyType is the request body encoding: "json" (default) or "formData".
 	// Empty and all non-formData metadata values are treated as "json" to match aliyun-cli-runtime.
 	ReqBodyType string `json:"req_body_type,omitempty"`
-	Endpoint    string `json:"endpoint,omitempty"`
-	Region      string `json:"region,omitempty"`
+	// DeclaredReqBodyType and DeclaredContentType retain metadata hints solely
+	// for safe dry-run rendering. Sending continues to use ReqBodyType above.
+	DeclaredReqBodyType string `json:"-"`
+	DeclaredContentType string `json:"-"`
+	Endpoint            string `json:"endpoint,omitempty"`
+	Region              string `json:"region,omitempty"`
 }
 
 // Response is what Execute returns.
@@ -215,7 +219,9 @@ func newAssembledRequest(api *meta.API) *AssembledRequest {
 		Query:    map[string]string{},
 		Headers:  map[string]string{},
 		// aliyun-cli-runtime defaults every operation to json and only generated formData APIs call SetReqBodyType("formData").
-		ReqBodyType: resolveReqBodyType(api),
+		ReqBodyType:         resolveReqBodyType(api),
+		DeclaredReqBodyType: strings.TrimSpace(api.ReqBodyType),
+		DeclaredContentType: strings.TrimSpace(api.ContentType),
 	}
 	if !strings.EqualFold(style, string(meta.StyleRPC)) {
 		req.PathPattern = api.URL

--- a/aliyun-openapi-runtime/runtime/executor_test.go
+++ b/aliyun-openapi-runtime/runtime/executor_test.go
@@ -643,6 +643,9 @@ func TestNonFormBodyMetadataKeepsLegacyJSONExecution(t *testing.T) {
 	if req.ReqBodyType != "json" {
 		t.Fatalf("ReqBodyType = %q, want json", req.ReqBodyType)
 	}
+	if req.DeclaredReqBodyType != "byte" || req.DeclaredContentType != "application/vnd.example.payload" {
+		t.Fatalf("dry-run body hints = %q, %q", req.DeclaredReqBodyType, req.DeclaredContentType)
+	}
 	if _, exists := req.Headers["content-type"]; exists {
 		t.Fatalf("non-form metadata must not override content-type: %#v", req.Headers)
 	}

--- a/main/dry_run_test.go
+++ b/main/dry_run_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/openapi"
+)
+
+func TestCSDryRunJSONRedactsRawPassword(t *testing.T) {
+	clearAgentDetectionEnv(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	profileJSON := []byte(`{"current":"default","profiles":[{"name":"default","mode":"AK","access_key_id":"test-access-key-id","access_key_secret":"test-access-key-secret","region_id":"cn-hangzhou","language":"en"}]}`)
+	if err := os.WriteFile(configPath, profileJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile, err := config.LoadProfile(configPath, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	root := newRootCommand(profile, &stdout)
+	ctx := newCommandContext(&stdout, &stderr)
+	ctx.EnterCommand(root)
+	root.Execute(ctx, []string{
+		"cs", "POST", "/clusters", "--body", "password=FAKE_SECRET_123", "--cli-dry-run-json",
+		"--config-path", configPath,
+	})
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", &stderr)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("FAKE_SECRET_123")) {
+		t.Fatal("dry-run output contains the unmasked password")
+	}
+	var output openapi.CliDryRunOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("invalid JSON output: %v; stdout: %s", err, &stdout)
+	}
+	if output.Method != "POST" || output.Pathname != "/clusters" || output.Body != "password=FAKE%2A%2A%2A" {
+		t.Fatalf("unexpected dry-run output: %+v", output)
+	}
+	t.Logf("actual dry-run JSON: %s", &stdout)
+}

--- a/main/dry_run_test.go
+++ b/main/dry_run_test.go
@@ -40,7 +40,7 @@ func TestCSDryRunJSONRedactsRawPassword(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
 		t.Fatalf("invalid JSON output: %v; stdout: %s", err, &stdout)
 	}
-	if output.Method != "POST" || output.Pathname != "/clusters" || output.Body != "password=FAKE%2A%2A%2A" {
+	if output.Method != "POST" || output.Pathname != "/clusters" || output.Body != "password=FAKE***" {
 		t.Fatalf("unexpected dry-run output: %+v", output)
 	}
 	t.Logf("actual dry-run JSON: %s", &stdout)

--- a/openapi/cli_dry_run.go
+++ b/openapi/cli_dry_run.go
@@ -72,12 +72,16 @@ func buildCliDryRunFromInvoker(inv Invoker) *CliDryRunOutput {
 	}
 
 	if len(req.Content) > 0 {
-		out.Body = runtimeredact.MaskBodyFull(string(req.Content))
 		out.BodyFormat = "raw"
+		out.Body = runtimeredact.MaskBodyForDryRun(
+			string(req.Content), out.BodyFormat, dryRunHeaderValue(req.Headers, "Content-Type"),
+		)
 	} else if len(req.FormParams) > 0 {
 		out.Query = mergeInto(out.Query, nil)
 		formJSON, _ := json.Marshal(req.FormParams)
-		out.Body = runtimeredact.MaskBodyFull(string(formJSON))
+		// FormParams are structured values, so their JSON projection can be
+		// redacted by key even though the wire encoding is form data.
+		out.Body = runtimeredact.MaskBodyForDryRun(string(formJSON))
 		out.BodyFormat = "form"
 	}
 
@@ -146,15 +150,25 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 	}
 
 	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
-		bodyJSON, err := json.Marshal(oc.openapiRequest.Body)
-		if err == nil && string(bodyJSON) != "null" {
-			out.Body = runtimeredact.MaskBodyFull(string(bodyJSON))
-			// Reflect the request-body encoding resolved in Prepare/ProcessBody:
-			// RPC-style products send form fields (ReqBodyType=formData), which
-			// the classic dry-run reports as "form"; ROA keeps the JSON body.
-			out.BodyFormat = "json"
-			if oc.openapiParams != nil && tea.StringValue(oc.openapiParams.ReqBodyType) == "formData" {
-				out.BodyFormat = "form"
+		if stream, ok := oc.openapiRequest.Body.([]byte); ok {
+			out.BodyFormat = "binary"
+			if oc.openapiParams != nil && oc.openapiParams.ReqBodyType != nil {
+				out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
+			}
+			out.Body = runtimeredact.MaskBodyForDryRun(
+				string(stream), out.BodyFormat, dryRunHeaderValue(out.Headers, "Content-Type"),
+			)
+		} else {
+			bodyJSON, err := json.Marshal(oc.openapiRequest.Body)
+			if err == nil && string(bodyJSON) != "null" {
+				out.Body = runtimeredact.MaskBodyForDryRun(string(bodyJSON))
+				// Reflect the request-body encoding resolved in Prepare/ProcessBody:
+				// RPC-style products send form fields (ReqBodyType=formData), which
+				// the classic dry-run reports as "form"; ROA keeps the JSON body.
+				out.BodyFormat = "json"
+				if oc.openapiParams != nil && tea.StringValue(oc.openapiParams.ReqBodyType) == "formData" {
+					out.BodyFormat = "form"
+				}
 			}
 		}
 	}
@@ -180,18 +194,16 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 		}
 	}
 
-	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
-		if stream, ok := oc.openapiRequest.Body.([]byte); ok {
-			out.Body = runtimeredact.MaskBodyFull(string(stream))
-			if oc.openapiParams != nil && oc.openapiParams.ReqBodyType != nil {
-				out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
-			} else {
-				out.BodyFormat = "binary"
-			}
+	return out
+}
+
+func dryRunHeaderValue(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
 		}
 	}
-
-	return out
+	return ""
 }
 
 func sanitizedDryRunPathname(pattern, pathname string, raw, sanitized map[string]string) string {

--- a/openapi/cli_dry_run.go
+++ b/openapi/cli_dry_run.go
@@ -72,16 +72,12 @@ func buildCliDryRunFromInvoker(inv Invoker) *CliDryRunOutput {
 	}
 
 	if len(req.Content) > 0 {
+		out.Body = runtimeredact.MaskBodyFull(string(req.Content), dryRunContentType(req.Headers))
 		out.BodyFormat = "raw"
-		out.Body = runtimeredact.MaskBodyForDryRun(
-			string(req.Content), out.BodyFormat, dryRunHeaderValue(req.Headers, "Content-Type"),
-		)
 	} else if len(req.FormParams) > 0 {
 		out.Query = mergeInto(out.Query, nil)
 		formJSON, _ := json.Marshal(req.FormParams)
-		// FormParams are structured values, so their JSON projection can be
-		// redacted by key even though the wire encoding is form data.
-		out.Body = runtimeredact.MaskBodyForDryRun(string(formJSON))
+		out.Body = runtimeredact.MaskBodyFull(string(formJSON))
 		out.BodyFormat = "form"
 	}
 
@@ -150,25 +146,35 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 	}
 
 	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
-		if stream, ok := oc.openapiRequest.Body.([]byte); ok {
+		body := oc.openapiRequest.Body
+		hints := []string{dryRunContentType(out.Headers)}
+		if oc.openapiParams != nil {
+			hints = append(hints, tea.StringValue(oc.openapiParams.ReqBodyType))
+		}
+		if oc.api != nil && oc.api.Operation != nil {
+			hints = append(hints, oc.api.Operation.ReqBodyType, oc.api.Operation.ContentType)
+		}
+		switch value := body.(type) {
+		case string:
+			out.Body = runtimeredact.MaskBodyFull(value, hints...)
+			out.BodyFormat = "raw"
+		case []byte:
+			out.Body = runtimeredact.MaskBodyFull(string(value), hints...)
 			out.BodyFormat = "binary"
-			if oc.openapiParams != nil && oc.openapiParams.ReqBodyType != nil {
-				out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
-			}
-			out.Body = runtimeredact.MaskBodyForDryRun(
-				string(stream), out.BodyFormat, dryRunHeaderValue(out.Headers, "Content-Type"),
-			)
-		} else {
-			bodyJSON, err := json.Marshal(oc.openapiRequest.Body)
+		default:
+			bodyJSON, err := json.Marshal(body)
 			if err == nil && string(bodyJSON) != "null" {
-				out.Body = runtimeredact.MaskBodyForDryRun(string(bodyJSON))
-				// Reflect the request-body encoding resolved in Prepare/ProcessBody:
-				// RPC-style products send form fields (ReqBodyType=formData), which
-				// the classic dry-run reports as "form"; ROA keeps the JSON body.
-				out.BodyFormat = "json"
-				if oc.openapiParams != nil && tea.StringValue(oc.openapiParams.ReqBodyType) == "formData" {
-					out.BodyFormat = "form"
-				}
+				out.Body = runtimeredact.MaskBodyFull(string(bodyJSON), hints...)
+			}
+			// Reflect the request-body encoding resolved in Prepare/ProcessBody:
+			// RPC-style products send form fields (ReqBodyType=formData), which
+			// the classic dry-run reports as "form"; ROA keeps the JSON body.
+			out.BodyFormat = "json"
+		}
+		if oc.openapiParams != nil && tea.StringValue(oc.openapiParams.ReqBodyType) != "" {
+			out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
+			if out.BodyFormat == "formData" {
+				out.BodyFormat = "form"
 			}
 		}
 	}
@@ -197,9 +203,9 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 	return out
 }
 
-func dryRunHeaderValue(headers map[string]string, name string) string {
+func dryRunContentType(headers map[string]string) string {
 	for key, value := range headers {
-		if strings.EqualFold(key, name) {
+		if strings.EqualFold(key, "Content-Type") {
 			return value
 		}
 	}

--- a/openapi/cli_dry_run_test.go
+++ b/openapi/cli_dry_run_test.go
@@ -195,7 +195,7 @@ func TestBuildCliDryRunFromInvoker_MasksPathSecret(t *testing.T) {
 	assert.NotContains(t, out.Pathname, "path-secret-value")
 }
 
-func TestCliDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
+func TestCliDryRunPreservesLongBodyAndRedaction(t *testing.T) {
 	const secret = "FAKE_SECRET_123"
 	text := strings.Repeat("流水线", 450) + "正文末尾"
 	for _, tc := range []struct {
@@ -206,13 +206,14 @@ func TestCliDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
 		{
 			"form",
 			"name=" + text + "&password=" + secret,
-			fmt.Sprintf("[body omitted: %d bytes]", len("name="+text+"&password="+secret)),
+			"name=" + text + "&password=FAKE%2A%2A%2A",
 		},
 		{
 			"xml",
 			"<Name>" + text + "</Name><Password>" + secret + "</Password>",
 			fmt.Sprintf("[body omitted: %d bytes]", len("<Name>"+text+"</Name><Password>"+secret+"</Password>")),
 		},
+		{"raw", "name: " + text + "\npassword: " + secret, "name: " + text + "\npassword: ***"},
 		{
 			"json",
 			`{"content":"` + text + `","password":"` + secret + `"}`,
@@ -228,7 +229,8 @@ func TestCliDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
 				openapiRequest: &openapiutil.OpenApiRequest{Body: stream},
 				openapiParams:  &openapiClient.Params{ReqBodyType: tea.String("json")},
 			}})
-			for _, out := range []*CliDryRunOutput{classic, openapi} {
+			textBody := buildCliDryRunFromOpenapi(&OpenapiContext{HttpContext: &HttpContext{openapiRequest: &openapiutil.OpenApiRequest{Body: tc.body}}})
+			for _, out := range []*CliDryRunOutput{classic, openapi, textBody} {
 				assert.Equal(t, tc.want, out.Body)
 				human := formatCliDryRunHuman(out)
 				assert.Contains(t, human, tc.want)
@@ -293,6 +295,37 @@ func TestBuildCliDryRunFromInvoker_WithFormParams(t *testing.T) {
 	assert.Contains(t, out.Body, "ecs.g6.large")
 	assert.Contains(t, out.Body, `"Password":"form***"`)
 	assert.NotContains(t, out.Body, "form-secret-value")
+}
+
+func TestCliDryRunNestedForm(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	fields := map[string]string{
+		"user.password.1": secret,
+		"user.2.password": secret,
+		"user.name":       "alice",
+		"config":          `{"name":"alice","password":"FAKE_SECRET_123"}`,
+	}
+	req := requests.NewCommonRequest()
+	req.FormParams = fields
+	classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
+	oc := &OpenapiContext{HttpContext: &HttpContext{
+		openapiRequest: &openapiutil.OpenApiRequest{Body: fields},
+		openapiParams:  &openapiClient.Params{ReqBodyType: tea.String("formData")},
+	}}
+	for _, out := range []*CliDryRunOutput{classic, buildCliDryRunFromOpenapi(oc)} {
+		var body map[string]string
+		assert.NoError(t, json.Unmarshal([]byte(out.Body), &body))
+		assert.Equal(t, "FAKE***", body["user.password.1"])
+		assert.Equal(t, "FAKE***", body["user.2.password"])
+		assert.Equal(t, "alice", body["user.name"])
+		assert.Equal(t, `{"name":"alice","password":"FAKE***"}`, body["config"])
+		assert.NotContains(t, formatCliDryRunHuman(out), secret)
+		encoded, err := marshalCliDryRunOutput(out)
+		assert.NoError(t, err)
+		assert.NotContains(t, encoded, secret)
+	}
+	assert.Equal(t, secret, fields["user.password.1"])
+	assert.Equal(t, `{"name":"alice","password":"FAKE_SECRET_123"}`, fields["config"])
 }
 
 func TestBuildCliDryRunFromOpenapi(t *testing.T) {
@@ -686,10 +719,10 @@ func TestProcessCliDryRunJson(t *testing.T) {
 	assert.Equal(t, "ecs.cn-hangzhou.aliyuncs.com", parsed.Endpoint)
 }
 
-func TestProcessCliDryRunOmitsNonJSONBodyFromStdoutAndStderr(t *testing.T) {
+func TestProcessCliDryRunRedactsTextBodyInStdoutAndStderr(t *testing.T) {
 	const secret = "FAKE_SECRET_123"
 	body := strings.Repeat("x", 1100) + "&password=" + secret
-	want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+	want := strings.Repeat("x", 1100) + "&password=FAKE%2A%2A%2A"
 
 	for _, jsonOutput := range []bool{false, true} {
 		name := "human"
@@ -716,7 +749,13 @@ func TestProcessCliDryRunOmitsNonJSONBodyFromStdoutAndStderr(t *testing.T) {
 				err = processCliDryRun(ctx, invoker)
 			}
 			assert.NoError(t, err)
-			assert.Contains(t, stdout.String(), want)
+			if jsonOutput {
+				var decoded CliDryRunOutput
+				assert.NoError(t, json.Unmarshal(stdout.Bytes(), &decoded))
+				assert.Equal(t, want, decoded.Body)
+			} else {
+				assert.Contains(t, stdout.String(), want)
+			}
 			assert.NotContains(t, stdout.String(), secret)
 			assert.NotContains(t, stderr.String(), secret)
 			assert.Empty(t, stderr.String())
@@ -1355,5 +1394,34 @@ func newOpenapiParams(method, pathname, action, version string) *openapiClient.P
 		Pathname: tea.String(pathname),
 		Action:   tea.String(action),
 		Version:  tea.String(version),
+	}
+}
+
+func TestCliDryRunExplicitContentTypes(t *testing.T) {
+	const body = `<Name>visible</Name><Password>FAKE_SECRET_123</Password>`
+	for _, tc := range []struct{ contentType, want string }{
+		{"application/xml", fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"application/octet-stream", fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"application/x-custom-format", fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+	} {
+		t.Run(tc.contentType, func(t *testing.T) {
+			req := requests.NewCommonRequest()
+			req.Content = []byte(body)
+			req.Headers["cOnTeNt-TyPe"] = tc.contentType
+			classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
+			oc := &OpenapiContext{
+				HttpContext: &HttpContext{openapiRequest: &openapiutil.OpenApiRequest{Body: []byte(body)}},
+				api:         &canonicalmeta.API{Operation: &canonicalmeta.Operation{ContentType: tc.contentType}},
+			}
+			for _, out := range []*CliDryRunOutput{classic, buildCliDryRunFromOpenapi(oc)} {
+				assert.Equal(t, tc.want, out.Body)
+				assert.NotContains(t, formatCliDryRunHuman(out), "FAKE_SECRET_123")
+				encoded, err := marshalCliDryRunOutput(out)
+				assert.NoError(t, err)
+				assert.NotContains(t, encoded, "FAKE_SECRET_123")
+			}
+			assert.Equal(t, body, string(req.Content))
+			assert.Equal(t, body, string(oc.openapiRequest.Body.([]byte)))
+		})
 	}
 }

--- a/openapi/cli_dry_run_test.go
+++ b/openapi/cli_dry_run_test.go
@@ -206,7 +206,7 @@ func TestCliDryRunPreservesLongBodyAndRedaction(t *testing.T) {
 		{
 			"form",
 			"name=" + text + "&password=" + secret,
-			"name=" + text + "&password=FAKE%2A%2A%2A",
+			"name=" + text + "&password=FAKE***",
 		},
 		{
 			"xml",
@@ -722,7 +722,7 @@ func TestProcessCliDryRunJson(t *testing.T) {
 func TestProcessCliDryRunRedactsTextBodyInStdoutAndStderr(t *testing.T) {
 	const secret = "FAKE_SECRET_123"
 	body := strings.Repeat("x", 1100) + "&password=" + secret
-	want := strings.Repeat("x", 1100) + "&password=FAKE%2A%2A%2A"
+	want := strings.Repeat("x", 1100) + "&password=FAKE***"
 
 	for _, jsonOutput := range []bool{false, true} {
 		name := "human"

--- a/openapi/cli_dry_run_test.go
+++ b/openapi/cli_dry_run_test.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -194,29 +195,53 @@ func TestBuildCliDryRunFromInvoker_MasksPathSecret(t *testing.T) {
 	assert.NotContains(t, out.Pathname, "path-secret-value")
 }
 
-func TestCliDryRunPreservesLongBodyAndRedaction(t *testing.T) {
+func TestCliDryRunOmitsNonJSONAndPreservesLongRedactedJSON(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
 	text := strings.Repeat("流水线", 450) + "正文末尾"
-	for _, tc := range []struct{ name, body, want string }{
-		{"raw", "name=" + text + "&pipelineId=123", "name=" + text + "&pipelineId=123"},
-		{"json", `{"content":"` + text + `","password":"secret-value"}`, `{"content":"` + text + `","password":"secr***"}`},
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"form",
+			"name=" + text + "&password=" + secret,
+			fmt.Sprintf("[body omitted: %d bytes]", len("name="+text+"&password="+secret)),
+		},
+		{
+			"xml",
+			"<Name>" + text + "</Name><Password>" + secret + "</Password>",
+			fmt.Sprintf("[body omitted: %d bytes]", len("<Name>"+text+"</Name><Password>"+secret+"</Password>")),
+		},
+		{
+			"json",
+			`{"content":"` + text + `","password":"` + secret + `"}`,
+			`{"content":"` + text + `","password":"FAKE***"}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			req := requests.NewCommonRequest()
 			req.SetContent([]byte(tc.body))
+			stream := []byte(tc.body)
 			classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
 			openapi := buildCliDryRunFromOpenapi(&OpenapiContext{HttpContext: &HttpContext{
-				openapiRequest: &openapiutil.OpenApiRequest{Body: []byte(tc.body)},
+				openapiRequest: &openapiutil.OpenApiRequest{Body: stream},
+				openapiParams:  &openapiClient.Params{ReqBodyType: tea.String("json")},
 			}})
 			for _, out := range []*CliDryRunOutput{classic, openapi} {
 				assert.Equal(t, tc.want, out.Body)
-				assert.Contains(t, formatCliDryRunHuman(out), tc.want)
+				human := formatCliDryRunHuman(out)
+				assert.Contains(t, human, tc.want)
+				assert.NotContains(t, human, secret)
 				encoded, err := marshalCliDryRunOutput(out)
 				assert.NoError(t, err)
+				assert.NotContains(t, encoded, secret)
 				var decoded CliDryRunOutput
 				assert.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
 				assert.Equal(t, tc.want, decoded.Body)
 			}
 			assert.Equal(t, tc.body, string(req.Content), "dry-run must not mutate the request")
+			assert.Equal(t, tc.body, string(stream), "dry-run must not mutate the OpenAPI body")
 		})
 	}
 }
@@ -478,7 +503,7 @@ func TestBuildCliDryRunFromOpenapi_WithBinaryBody(t *testing.T) {
 	api := &testLegacyAPI{Name: "PutLogs", Product: product}
 	profile := &config.Profile{RegionId: "cn-hangzhou", Endpoint: "cn-hangzhou.log.aliyuncs.com"}
 
-	binaryData := []byte("compressed-data-here")
+	binaryData := []byte(`{"password":"FAKE_SECRET_123"}`)
 	oc := &OpenapiContext{
 		HttpContext: &HttpContext{
 			profile: profile,
@@ -498,7 +523,9 @@ func TestBuildCliDryRunFromOpenapi_WithBinaryBody(t *testing.T) {
 
 	out := buildCliDryRunFromOpenapi(oc)
 	assert.Equal(t, "binary", out.BodyFormat)
-	assert.Equal(t, "compressed-data-here", out.Body)
+	assert.Equal(t, fmt.Sprintf("[body omitted: %d bytes]", len(binaryData)), out.Body)
+	assert.NotContains(t, out.Body, "FAKE_SECRET_123")
+	assert.Equal(t, `{"password":"FAKE_SECRET_123"}`, string(binaryData), "dry-run must not mutate binary data")
 }
 
 func TestBuildCliDryRunFromOpenapi_NilHeaders(t *testing.T) {
@@ -657,6 +684,45 @@ func TestProcessCliDryRunJson(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "RPC", parsed.Style)
 	assert.Equal(t, "ecs.cn-hangzhou.aliyuncs.com", parsed.Endpoint)
+}
+
+func TestProcessCliDryRunOmitsNonJSONBodyFromStdoutAndStderr(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	body := strings.Repeat("x", 1100) + "&password=" + secret
+	want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+
+	for _, jsonOutput := range []bool{false, true} {
+		name := "human"
+		if jsonOutput {
+			name = "json"
+		}
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+			ctx := cli.NewCommandContext(stdout, stderr)
+			cmd := &cli.Command{}
+			cmd.EnableUnknownFlag = true
+			AddFlags(cmd.Flags())
+			ctx.EnterCommand(cmd)
+
+			req := requests.NewCommonRequest()
+			req.Method = "POST"
+			req.SetContent([]byte(body))
+			invoker := &RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}}
+
+			var err error
+			if jsonOutput {
+				err = processCliDryRunJson(ctx, invoker)
+			} else {
+				err = processCliDryRun(ctx, invoker)
+			}
+			assert.NoError(t, err)
+			assert.Contains(t, stdout.String(), want)
+			assert.NotContains(t, stdout.String(), secret)
+			assert.NotContains(t, stderr.String(), secret)
+			assert.Empty(t, stderr.String())
+			assert.Equal(t, body, string(req.Content), "dry-run must not mutate the request")
+		})
+	}
 }
 
 func TestProcessCliDryRunOpenapi(t *testing.T) {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -1515,6 +1515,8 @@ func TestProcessApiInvokeFilterError(t *testing.T) {
 }
 
 func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	body := strings.Repeat("x", 1100) + "&password=" + secret
 	profile := config.Profile{
 		Language:        "en",
 		Mode:            "AK",
@@ -1531,6 +1533,8 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 	AddFlags(cmd.Flags())
 	ctx.EnterCommand(cmd)
 	DryRunJsonFlag(ctx.Flags()).SetAssigned(true)
+	BodyFlag(ctx.Flags()).SetAssigned(true)
+	BodyFlag(ctx.Flags()).SetValue(body)
 
 	command := NewCommando(stdout, profile)
 	product := &meta.Product{Code: "sls", Version: "2020-03-31"}
@@ -1559,7 +1563,7 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 		}
 	}
 
-	err := command.processApiInvoke(ctx, product, canonicalTestAPI(api), "GET", "/projects/foo")
+	err := command.processApiInvoke(ctx, product, canonicalTestAPI(api), "POST", "/clusters")
 	assert.NoError(t, err)
 
 	output := strings.TrimSpace(stdout.String())
@@ -1568,9 +1572,14 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 	var m CliDryRunOutput
 	assert.Nil(t, json.Unmarshal([]byte(output), &m), "stdout must be valid JSON: %q", output)
 	assert.Equal(t, "ROA", m.Style)
-	assert.Equal(t, "GET", m.Method)
+	assert.Equal(t, "POST", m.Method)
 	assert.Equal(t, "GetProject", m.Action)
 	assert.Equal(t, "2020-03-31", m.Version)
+	assert.Equal(t, "json", m.BodyFormat)
+	assert.Equal(t, fmt.Sprintf("[body omitted: %d bytes]", len(body)), m.Body)
+	assert.NotContains(t, stdout.String(), secret)
+	assert.NotContains(t, stderr.String(), secret)
+	assert.Empty(t, stderr.String())
 	// SLS without --endpoint / profile.Endpoint falls back to {region}.log.aliyuncs.com.
 	assert.Equal(t, "cn-hangzhou.log.aliyuncs.com", m.Endpoint)
 }

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -1576,7 +1576,7 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 	assert.Equal(t, "GetProject", m.Action)
 	assert.Equal(t, "2020-03-31", m.Version)
 	assert.Equal(t, "json", m.BodyFormat)
-	assert.Equal(t, strings.Repeat("x", 1100)+"&password=FAKE%2A%2A%2A", m.Body)
+	assert.Equal(t, strings.Repeat("x", 1100)+"&password=FAKE***", m.Body)
 	assert.NotContains(t, stdout.String(), secret)
 	assert.NotContains(t, stderr.String(), secret)
 	assert.Empty(t, stderr.String())

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -1576,7 +1576,7 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 	assert.Equal(t, "GetProject", m.Action)
 	assert.Equal(t, "2020-03-31", m.Version)
 	assert.Equal(t, "json", m.BodyFormat)
-	assert.Equal(t, fmt.Sprintf("[body omitted: %d bytes]", len(body)), m.Body)
+	assert.Equal(t, strings.Repeat("x", 1100)+"&password=FAKE%2A%2A%2A", m.Body)
 	assert.NotContains(t, stdout.String(), secret)
 	assert.NotContains(t, stderr.String(), secret)
 	assert.Empty(t, stderr.String())


### PR DESCRIPTION
Fixes sensitive data exposure in dry-run output by redacting JSON, form, and raw key/value bodies, including nested form fields. XML, binary, and unsupported formats are omitted.

For example, password=FAKE_SECRET_123 now displays as password=FAKE***.