### PR TITLE
Harden plugin installation with rollback, archive limits, and URL redaction

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -11,7 +11,8 @@ jobs:
   installer:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        # macos-13 is Intel (amd64); macos-14 is Apple Silicon (arm64)
+        os: [ubuntu-latest, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/aliyun-openapi-runtime/engine/builder.go
+++ b/aliyun-openapi-runtime/engine/builder.go
@@ -692,43 +692,66 @@ func sanitizeDryRunValues(values map[string]string) map[string]string {
 	return out
 }
 
-func dryRunBody(body any, reqBodyType string) (value, format string, err error) {
+func dryRunHeaderValue(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+	return ""
+}
+
+func dryRunBody(body any, reqBodyType string, formatHints ...string) (value, format string, err error) {
 	if body == nil {
 		return "", "", nil
 	}
+	declaredFormat := ""
+	if len(formatHints) > 0 {
+		declaredFormat = formatHints[0]
+	}
+	formats := append([]string{reqBodyType}, formatHints...)
 	if data, ok := body.(string); ok {
-		format = reqBodyType
-		if format == "" {
-			format = "raw"
-		}
-		if strings.EqualFold(format, "formData") {
-			format = "form"
-		}
-		return redact.MaskBodyFull(data), format, nil
+		format = dryRunBodyFormat(reqBodyType, declaredFormat, "raw")
+		return redact.MaskBodyFull(data, formats...), format, nil
 	}
 	if data, ok := body.([]byte); ok {
-		format = reqBodyType
-		if format == "" {
-			format = "binary"
-		}
-		if strings.EqualFold(format, "formData") {
-			format = "form"
-		}
-		return redact.MaskBodyFull(string(data)), format, nil
+		format = dryRunBodyFormat(reqBodyType, declaredFormat, "binary")
+		return redact.MaskBodyFull(string(data), formats...), format, nil
 	}
-	b, err := json.Marshal(redact.MaskAny(body))
+	b, err := json.Marshal(body)
 	if err != nil {
 		return "", "", err
 	}
-	format = "json"
-	if strings.EqualFold(reqBodyType, "formData") {
-		format = "form"
+	format = dryRunBodyFormat(reqBodyType, declaredFormat, "json")
+	return redact.MaskBodyFull(string(b), formats...), format, nil
+}
+
+func dryRunBodyFormat(reqBodyType, declaredFormat, fallback string) string {
+	format := strings.TrimSpace(declaredFormat)
+	if format == "" {
+		format = strings.TrimSpace(reqBodyType)
 	}
-	return string(b), format, nil
+	if format == "" {
+		format = fallback
+	}
+	switch {
+	case strings.EqualFold(format, "formData"):
+		return "form"
+	case strings.EqualFold(format, "byte"), strings.EqualFold(format, "bytes"), strings.EqualFold(format, "binary"):
+		return "binary"
+	default:
+		return format
+	}
 }
 
 func buildCliDryRunOutput(product string, req *runtime.AssembledRequest) (*cliDryRunOutput, error) {
-	body, bodyFormat, err := dryRunBody(req.Body, req.ReqBodyType)
+	body, bodyFormat, err := dryRunBody(
+		req.Body,
+		req.ReqBodyType,
+		req.DeclaredReqBodyType,
+		req.DeclaredContentType,
+		dryRunHeaderValue(req.Headers, "Content-Type"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -762,11 +785,11 @@ func renderDryRun(w io.Writer, product string, req *runtime.AssembledRequest, js
 	if req == nil {
 		return fmt.Errorf("dry-run produced no request")
 	}
+	output, err := buildCliDryRunOutput(product, req)
+	if err != nil {
+		return err
+	}
 	if jsonMeta {
-		output, err := buildCliDryRunOutput(product, req)
-		if err != nil {
-			return err
-		}
 		b, err := json.Marshal(output)
 		if err != nil {
 			return err
@@ -797,16 +820,7 @@ func renderDryRun(w io.Writer, product string, req *runtime.AssembledRequest, js
 	printSortedKV(w, "Headers", req.Headers)
 	printSortedKV(w, "Query Parameters", req.Query)
 	if req.Body != nil {
-		switch body := req.Body.(type) {
-		case string:
-			// Raw --body/--body-file strings are sent as-is by the SDK.
-			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBodyFull(body))
-		case []byte:
-			fmt.Fprintf(w, "Body:\n  %s\n", redact.MaskBodyFull(string(body)))
-		default:
-			b, _ := json.Marshal(redact.MaskAny(req.Body))
-			fmt.Fprintf(w, "Body:\n  %s\n", string(b))
-		}
+		fmt.Fprintf(w, "Body:\n  %s\n", output.Body)
 	}
 	fmt.Fprintf(w, "%s\nRequest NOT sent (dry-run mode)\n%s\n", bar, bar)
 	fmt.Fprintln(w, "{")

--- a/aliyun-openapi-runtime/engine/builder_additional_test.go
+++ b/aliyun-openapi-runtime/engine/builder_additional_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -496,31 +497,141 @@ func TestBuilderOptionAndRenderingHelpers(t *testing.T) {
 }
 
 func TestDryRunPreservesLongBodyAndRedaction(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
 	text := strings.Repeat("流水线", 450) + "正文末尾"
-	for _, tc := range []struct{ body, want string }{
-		{"name=" + text + "&pipelineId=123", "name=" + text + "&pipelineId=123"},
-		{`{"content":"` + text + `","password":"secret-value"}`, `{"content":"` + text + `","password":"secr***"}`},
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"form",
+			"name=" + text + "&password=" + secret,
+			"name=" + text + "&password=FAKE***",
+		},
+		{
+			"xml",
+			"<Name>" + text + "</Name><Password>" + secret + "</Password>",
+			fmt.Sprintf("[body omitted: %d bytes]", len("<Name>"+text+"</Name><Password>"+secret+"</Password>")),
+		},
+		{"raw", "name: " + text + "\npassword: " + secret, "name: " + text + "\npassword: ***"},
+		{
+			"json",
+			`{"content":"` + text + `","password":"` + secret + `"}`,
+			`{"content":"` + text + `","password":"FAKE***"}`,
+		},
 	} {
-		for _, body := range []any{tc.body, []byte(tc.body)} {
-			value, _, err := dryRunBody(body, "raw")
-			if err != nil || value != tc.want {
-				t.Fatalf("dryRunBody(%T) lost body content or redaction: %v", body, err)
+		t.Run(tc.name, func(t *testing.T) {
+			for _, body := range []any{tc.body, []byte(tc.body)} {
+				value, _, err := dryRunBody(body, "raw")
+				if err != nil || value != tc.want {
+					t.Fatalf("dryRunBody(%T) = %q, %v; want %q", body, value, err, tc.want)
+				}
+				for _, jsonOutput := range []bool{false, true} {
+					var out bytes.Buffer
+					if err := renderDryRun(&out, "demo", &runtime.AssembledRequest{Body: body}, jsonOutput, false); err != nil {
+						t.Fatal(err)
+					}
+					if strings.Contains(out.String(), secret) {
+						t.Fatalf("secret leaked from %T dry-run output: %s", body, out.String())
+					}
+					if jsonOutput {
+						var decoded cliDryRunOutput
+						if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
+							t.Fatalf("JSON dry-run body = %q, %v; want %q", decoded.Body, err, tc.want)
+						}
+					} else if !strings.Contains(out.String(), tc.want) {
+						t.Fatalf("text dry-run body missing %q", tc.want)
+					}
+				}
+				if data, ok := body.([]byte); ok && string(data) != tc.body {
+					t.Fatal("dry-run mutated byte body")
+				}
+			}
+		})
+	}
+}
+
+func TestDryRunOmitsExplicitBinaryEvenWhenBodyIsJSON(t *testing.T) {
+	const body = `{"password":"FAKE_SECRET_123"}`
+	want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+	for name, req := range map[string]*runtime.AssembledRequest{
+		"metadata": {
+			Body:                []byte(body),
+			ReqBodyType:         "json",
+			DeclaredReqBodyType: "byte",
+			DeclaredContentType: "application/octet-stream",
+		},
+		"header": {
+			Body:        []byte(body),
+			ReqBodyType: "json",
+			Headers:     map[string]string{"Content-Type": "application/octet-stream"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			value, _, err := dryRunBody(
+				req.Body,
+				req.ReqBodyType,
+				req.DeclaredReqBodyType,
+				req.DeclaredContentType,
+				dryRunHeaderValue(req.Headers, "Content-Type"),
+			)
+			if err != nil || value != want {
+				t.Fatalf("dryRunBody(binary) = %q, %v; want %q", value, err, want)
 			}
 			for _, jsonOutput := range []bool{false, true} {
 				var out bytes.Buffer
-				if err := renderDryRun(&out, "demo", &runtime.AssembledRequest{Body: body}, jsonOutput, false); err != nil {
+				if err := renderDryRun(&out, "demo", req, jsonOutput, false); err != nil {
 					t.Fatal(err)
 				}
-				if jsonOutput {
-					var decoded cliDryRunOutput
-					if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
-						t.Fatalf("JSON dry-run lost body content or redaction: %v", err)
-					}
-				} else if !strings.Contains(out.String(), tc.want) {
-					t.Fatal("text dry-run lost body content or redaction")
+				if strings.Contains(out.String(), "FAKE_SECRET_123") || !strings.Contains(out.String(), want) {
+					t.Fatalf("unsafe binary dry-run output: %s", out.String())
 				}
 			}
+			if string(req.Body.([]byte)) != body {
+				t.Fatal("dry-run mutated binary request body")
+			}
+		})
+	}
+}
+
+func TestDryRunNestedForm(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	req, err := runtime.Assemble(&runtime.ExecContext{
+		API: &meta.API{Name: "Submit", ReqBodyType: "formData", Parameters: []meta.Parameter{
+			{Name: "config", RawName: "config", Type: meta.TypeObject, Position: meta.PosFormData, ParamStyle: "json"},
+		}},
+		Args: map[string]any{"config": map[string]any{"name": "alice", "password": secret}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range []any{req.Body, map[string]any{"user.password.1": secret, "user.name": "alice"}} {
+		req.Body = body
+		before, _ := json.Marshal(body)
+		for _, jsonOutput := range []bool{false, true} {
+			var out bytes.Buffer
+			if err := renderDryRun(&out, "demo", req, jsonOutput, false); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(out.String(), secret) || !strings.Contains(out.String(), "alice") || !strings.Contains(out.String(), "FAKE***") {
+				t.Fatalf("incorrect nested form redaction: %s", out.String())
+			}
+			if strings.Contains(out.String(), "DeclaredReqBodyType") || strings.Contains(out.String(), "DeclaredContentType") {
+				t.Fatal("internal format hints must not be printed")
+			}
 		}
+		after, _ := json.Marshal(body)
+		if !bytes.Equal(before, after) {
+			t.Fatal("dry-run mutated the form request")
+		}
+	}
+	// Structured bodies must also honor all declared formats, not just ReqBodyType.
+	req.DeclaredContentType = "application/octet-stream"
+	bodyJSON, _ := json.Marshal(req.Body)
+	out, err := buildCliDryRunOutput("demo", req)
+	if err != nil || out.Body != fmt.Sprintf("[body omitted: %d bytes]", len(bodyJSON)) {
+		t.Fatalf("lost binary format hint for structured body: %+v, %v", out, err)
 	}
 }
 
@@ -614,5 +725,42 @@ func TestBuilderErrorAndRenderBranches(t *testing.T) {
 	}
 	if err := writeJSON(io.Discard, make(chan int), nil, "filtered", false); err == nil {
 		t.Fatal("writeJSON accepted channel")
+	}
+}
+
+func TestDryRunExplicitBodyFormats(t *testing.T) {
+	const body = `<Request><Name>visible</Name><Password>FAKE_SECRET_123</Password></Request>`
+	for _, tc := range []struct {
+		name string
+		req  runtime.AssembledRequest
+		want string
+	}{
+		{"XML", runtime.AssembledRequest{Headers: map[string]string{"Content-Type": "application/xml"}}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"binary", runtime.AssembledRequest{ReqBodyType: "binary"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"declared binary", runtime.AssembledRequest{ReqBodyType: "json", DeclaredReqBodyType: "byte"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"declared content type", runtime.AssembledRequest{DeclaredContentType: "application/octet-stream"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"unknown content type", runtime.AssembledRequest{ReqBodyType: "json", DeclaredContentType: "application/x-custom-format"}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"header", runtime.AssembledRequest{Headers: map[string]string{"cOnTeNt-TyPe": "application/octet-stream"}}, fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.req.Body = []byte(body)
+			for _, jsonOutput := range []bool{false, true} {
+				var out bytes.Buffer
+				if err := renderDryRun(&out, "demo", &tc.req, jsonOutput, false); err != nil {
+					t.Fatal(err)
+				}
+				if jsonOutput {
+					var decoded cliDryRunOutput
+					if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || decoded.Body != tc.want {
+						t.Fatalf("body = %q, err = %v", decoded.Body, err)
+					}
+				} else if !strings.Contains(out.String(), tc.want) {
+					t.Fatalf("unexpected text output: %s", &out)
+				}
+				if strings.Contains(out.String(), "FAKE_SECRET_123") || string(tc.req.Body.([]byte)) != body {
+					t.Fatal("dry-run leaked a secret or changed the request body")
+				}
+			}
+		})
 	}
 }

--- a/aliyun-openapi-runtime/internal/redact.go
+++ b/aliyun-openapi-runtime/internal/redact.go
@@ -17,9 +17,15 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
+	"reflect"
+	"regexp"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -101,58 +107,205 @@ func MaskValue(value string) string {
 	return value[:4] + "***"
 }
 
+// Form/RPC serializers flatten objects and arrays into keys such as
+// user.password.1 and user.1.password. Match whole path components only.
+func isSensitivePath(field string) bool {
+	if IsSensitive(field) {
+		return true
+	}
+	for _, part := range strings.FieldsFunc(field, func(r rune) bool { return r == '.' || r == '[' || r == ']' }) {
+		if IsSensitive(part) {
+			return true
+		}
+	}
+	return false
+}
+
 func MaskKV(key, value string) string {
-	if IsSensitive(key) {
+	if isSensitivePath(key) {
 		return MaskValue(value)
 	}
-	return value
+	return maskEmbeddedJSON(value, "***")
 }
 
 func MaskBody(body string) string {
 	return truncate(MaskBodyFull(body))
 }
 
-// MaskBodyFull applies the same redaction policy without truncating dry-run output.
-func MaskBodyFull(body string) string {
+// MaskBodyFull redacts text without truncation. Only supported format declarations
+// enter text redaction; unknown declarations are omitted even if the body is JSON.
+func MaskBodyFull(body string, formats ...string) string {
+	if body == "" {
+		return ""
+	}
+	form := false
+	for _, format := range formats {
+		format = strings.ToLower(strings.TrimSpace(strings.SplitN(format, ";", 2)[0]))
+		switch format {
+		case "", "raw", "json", "application/json", "text/json":
+		case "form", "formdata", "application/x-www-form-urlencoded":
+			form = true
+		default:
+			if !strings.Contains(format, "/") || !strings.HasSuffix(format, "+json") {
+				return fmt.Sprintf("[body omitted: %d bytes]", len(body))
+			}
+		}
+	}
+	if !utf8.ValidString(body) || strings.ContainsFunc(body, func(r rune) bool {
+		return unicode.IsControl(r) && r != '\n' && r != '\r' && r != '\t'
+	}) {
+		return fmt.Sprintf("[body omitted: %d bytes]", len(body))
+	}
 	var data any
 	if json.Valid([]byte(body)) {
 		decoder := json.NewDecoder(strings.NewReader(body))
 		decoder.UseNumber()
 		if err := decoder.Decode(&data); err == nil {
-			if masked, err := json.Marshal(maskJSON(data)); err == nil {
+			if masked, err := json.Marshal(maskJSON(data, "***")); err == nil {
 				return string(masked)
 			}
 		}
 	}
-	return body
+	trimmed := strings.TrimSpace(body)
+	if strings.HasPrefix(trimmed, "<") {
+		return fmt.Sprintf("[body omitted: %d bytes]", len(body))
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return redactedText(body)
+	}
+	if form || (strings.Contains(body, "=") && !strings.ContainsAny(body, ",;\"'")) {
+		if _, err := url.ParseQuery(body); err != nil {
+			return redactedText(body)
+		}
+		parts := strings.Split(body, "&")
+		isForm := true
+		for i, part := range parts {
+			part = strings.ReplaceAll(part, "*", "%2A")
+			parts[i] = part
+			key, value, found := strings.Cut(part, "=")
+			name, _ := url.QueryUnescape(key)
+			if strings.ContainsAny(name, " \t:\"'") {
+				isForm = false
+			}
+			if found && isSensitivePath(name) {
+				decoded, _ := url.QueryUnescape(value)
+				if decoded != "" {
+					prefix := strings.TrimSuffix(MaskValue(decoded), "***")
+					parts[i] = key + "=" + url.QueryEscape(prefix) + "***"
+				}
+			} else {
+				decoded, _ := url.QueryUnescape(value)
+				if masked := maskEmbeddedJSON(decoded, "***"); found && masked != decoded {
+					// Pick a marker absent from the normal output, including decoded
+					// nested JSON, so original stars and marker-like text stay encoded.
+					marker := "__REDACTED__"
+					for strings.Contains(masked, marker) {
+						marker += "_"
+					}
+					marked := maskEmbeddedJSON(decoded, marker)
+					parts[i] = key + "=" + strings.ReplaceAll(url.QueryEscape(marked), marker, "***")
+				} else {
+					parts[i] = maskTextFields(part)
+				}
+			}
+		}
+		if isForm {
+			return strings.Join(parts, "&")
+		}
+	}
+	return maskTextFields(body)
+}
+
+func redactedText(body string) string {
+	return fmt.Sprintf("[body redacted: %d bytes]", len(body))
+}
+
+// ParamStyle=json puts serialized JSON inside a form field's string value.
+// Retain its string type, and preserve the original spelling when unchanged.
+func maskEmbeddedJSON(value, marker string) string {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, `"`) {
+		return value
+	}
+	var data any
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+	if !json.Valid([]byte(value)) || decoder.Decode(&data) != nil {
+		return redactedText(value)
+	}
+	masked := maskJSON(data, marker)
+	if reflect.DeepEqual(data, masked) {
+		return value
+	}
+	b, err := json.Marshal(masked)
+	if err != nil {
+		return redactedText(value)
+	}
+	return string(b)
+}
+
+// ponytail: raw text supports named key/value pairs, not secrets in arbitrary
+// prose; add a format parser when another structured text format is supported.
+var textField = regexp.MustCompile(`([\w.\[\]-]+|"[\w.\[\]-]+"|'[\w.\[\]-]+')([ \t]*[:=][ \t]*)`)
+var textValue = regexp.MustCompile(`^("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\r\n&,;]+)`)
+
+func maskTextFields(body string) string {
+	var out strings.Builder
+	last := 0
+	for _, match := range textField.FindAllStringSubmatchIndex(body, -1) {
+		if match[0] < last || !isSensitivePath(strings.Trim(body[match[2]:match[3]], `"'`)) {
+			continue
+		}
+		value := textValue.FindString(body[match[1]:])
+		if value == "" {
+			if strings.TrimSpace(body[match[1]:]) != "" && strings.ContainsAny(body[match[1]:match[1]+1], "\r\n") {
+				return redactedText(body)
+			}
+			continue
+		}
+		if (value[0] == '"' || value[0] == '\'') && (len(value) == 1 || value[len(value)-1] != value[0]) {
+			return redactedText(body)
+		}
+		out.WriteString(body[last:match[1]])
+		out.WriteString("***")
+		last = match[1] + len(value)
+	}
+	out.WriteString(body[last:])
+	return out.String()
 }
 
 func MaskAny(data any) any {
-	return maskJSON(data)
+	return maskJSON(data, "***")
 }
 
-func maskJSON(data any) any {
+func maskJSON(data any, marker string) any {
 	switch value := data.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(value))
 		for key, item := range value {
-			if IsSensitive(key) {
+			if isSensitivePath(key) {
 				if text, ok := item.(string); ok {
-					out[key] = MaskValue(text)
+					masked := MaskValue(text)
+					if text != "" {
+						masked = strings.TrimSuffix(masked, "***") + marker
+					}
+					out[key] = masked
 				} else {
-					out[key] = "***"
+					out[key] = marker
 				}
 				continue
 			}
-			out[key] = maskJSON(item)
+			out[key] = maskJSON(item, marker)
 		}
 		return out
 	case []any:
 		out := make([]any, len(value))
 		for i, item := range value {
-			out[i] = maskJSON(item)
+			out[i] = maskJSON(item, marker)
 		}
 		return out
+	case string:
+		return maskEmbeddedJSON(value, marker)
 	default:
 		return data
 	}

--- a/aliyun-openapi-runtime/internal/redact_test.go
+++ b/aliyun-openapi-runtime/internal/redact_test.go
@@ -16,6 +16,8 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -90,6 +92,229 @@ func TestMaskBodyMasksBeforeTruncating(t *testing.T) {
 	}
 	if !strings.HasSuffix(output, "... (truncated)") {
 		t.Fatalf("long body was not truncated: %q", output)
+	}
+}
+
+func TestMaskBodyTextFormats(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	for _, tc := range []struct {
+		name, body, want string
+		hints            []string
+	}{
+		{"empty", "", "", []string{"binary"}},
+		{"form", "name=visible&Password=" + secret, "name=visible&Password=FAKE***", []string{"formData"}},
+		{"encoded form keys", "%50assword=" + secret + "&Password=another-secret&name=%E4%B8%AD", "%50assword=FAKE***&Password=anot***&name=%E4%B8%AD", nil},
+		{"form escaped delimiters", "password=a%26%3D%2BSECRET&name=alice", "password=a%26%3D%2B***&name=alice", []string{"formData"}},
+		{"form empty and short secrets", "password=&token=x&name=alice", "password=&token=***&name=alice", []string{"formData"}},
+		{"raw lines", "name: visible\nPassword: " + secret + "\nregion: cn-hangzhou", "name: visible\nPassword: ***\nregion: cn-hangzhou", []string{"raw"}},
+		{"raw assignments", "name=visible, password=" + secret + ", region=cn-hangzhou", "name=visible, password=***, region=cn-hangzhou", []string{"raw"}},
+		{"raw space separated fields", "name=visible password=" + secret, "name=visible password=***", []string{"raw"}},
+		{"form literal newline", "%50assword=" + secret + "\ncontinued&name=visible", "%50assword=FAKE***&name=visible", []string{"formData"}},
+		{"raw quoted values", `name: visible, token: "` + secret + `, with spaces", region: cn-hangzhou`, `name: visible, token: ***, region: cn-hangzhou`, nil},
+		{"raw quoted assignment", `name=visible password="` + secret + `&continued-secret"`, `name=visible password=***`, []string{"raw"}},
+		{"plain text", "ordinary text 正文末尾", "ordinary text 正文末尾", []string{"raw"}},
+		{"JSON without declaration", `{"name":"visible","password":"` + secret + `"}`, `{"name":"visible","password":"FAKE***"}`, nil},
+		{"JSON with raw declaration", `{"name":"visible","password":"` + secret + `"}`, `{"name":"visible","password":"FAKE***"}`, []string{"raw"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskBodyFull(tc.body, tc.hints...); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+			if got := MaskBody(tc.body); strings.Contains(got, secret) {
+				t.Errorf("log body leaked secret: %q", got)
+			}
+		})
+	}
+}
+
+func TestMaskBodyFormKeepsOriginalStarsEncoded(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{"password prefix", "password=*abcSECRET&note=***", "password=%2Aabc***&note=%2A%2A%2A"},
+		{"star-only prefix", "password=****SECRET", "password=%2A%2A%2A%2A***"},
+		{"already encoded stars", "password=%2AabcSECRET&note=%2A%2A%2A", "password=%2Aabc***&note=%2A%2A%2A"},
+		{"ordinary field", "note=***", "note=%2A%2A%2A"},
+		{"embedded JSON", "config=" + url.QueryEscape(`{"note":"***","password":"*abcSECRET"}`), "config=%7B%22note%22%3A%22%2A%2A%2A%22%2C%22password%22%3A%22%2Aabc***%22%7D"},
+		{"embedded JSON array", "config=" + url.QueryEscape(`[{"note":"*","token":123}]`), "config=%5B%7B%22note%22%3A%22%2A%22%2C%22token%22%3A%22***%22%7D%5D"},
+		{"nested JSON string and marker collision", "config=" + url.QueryEscape(`{"inner":"{\"note\":\"\\u005f_REDACTED__***\",\"password\":\"*abcSECRET\"}"}`), "config=%7B%22inner%22%3A%22%7B%5C%22note%5C%22%3A%5C%22__REDACTED__%2A%2A%2A%5C%22%2C%5C%22password%5C%22%3A%5C%22%2Aabc***%5C%22%7D%22%7D"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskBodyFull(tc.body, "formData"); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMaskBodyNestedForm(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	const nested = `{"name":"alice","password":"FAKE_SECRET_123","id":3460000290000487710}`
+	const maskedNested = `{"id":3460000290000487710,"name":"alice","password":"FAKE***"}`
+	for _, key := range []string{"user.password", "user.password.1", "user.password.2", "user.1.password", "user[password]", "user[1][password]", "user.%70assword.1"} {
+		t.Run(key, func(t *testing.T) {
+			body := key + "=" + secret + "&user.name=alice"
+			got := MaskBodyFull(body, "formData")
+			if want := key + "=FAKE***&user.name=alice"; got != want {
+				t.Fatalf("got %q, want %q", got, want)
+			}
+		})
+	}
+	for _, tc := range []struct{ name, body, want string }{
+		{"embedded JSON", "config=" + url.QueryEscape(nested), "config=" + strings.ReplaceAll(url.QueryEscape(maskedNested), "%2A", "*")},
+		{"embedded JSON array", "config=" + url.QueryEscape("["+nested+"]"), "config=" + strings.ReplaceAll(url.QueryEscape("["+maskedNested+"]"), "%2A", "*")},
+		{"repeated JSON fields", "config=" + url.QueryEscape(nested) + "&config=" + url.QueryEscape(nested), "config=" + strings.ReplaceAll(url.QueryEscape(maskedNested), "%2A", "*") + "&config=" + strings.ReplaceAll(url.QueryEscape(maskedNested), "%2A", "*")},
+		{"ordinary encoded value", "name=%E4%B8%AD&note=hello%20world", "name=%E4%B8%AD&note=hello%20world"},
+		{"non-sensitive JSON spelling", "config=" + url.QueryEscape(`{ "name": "alice", "id": 1 }`), "config=" + url.QueryEscape(`{ "name": "alice", "id": 1 }`)},
+		{"flat form map", `{"user.password.1":"FAKE_SECRET_123","user.name":"alice"}`, `{"user.name":"alice","user.password.1":"FAKE***"}`},
+		{"non-sensitive similar names", "user.passwordHint=visible&tokenizer.1=visible", "user.passwordHint=visible&tokenizer.1=visible"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskBodyFull(tc.body, "formData"); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+	// ParamStyle=json stores JSON inside a string in the form map.
+	body, _ := json.Marshal(map[string]any{"config": nested})
+	got := MaskBodyFull(string(body), "formData")
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil || decoded["config"] != maskedNested {
+		t.Fatalf("JSON string field = %s, error = %v", got, err)
+	}
+	// A JSON-valued form field can itself contain another JSON string field.
+	inner, _ := json.Marshal(map[string]string{"inner": nested})
+	body = []byte("config=" + url.QueryEscape(string(inner)))
+	form, err := url.ParseQuery(MaskBodyFull(string(body), "formData"))
+	if err != nil || json.Unmarshal([]byte(form.Get("config")), &decoded) != nil || decoded["inner"] != maskedNested {
+		t.Fatalf("nested JSON string field = %v, error = %v", form, err)
+	}
+	// Damaged nested JSON must not escape via a non-sensitive outer field.
+	broken := `{"password":"FAKE_SECRET_123`
+	body = []byte("config=" + url.QueryEscape(broken) + "&name=alice")
+	if got := MaskBodyFull(string(body), "formData"); strings.Contains(got, secret) || !strings.Contains(got, "name=alice") {
+		t.Fatalf("unsafe malformed JSON value: %s", got)
+	}
+}
+
+func TestMaskBodyFullOmitsXML(t *testing.T) {
+	for _, body := range []string{
+		`<Request><Password>FAKE_SECRET_123</Password></Request>`,
+		" \n<?xml version=\"1.0\"?><credentials><User>中文</User><Password>FAKE_SECRET_123</Password></credentials>",
+		`<Request><Password>FAKE_SECRET_123</Request>`,
+	} {
+		for _, format := range []string{"", "raw", "application/xml"} {
+			want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+			if got := MaskBodyFull(body, format); got != want {
+				t.Errorf("MaskBodyFull(%q, %q) = %q, want %q", body, format, got, want)
+			}
+		}
+	}
+}
+
+func TestMaskBodyUnsafeFormats(t *testing.T) {
+	for _, body := range []string{
+		`{"password":"FAKE_SECRET_123`,
+		`%50assword=FAKE_SECRET_123&name=%zz`,
+		"password: \"FAKE_SECRET_123\ncontinued-secret",
+		"password:\n  FAKE_SECRET_123",
+	} {
+		if got, want := MaskBodyFull(body), fmt.Sprintf("[body redacted: %d bytes]", len(body)); got != want {
+			t.Errorf("malformed text: got %q, want %q", got, want)
+		}
+	}
+	for _, tc := range []struct{ body, format string }{
+		{"\x00FAKE_SECRET_123", "raw"},
+		{"\xffFAKE_SECRET_123", ""},
+		{`{"password":"FAKE_SECRET_123"}`, "binary"},
+		{"Password=FAKE_SECRET_123", "Application/Octet-Stream; charset=utf-8"},
+	} {
+		if got, want := MaskBodyFull(tc.body, tc.format), fmt.Sprintf("[body omitted: %d bytes]", len(tc.body)); got != want {
+			t.Errorf("binary: got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestMaskBodyFullOmitsUnsupportedFormats(t *testing.T) {
+	const body = `{"password":"FAKE_SECRET_123"}`
+	for _, format := range []string{
+		"byte",
+		"binary",
+		"application/octet-stream",
+		"application/x-protobuf",
+		"application/pdf",
+		"application/zip",
+		"application/cbor",
+		"application/msgpack",
+		"application/x-custom-format",
+		" FutureFormat ; version=2",
+		"yaml",
+		"text/yaml",
+		"text/csv",
+		"multipart/form-data; boundary=example",
+		"image/png",
+		"audio/ogg",
+		"video/webm",
+		"not-a-media-type+json",
+		"text/plain",
+		"text/xml",
+		"application/xml; charset=utf-8",
+		"text",
+		"xml",
+		"application/example+xml; charset=utf-8",
+		"image/svg+xml",
+	} {
+		t.Run(format, func(t *testing.T) {
+			want := fmt.Sprintf("[body omitted: %d bytes]", len(body))
+			for _, hints := range [][]string{{format}, {"json", format}, {format, "application/json"}} {
+				if got := MaskBodyFull(body, hints...); got != want {
+					t.Fatalf("MaskBodyFull(%q) = %q, want %q", hints, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestMaskBodyFullAllowsSupportedTextFormats(t *testing.T) {
+	const body = `{"password":"FAKE_SECRET_123","name":"visible"}`
+	for _, format := range []string{
+		"",
+		"raw",
+		"json",
+		"form",
+		"formData",
+		" Application/JSON ; charset=utf-8",
+		"application/json; charset=utf-8",
+		"application/problem+json",
+		"text/json",
+		"application/x-www-form-urlencoded",
+	} {
+		t.Run(format, func(t *testing.T) {
+			got := MaskBodyFull(body, format)
+			if got != `{"password":"FAKE***","name":"visible"}` && got != `{"name":"visible","password":"FAKE***"}` {
+				t.Fatalf("MaskBodyFull(%q) = %q", format, got)
+			}
+		})
+	}
+}
+
+func TestMaskBodyFullPreservesCompleteRedactedJSON(t *testing.T) {
+	padding := strings.Repeat("x", 1200)
+	input := `{"content":"` + padding + `","password":"FAKE_SECRET_123"}`
+	output := MaskBodyFull(input)
+
+	if strings.Contains(output, "FAKE_SECRET_123") {
+		t.Fatalf("secret leaked from JSON body: %s", output)
+	}
+	if !strings.Contains(output, padding) {
+		t.Fatal("dry-run JSON body was truncated")
+	}
+	if !strings.Contains(output, `"password":"FAKE***"`) {
+		t.Fatalf("JSON secret was not masked: %s", output)
+	}
+}
+
+func TestMaskBodyFullEmpty(t *testing.T) {
+	if got := MaskBodyFull(""); got != "" {
+		t.Fatalf("MaskBodyFull(empty) = %q", got)
 	}
 }
 

--- a/aliyun-openapi-runtime/redact/redact.go
+++ b/aliyun-openapi-runtime/redact/redact.go
@@ -28,6 +28,8 @@ func MaskKV(key, value string) string { return internal.MaskKV(key, value) }
 func MaskBody(body string) string { return internal.MaskBody(body) }
 
 // MaskBodyFull redacts the complete body for dry-run output without a size limit.
-func MaskBodyFull(body string) string { return internal.MaskBodyFull(body) }
+func MaskBodyFull(body string, formats ...string) string {
+	return internal.MaskBodyFull(body, formats...)
+}
 
 func MaskAny(data any) any { return internal.MaskAny(data) }

--- a/aliyun-openapi-runtime/redact/redact_test.go
+++ b/aliyun-openapi-runtime/redact/redact_test.go
@@ -29,6 +29,12 @@ func TestPublicRedactionContract(t *testing.T) {
 	if got := MaskBody(`{"password":"secret-value"}`); got != `{"password":"secr***"}` {
 		t.Fatalf("MaskBody = %q", got)
 	}
+	if got := MaskBodyFull("password=secret-value"); got != "password=secr***" {
+		t.Fatalf("MaskBodyFull = %q", got)
+	}
+	if got := MaskBodyFull(`{"name":"visible"}`, "binary"); got != "[body omitted: 18 bytes]" {
+		t.Fatalf("MaskBodyFull = %q", got)
+	}
 	masked := MaskAny(map[string]any{"token": "secret-value"}).(map[string]any)
 	if masked["token"] != "secr***" {
 		t.Fatalf("MaskAny = %#v", masked)

--- a/aliyun-openapi-runtime/runtime/executor.go
+++ b/aliyun-openapi-runtime/runtime/executor.go
@@ -132,8 +132,12 @@ type AssembledRequest struct {
 	// ReqBodyType is the request body encoding: "json" (default) or "formData".
 	// Empty and all non-formData metadata values are treated as "json" to match aliyun-cli-runtime.
 	ReqBodyType string `json:"req_body_type,omitempty"`
-	Endpoint    string `json:"endpoint,omitempty"`
-	Region      string `json:"region,omitempty"`
+	// DeclaredReqBodyType and DeclaredContentType retain metadata hints solely
+	// for safe dry-run rendering. Sending continues to use ReqBodyType above.
+	DeclaredReqBodyType string `json:"-"`
+	DeclaredContentType string `json:"-"`
+	Endpoint            string `json:"endpoint,omitempty"`
+	Region              string `json:"region,omitempty"`
 }
 
 // Response is what Execute returns.
@@ -215,7 +219,9 @@ func newAssembledRequest(api *meta.API) *AssembledRequest {
 		Query:    map[string]string{},
 		Headers:  map[string]string{},
 		// aliyun-cli-runtime defaults every operation to json and only generated formData APIs call SetReqBodyType("formData").
-		ReqBodyType: resolveReqBodyType(api),
+		ReqBodyType:         resolveReqBodyType(api),
+		DeclaredReqBodyType: strings.TrimSpace(api.ReqBodyType),
+		DeclaredContentType: strings.TrimSpace(api.ContentType),
 	}
 	if !strings.EqualFold(style, string(meta.StyleRPC)) {
 		req.PathPattern = api.URL

--- a/aliyun-openapi-runtime/runtime/executor_test.go
+++ b/aliyun-openapi-runtime/runtime/executor_test.go
@@ -643,6 +643,9 @@ func TestNonFormBodyMetadataKeepsLegacyJSONExecution(t *testing.T) {
 	if req.ReqBodyType != "json" {
 		t.Fatalf("ReqBodyType = %q, want json", req.ReqBodyType)
 	}
+	if req.DeclaredReqBodyType != "byte" || req.DeclaredContentType != "application/vnd.example.payload" {
+		t.Fatalf("dry-run body hints = %q, %q", req.DeclaredReqBodyType, req.DeclaredContentType)
+	}
 	if _, exists := req.Headers["content-type"]; exists {
 		t.Fatalf("non-form metadata must not override content-type: %#v", req.Headers)
 	}

--- a/cli/plugin/archive.go
+++ b/cli/plugin/archive.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxPluginArchiveBytes   int64 = 64 << 20
+	maxPluginFileBytes      int64 = 128 << 20
+	maxPluginExtractedBytes int64 = 256 << 20
+	maxPluginArchiveEntries       = 10_000
+)
+
+type pluginArchiveLimits struct {
+	archiveBytes   int64
+	fileBytes      int64
+	extractedBytes int64
+	entries        int
+}
+
+var defaultPluginArchiveLimits = pluginArchiveLimits{
+	archiveBytes:   maxPluginArchiveBytes,
+	fileBytes:      maxPluginFileBytes,
+	extractedBytes: maxPluginExtractedBytes,
+	entries:        maxPluginArchiveEntries,
+}
+
+func downloadFile(url, dest string) error {
+	return downloadFileWithLimit(url, dest, defaultPluginArchiveLimits.archiveBytes)
+}
+
+func downloadFileWithLimit(url, dest string, limit int64) error {
+	resp, err := httpGet(url, pluginArchiveDLTimeout)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %d", resp.StatusCode)
+	}
+	return writePluginArchiveResponse(resp, dest, limit)
+}
+
+func writePluginArchiveResponse(resp *http.Response, dest string, limit int64) error {
+	if resp.ContentLength > limit {
+		return fmt.Errorf("plugin archive download size %d exceeds limit of %d bytes", resp.ContentLength, limit)
+	}
+	return writeReaderWithLimit(resp.Body, dest, limit)
+}
+
+func writeReaderWithLimit(reader io.Reader, dest string, limit int64) (err error) {
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	keep := false
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+			keep = false
+		}
+		if !keep {
+			_ = os.Remove(dest)
+		}
+	}()
+
+	written, err := io.Copy(out, io.LimitReader(reader, limit+1))
+	if err != nil {
+		return err
+	}
+	if written > limit {
+		return fmt.Errorf("plugin archive download exceeds limit of %d bytes", limit)
+	}
+	keep = true
+	return nil
+}
+
+func validatePluginArchiveSize(src string, limit int64) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("plugin archive is a directory: %s", src)
+	}
+	if info.Size() > limit {
+		return fmt.Errorf("plugin archive size %d exceeds limit of %d bytes", info.Size(), limit)
+	}
+	return nil
+}
+
+func untar(src, dest string) error {
+	return untarWithLimits(src, dest, defaultPluginArchiveLimits)
+}
+
+func untarWithLimits(src, dest string, limits pluginArchiveLimits) error {
+	if err := validatePluginArchiveSize(src, limits.archiveBytes); err != nil {
+		return err
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	var extracted int64
+	entries := 0
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		entries++
+		if entries > limits.entries {
+			return fmt.Errorf("plugin archive contains more than %d entries", limits.entries)
+		}
+
+		target, err := safeArchiveTarget(dest, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := validateExtractedFileSize(header.Name, header.Size, extracted, limits); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			written, err := writeExtractedFile(target, os.FileMode(header.Mode), tr, header.Size)
+			if err != nil {
+				return err
+			}
+			if written != header.Size {
+				return fmt.Errorf("plugin archive file %q size changed during extraction", header.Name)
+			}
+			extracted += written
+		}
+	}
+}
+
+func unzip(src, dest string) error {
+	return unzipWithLimits(src, dest, defaultPluginArchiveLimits)
+}
+
+func unzipWithLimits(src, dest string, limits pluginArchiveLimits) error {
+	if err := validatePluginArchiveSize(src, limits.archiveBytes); err != nil {
+		return err
+	}
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if len(r.File) > limits.entries {
+		return fmt.Errorf("plugin archive contains more than %d entries", limits.entries)
+	}
+	var extracted int64
+	for _, file := range r.File {
+		target, err := safeArchiveTarget(dest, file.Name)
+		if err != nil {
+			return err
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+			continue
+		}
+		if file.UncompressedSize64 > uint64(^uint64(0)>>1) {
+			return fmt.Errorf("plugin archive file %q has unsupported size", file.Name)
+		}
+		size := int64(file.UncompressedSize64)
+		if err := validateExtractedFileSize(file.Name, size, extracted, limits); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		written, writeErr := writeExtractedFile(target, file.Mode(), rc, minInt64(limits.fileBytes, limits.extractedBytes-extracted))
+		closeErr := rc.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if written != size {
+			return fmt.Errorf("plugin archive file %q size changed during extraction", file.Name)
+		}
+		extracted += written
+	}
+	return nil
+}
+
+func validateExtractedFileSize(name string, size, extracted int64, limits pluginArchiveLimits) error {
+	if size < 0 {
+		return fmt.Errorf("plugin archive file %q has invalid size %d", name, size)
+	}
+	if size > limits.fileBytes {
+		return fmt.Errorf("plugin archive file %q size %d exceeds per-file limit of %d bytes", name, size, limits.fileBytes)
+	}
+	if size > limits.extractedBytes-extracted {
+		return fmt.Errorf("plugin archive extracted size exceeds limit of %d bytes", limits.extractedBytes)
+	}
+	return nil
+}
+
+func writeExtractedFile(target string, mode os.FileMode, reader io.Reader, limit int64) (written int64, err error) {
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return 0, err
+	}
+	keep := false
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+			keep = false
+		}
+		if !keep {
+			_ = os.Remove(target)
+		}
+	}()
+
+	written, err = io.Copy(out, io.LimitReader(reader, limit+1))
+	if err != nil {
+		return written, err
+	}
+	if written > limit {
+		return written, fmt.Errorf("plugin archive file %q exceeds extraction limit of %d bytes", target, limit)
+	}
+	keep = true
+	return written, nil
+}
+
+func safeArchiveTarget(dest, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("illegal absolute path in archive: %s", name)
+	}
+	if strings.Contains(name, "..") {
+		return "", fmt.Errorf("illegal path with '..' in archive: %s", name)
+	}
+	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
+		return "", fmt.Errorf("illegal path starting with separator in archive: %s", name)
+	}
+
+	target := filepath.Clean(filepath.Join(dest, name))
+	destPath := filepath.Clean(dest) + string(os.PathSeparator)
+	if !strings.HasPrefix(target, destPath) {
+		return "", fmt.Errorf("illegal file path in archive: %s", name)
+	}
+	return target, nil
+}
+
+func minInt64(left, right int64) int64 {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func (m *Manager) effectiveArchiveLimits() pluginArchiveLimits {
+	if m != nil && m.archiveLimits != nil {
+		return *m.archiveLimits
+	}
+	return defaultPluginArchiveLimits
+}

--- a/cli/plugin/archive_test.go
+++ b/cli/plugin/archive_test.go
@@ -1,0 +1,199 @@
+package plugin
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWritePluginArchiveResponseEnforcesStreamingLimit(t *testing.T) {
+	t.Run("exact limit succeeds", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "plugin.tgz")
+		resp := &http.Response{
+			Body:          io.NopCloser(strings.NewReader("12345")),
+			ContentLength: -1,
+		}
+		require.NoError(t, writePluginArchiveResponse(resp, dest, 5))
+		assert.FileExists(t, dest)
+	})
+
+	t.Run("chunked body over limit is removed", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "plugin.tgz")
+		resp := &http.Response{
+			Body:          io.NopCloser(strings.NewReader("123456")),
+			ContentLength: -1,
+		}
+		err := writePluginArchiveResponse(resp, dest, 5)
+		require.ErrorContains(t, err, "exceeds limit")
+		_, statErr := os.Stat(dest)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("content length over limit is rejected", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "plugin.tgz")
+		resp := &http.Response{
+			Body:          io.NopCloser(strings.NewReader("small")),
+			ContentLength: 6,
+		}
+		err := writePluginArchiveResponse(resp, dest, 5)
+		require.ErrorContains(t, err, "size 6 exceeds limit")
+		_, statErr := os.Stat(dest)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+}
+
+func TestUntarResourceLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []testFile
+		limits  pluginArchiveLimits
+		wantErr string
+	}{
+		{
+			name:   "exact limits succeed",
+			files:  []testFile{{name: "file", content: "12345"}},
+			limits: pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 5, entries: 1},
+		},
+		{
+			name:    "single file exceeds limit",
+			files:   []testFile{{name: "file", content: "123456"}},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 10, entries: 2},
+			wantErr: "per-file limit",
+		},
+		{
+			name: "total extracted size exceeds limit",
+			files: []testFile{
+				{name: "first", content: "12345"},
+				{name: "second", content: "6789"},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 8, entries: 2},
+			wantErr: "extracted size exceeds limit",
+		},
+		{
+			name: "entry count exceeds limit",
+			files: []testFile{
+				{name: "one/", isDir: true},
+				{name: "two/", isDir: true},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 10, extractedBytes: 10, entries: 1},
+			wantErr: "more than 1 entries",
+		},
+		{
+			name:    "compressed expansion exceeds total limit",
+			files:   []testFile{{name: "zeros", content: strings.Repeat("0", 4096)}},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 8192, extractedBytes: 1024, entries: 1},
+			wantErr: "extracted size exceeds limit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := filepath.Join(t.TempDir(), "plugin.tgz")
+			require.NoError(t, createTestTarGz(archivePath, test.files))
+			err := untarWithLimits(archivePath, filepath.Join(t.TempDir(), "extract"), test.limits)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestUnzipResourceLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []testFile
+		limits  pluginArchiveLimits
+		wantErr string
+	}{
+		{
+			name:   "exact limits succeed",
+			files:  []testFile{{name: "file", content: "12345"}},
+			limits: pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 5, entries: 1},
+		},
+		{
+			name:    "single file exceeds limit",
+			files:   []testFile{{name: "file", content: "123456"}},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 10, entries: 2},
+			wantErr: "per-file limit",
+		},
+		{
+			name: "total extracted size exceeds limit",
+			files: []testFile{
+				{name: "first", content: "12345"},
+				{name: "second", content: "6789"},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 8, entries: 2},
+			wantErr: "extracted size exceeds limit",
+		},
+		{
+			name: "entry count exceeds limit",
+			files: []testFile{
+				{name: "one/", isDir: true},
+				{name: "two/", isDir: true},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 10, extractedBytes: 10, entries: 1},
+			wantErr: "more than 1 entries",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := filepath.Join(t.TempDir(), "plugin.zip")
+			require.NoError(t, createTestZip(archivePath, test.files))
+			err := unzipWithLimits(archivePath, filepath.Join(t.TempDir(), "extract"), test.limits)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractPluginFailureCleansStaging(t *testing.T) {
+	root := t.TempDir()
+	archivePath := filepath.Join(root, "broken.tgz")
+	require.NoError(t, os.WriteFile(archivePath, []byte("not gzip"), 0644))
+	extractDir := filepath.Join(root, "staging")
+	require.NoError(t, os.MkdirAll(extractDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(extractDir, "partial"), []byte("partial"), 0644))
+
+	err := (&Manager{rootDir: root}).extractPlugin(archivePath, extractDir, archivePath)
+	require.Error(t, err)
+	_, statErr := os.Stat(extractDir)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestOversizedLocalPackagePreservesExistingPlugin(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "limited-plugin")
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "old-binary"), []byte("old"), 0755))
+
+	archive := createTestPluginArchive(t, "limited-plugin", "2.0.0", "limited")
+	archivePath := filepath.Join(t.TempDir(), "limited-plugin.tgz")
+	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
+	limits := defaultPluginArchiveLimits
+	limits.archiveBytes = int64(len(archive) - 1)
+	mgr := &Manager{rootDir: root, archiveLimits: &limits}
+	require.NoError(t, mgr.saveLocalManifest(&LocalManifest{Plugins: map[string]LocalPlugin{
+		"limited-plugin": {
+			Name: "limited-plugin", Version: "1.0.0", Path: pluginDir, Command: "limited",
+		},
+	}}))
+
+	err := mgr.installFromPackageFile(newTestContext(), archivePath, archivePath)
+	require.ErrorContains(t, err, "plugin archive size")
+	assert.FileExists(t, filepath.Join(pluginDir, "old-binary"))
+	manifest, manifestErr := mgr.GetLocalManifest()
+	require.NoError(t, manifestErr)
+	assert.Equal(t, "1.0.0", manifest.Plugins["limited-plugin"].Version)
+}

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -1,9 +1,6 @@
 package plugin
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -64,6 +61,10 @@ type Manager struct {
 	goOnly bool
 	// skipPluginIndexCacheForCLI is set when --source-base is used on this command only.
 	skipPluginIndexCacheForCLI bool
+	// saveLocalManifestHook injects manifest commit failures in transaction tests.
+	saveLocalManifestHook func(*LocalManifest) error
+	// archiveLimits overrides package resource boundaries in tests.
+	archiveLimits *pluginArchiveLimits
 }
 
 func getHomePath() string {
@@ -480,16 +481,49 @@ func (m *Manager) GetLocalManifest() (*LocalManifest, error) {
 }
 
 func (m *Manager) saveLocalManifest(manifest *LocalManifest) error {
+	if m.saveLocalManifestHook != nil {
+		return m.saveLocalManifestHook(manifest)
+	}
+	if err := os.MkdirAll(m.rootDir, 0755); err != nil {
+		return err
+	}
 	path := filepath.Join(m.rootDir, "manifest.json")
-	f, err := os.Create(path)
+	f, err := os.CreateTemp(m.rootDir, ".manifest-*.tmp")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	tmpPath := f.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
-	return enc.Encode(manifest)
+	if err := enc.Encode(manifest); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+
+	replacement, err := replacePathWithRollback(tmpPath, path, ".manifest-rollback-*")
+	if err != nil {
+		return err
+	}
+	removeTemp = false
+	replacement.commit()
+	return nil
 }
 
 func (m *Manager) findPluginInIndex(pluginName string) (*PluginInfo, error) {
@@ -568,153 +602,6 @@ func (m *Manager) validateVersionAndPlatform(ctx *cli.Context, targetPlugin *Plu
 	return &platInfo, nil
 }
 
-func downloadFile(url, dest string) error {
-	resp, err := httpGet(url, pluginArchiveDLTimeout)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed: %d", resp.StatusCode)
-	}
-
-	out, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, resp.Body)
-	return err
-}
-
-func untar(src, dest string) error {
-	f, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return err
-	}
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		// check if the path is absolute or contains suspicious patterns
-		if filepath.IsAbs(header.Name) {
-			return fmt.Errorf("illegal absolute path in archive: %s", header.Name)
-		}
-		if strings.Contains(header.Name, "..") {
-			return fmt.Errorf("illegal path with '..' in archive: %s", header.Name)
-		}
-		// Reject paths starting with / or \ for cross-platform security
-		if strings.HasPrefix(header.Name, "/") || strings.HasPrefix(header.Name, "\\") {
-			return fmt.Errorf("illegal path starting with separator in archive: %s", header.Name)
-		}
-
-		target := filepath.Join(dest, header.Name)
-		target = filepath.Clean(target)
-
-		// Double-check: ensure the target path is within the destination directory
-		destPath := filepath.Clean(dest) + string(os.PathSeparator)
-		if !strings.HasPrefix(target, destPath) {
-			return fmt.Errorf("illegal file path in archive: %s", header.Name)
-		}
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
-				return err
-			}
-		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return err
-			}
-			f.Close()
-		}
-	}
-	return nil
-}
-
-func unzip(src, dest string) error {
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-		// check if the path is absolute or contains suspicious patterns
-		if filepath.IsAbs(f.Name) {
-			return fmt.Errorf("illegal absolute path in archive: %s", f.Name)
-		}
-		if strings.Contains(f.Name, "..") {
-			return fmt.Errorf("illegal path with '..' in archive: %s", f.Name)
-		}
-		// Reject paths starting with / or \ for cross-platform security
-		if strings.HasPrefix(f.Name, "/") || strings.HasPrefix(f.Name, "\\") {
-			return fmt.Errorf("illegal path starting with separator in archive: %s", f.Name)
-		}
-
-		fpath := filepath.Join(dest, f.Name)
-		fpath = filepath.Clean(fpath)
-
-		// Double-check: ensure the target path is within the destination directory
-		destPath := filepath.Clean(dest) + string(os.PathSeparator)
-		if !strings.HasPrefix(fpath, destPath) {
-			return fmt.Errorf("illegal file path in archive: %s", f.Name)
-		}
-
-		if f.FileInfo().IsDir() {
-			os.MkdirAll(fpath, os.ModePerm)
-			continue
-		}
-
-		if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-			return err
-		}
-
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			outFile.Close()
-			return err
-		}
-
-		_, err = io.Copy(outFile, rc)
-
-		outFile.Close()
-		rc.Close()
-
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func calculateSHA256(filePath string) (string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -739,7 +626,7 @@ func (m *Manager) downloadAndVerifyPlugin(ctx *cli.Context, platInfo *PlatformIn
 	}
 
 	archivePath := filepath.Join(tmpDir, "plugin.archive")
-	if err := downloadFile(platInfo.URL, archivePath); err != nil {
+	if err := downloadFileWithLimit(platInfo.URL, archivePath, m.effectiveArchiveLimits().archiveBytes); err != nil {
 		os.RemoveAll(tmpDir)
 		return "", err
 	}
@@ -763,18 +650,23 @@ func (m *Manager) downloadAndVerifyPlugin(ctx *cli.Context, platInfo *PlatformIn
 	return archivePath, nil
 }
 
-func (m *Manager) extractPlugin(archivePath, extractDir, downloadURL string) error {
+func (m *Manager) extractPlugin(archivePath, extractDir, downloadURL string) (err error) {
 	if err := os.RemoveAll(extractDir); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(extractDir, 0755); err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(extractDir)
+		}
+	}()
 
 	if strings.HasSuffix(strings.ToLower(downloadURL), ".zip") {
-		return unzip(archivePath, extractDir)
+		return unzipWithLimits(archivePath, extractDir, m.effectiveArchiveLimits())
 	}
-	return untar(archivePath, extractDir)
+	return untarWithLimits(archivePath, extractDir, m.effectiveArchiveLimits())
 }
 
 func expandPluginSourcePath(raw string) (string, error) {
@@ -923,48 +815,23 @@ func validateAndResolvePackageType(extractDir string, manifest *PluginManifest) 
 	return runtimesource.ValidateMetadataPlugin(extractDir, manifest.Metadata)
 }
 
-func copyDirTree(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode().Perm())
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return err
-		}
-		return os.WriteFile(target, data, info.Mode().Perm())
-	})
+func (m *Manager) newPluginStagingDir(pattern string) (string, error) {
+	if err := os.MkdirAll(m.rootDir, 0755); err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(m.rootDir, pattern)
 }
 
-func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (string, error) {
+func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (*pathReplacement, error) {
 	finalDir, err := resolvePluginInstallDir(m.rootDir, pluginName)
 	if err != nil {
-		return "", fmt.Errorf("invalid plugin name: %w", err)
+		return nil, fmt.Errorf("invalid plugin name: %w", err)
 	}
-	if err := os.RemoveAll(finalDir); err != nil {
-		return "", fmt.Errorf("failed to remove existing plugin directory: %w", err)
+	replacement, err := replacePathWithRollback(tmpExtract, finalDir, "."+pluginName+"-rollback-*")
+	if err != nil {
+		return nil, err
 	}
-	if err := os.Rename(tmpExtract, finalDir); err == nil {
-		return finalDir, nil
-	}
-	if err := copyDirTree(tmpExtract, finalDir); err != nil {
-		return "", fmt.Errorf("failed to copy plugin files: %w", err)
-	}
-	if err := os.RemoveAll(tmpExtract); err != nil {
-		return "", fmt.Errorf("failed to remove temporary extract directory: %w", err)
-	}
-	return finalDir, nil
+	return replacement, nil
 }
 
 func (m *Manager) printOverwriteIfPluginInstalled(ctx *cli.Context, pluginName, incomingVersion string) {
@@ -1027,11 +894,12 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL string) e
 		return fmt.Errorf("package URL path must end with .zip, .tar.gz, or .tgz")
 	}
 
-	cli.Printf(ctx.Stdout(), "Downloading plugin package from %s...\n", rawURL)
+	displayURL := safePluginPackageURL(u)
+	cli.Printf(ctx.Stdout(), "Downloading plugin package from %s...\n", displayURL)
 
 	resp, err := httpGet(rawURL, pluginArchiveDLTimeout)
 	if err != nil {
-		return fmt.Errorf("download plugin package: %w", err)
+		return safePluginDownloadError(err, displayURL)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -1049,19 +917,11 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL string) e
 		base = "plugin.tgz"
 	}
 	dest := filepath.Join(tmpParent, base)
-	out, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("create temp package file: %w", err)
-	}
-	if _, err := io.Copy(out, resp.Body); err != nil {
-		out.Close()
-		return fmt.Errorf("write plugin package: %w", err)
-	}
-	if err := out.Close(); err != nil {
+	if err := writePluginArchiveResponse(resp, dest, m.effectiveArchiveLimits().archiveBytes); err != nil {
 		return fmt.Errorf("write plugin package: %w", err)
 	}
 
-	return m.installFromPackageFile(ctx, dest, rawURL)
+	return m.installFromPackageFile(ctx, dest, displayURL)
 }
 
 func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing string) error {
@@ -1071,7 +931,7 @@ func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing s
 
 	cli.Printf(ctx.Stdout(), "Installing plugin from %s...\n", userFacing)
 
-	tmpParent, err := os.MkdirTemp("", "aliyun-plugin-local-*")
+	tmpParent, err := m.newPluginStagingDir(".aliyun-plugin-local-*")
 	if err != nil {
 		return err
 	}
@@ -1089,14 +949,18 @@ func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing s
 
 	m.printOverwriteIfPluginInstalled(ctx, pManifest.Name, pManifest.Version)
 
-	finalDir, err := m.promoteExtractedPlugin(tmpExtract, pManifest.Name)
+	promotion, err := m.promoteExtractedPlugin(tmpExtract, pManifest.Name)
 	if err != nil {
 		return err
 	}
 
-	if err := m.savePluginToManifest(pManifest.Name, pManifest.Version, finalDir, pManifest); err != nil {
+	if err := m.savePluginToManifest(pManifest.Name, pManifest.Version, promotion.finalPath, pManifest); err != nil {
+		if rollbackErr := promotion.rollback(); rollbackErr != nil {
+			return fmt.Errorf("%w; failed to restore previous plugin: %v", err, rollbackErr)
+		}
 		return err
 	}
+	promotion.commit()
 
 	cli.Printf(ctx.Stdout(), "Plugin %s %s installed successfully!\n", pManifest.Name, pManifest.Version)
 	return nil
@@ -1210,10 +1074,12 @@ func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, vers
 		m.printOverwriteIfPluginInstalled(ctx, actualPluginName, version)
 	}
 
-	extractDir, err := resolvePluginInstallDir(m.rootDir, actualPluginName)
+	stagingParent, err := m.newPluginStagingDir("." + actualPluginName + "-staging-*")
 	if err != nil {
-		return fmt.Errorf("invalid plugin name from repository: %w", err)
+		return fmt.Errorf("create plugin staging directory: %w", err)
 	}
+	defer os.RemoveAll(stagingParent)
+	extractDir := filepath.Join(stagingParent, "extract")
 	if err := m.extractPlugin(archivePath, extractDir, downloadURL); err != nil {
 		return err
 	}
@@ -1227,9 +1093,17 @@ func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, vers
 		populateMinCliVersionFromIndex(pManifest, verInfo)
 	}
 
-	if err := m.savePluginToManifest(actualPluginName, version, extractDir, pManifest); err != nil {
+	promotion, err := m.promoteExtractedPlugin(extractDir, actualPluginName)
+	if err != nil {
 		return err
 	}
+	if err := m.savePluginToManifest(actualPluginName, version, promotion.finalPath, pManifest); err != nil {
+		if rollbackErr := promotion.rollback(); rollbackErr != nil {
+			return fmt.Errorf("%w; failed to restore previous plugin: %v", err, rollbackErr)
+		}
+		return err
+	}
+	promotion.commit()
 
 	cli.Printf(ctx.Stdout(), "Plugin %s %s installed successfully!\n", actualPluginName, version)
 	return nil

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -16,52 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopyDirTree(t *testing.T) {
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "out")
-
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "nested"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "nested", "b.txt"), []byte("beta"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("alpha"), 0644))
-
-	require.NoError(t, copyDirTree(src, dst))
-
-	b, err := os.ReadFile(filepath.Join(dst, "nested", "b.txt"))
-	require.NoError(t, err)
-	assert.Equal(t, "beta", string(b))
-	a, err := os.ReadFile(filepath.Join(dst, "a.txt"))
-	require.NoError(t, err)
-	assert.Equal(t, "alpha", string(a))
-}
-
-func TestCopyDirTree_emptyTree(t *testing.T) {
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "empty-out")
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "child"), 0755))
-
-	require.NoError(t, copyDirTree(src, dst))
-
-	st, err := os.Stat(filepath.Join(dst, "child"))
-	require.NoError(t, err)
-	assert.True(t, st.IsDir())
-}
-
-func TestCopyDirTree_preservesFilePerm(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permission bits differ on Windows")
-	}
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "perm-out")
-	p := filepath.Join(src, "secret")
-	require.NoError(t, os.WriteFile(p, []byte("x"), 0600))
-
-	require.NoError(t, copyDirTree(src, dst))
-
-	st, err := os.Stat(filepath.Join(dst, "secret"))
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0600), st.Mode().Perm())
-}
-
 func TestPromoteExtractedPlugin_rename(t *testing.T) {
 	root := t.TempDir()
 	tmpExtract := filepath.Join(root, "_extract_me")
@@ -69,15 +22,36 @@ func TestPromoteExtractedPlugin_rename(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpExtract, "manifest.json"), []byte("{}"), 0644))
 
 	mgr := &Manager{rootDir: root}
-	finalDir, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
+	promotion, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
 	require.NoError(t, err)
+	promotion.commit()
 
 	want := filepath.Join(root, "myplugin")
-	assert.Equal(t, want, finalDir)
+	assert.Equal(t, want, promotion.finalPath)
 	_, err = os.Stat(filepath.Join(want, "manifest.json"))
 	require.NoError(t, err)
 	_, err = os.Stat(tmpExtract)
 	assert.True(t, os.IsNotExist(err), "temp extract dir should be gone after rename")
+}
+
+func TestPromoteExtractedPlugin_rollbackRestoresExistingDirectory(t *testing.T) {
+	root := t.TempDir()
+	finalDir := filepath.Join(root, "myplugin")
+	require.NoError(t, os.MkdirAll(finalDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(finalDir, "version"), []byte("old"), 0644))
+
+	tmpExtract := filepath.Join(root, "_extract_me")
+	require.NoError(t, os.MkdirAll(tmpExtract, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpExtract, "version"), []byte("new"), 0644))
+
+	mgr := &Manager{rootDir: root}
+	promotion, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
+	require.NoError(t, err)
+	require.NoError(t, promotion.rollback())
+
+	version, err := os.ReadFile(filepath.Join(finalDir, "version"))
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(version))
 }
 
 func TestValidatePluginNameRejectsPathValues(t *testing.T) {
@@ -240,16 +214,33 @@ func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
 	mgr := &Manager{rootDir: pluginRoot}
 	archiveBody := createTestPluginArchive(t, "remote-url-plugin", "7.8.9", "x")
 
+	type requestDetails struct {
+		username string
+		password string
+		token    string
+	}
+	requests := make(chan requestDetails, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, _ := r.BasicAuth()
+		requests <- requestDetails{
+			username: username,
+			password: password,
+			token:    r.URL.Query().Get("token"),
+		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = w.Write(archiveBody)
 	}))
 	defer srv.Close()
-	archiveURL := srv.URL + "/pkgs/remote-url-plugin/7.8.9/plugin.tgz"
+	archiveURL := strings.Replace(srv.URL, "http://", "http://log-user:log-password@", 1) +
+		"/pkgs/remote-url-plugin/7.8.9/plugin.tgz?token=query-secret&signature=signature-secret#fragment-secret"
 
 	ctx := newTestContext()
 	err := mgr.InstallFromPackage(ctx, archiveURL)
 	require.NoError(t, err)
+	request := <-requests
+	assert.Equal(t, "log-user", request.username)
+	assert.Equal(t, "log-password", request.password)
+	assert.Equal(t, "query-secret", request.token)
 
 	manifest, err := mgr.GetLocalManifest()
 	require.NoError(t, err)
@@ -259,6 +250,12 @@ func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
 	out := ctx.Stdout().(*bytes.Buffer).String()
 	assert.Contains(t, out, "Downloading plugin package from")
 	assert.Contains(t, out, "Installing plugin from")
+	assert.Contains(t, out, srv.URL+"/pkgs/remote-url-plugin/7.8.9/plugin.tgz")
+	assert.NotContains(t, out, "log-user")
+	assert.NotContains(t, out, "log-password")
+	assert.NotContains(t, out, "query-secret")
+	assert.NotContains(t, out, "signature-secret")
+	assert.NotContains(t, out, "fragment-secret")
 }
 
 func TestManager_InstallFromPackage_RemoteURLBadSuffix(t *testing.T) {
@@ -292,9 +289,15 @@ func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
 		}))
 		base := srv.URL
 		srv.Close()
-		err := mgr.installFromRemotePackageURL(ctx, base+"/plugin.tgz")
+		rawURL := strings.Replace(base, "http://", "http://error-user:error-password@", 1) +
+			"/plugin.tgz?token=error-token#fragment-secret"
+		err := mgr.installFromRemotePackageURL(ctx, rawURL)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "download plugin package:")
+		assert.Contains(t, err.Error(), "download plugin package from "+base+"/plugin.tgz:")
+		assert.NotContains(t, err.Error(), "error-user")
+		assert.NotContains(t, err.Error(), "error-password")
+		assert.NotContains(t, err.Error(), "error-token")
+		assert.NotContains(t, err.Error(), "fragment-secret")
 	})
 
 	t.Run("non-OK status", func(t *testing.T) {
@@ -308,30 +311,35 @@ func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
 	})
 }
 
-func TestInstallFromPackageFile_saveLocalManifestFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("read-only manifest.json via chmod is not reliable on Windows")
-	}
+func TestInstallFromPackageFile_saveLocalManifestFailsRollsBack(t *testing.T) {
 	root := t.TempDir()
-	mani := filepath.Join(root, "manifest.json")
-	require.NoError(t, os.WriteFile(mani, []byte(`{"plugins":{}}`), 0644))
-	require.NoError(t, os.Chmod(mani, 0444))
-	defer func() { _ = os.Chmod(mani, 0644) }()
-
 	mgr := &Manager{rootDir: root}
-	archiveBody := createTestPluginArchive(t, "save-fail-pl", "2.0.0", "x")
-	archivePath := filepath.Join(t.TempDir(), "save-fail.tgz")
-	require.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
-
 	ctx := newTestContext()
+
+	v1 := createTestPluginArchive(t, "save-fail-pl", "1.0.0", "x")
+	v1Path := filepath.Join(t.TempDir(), "v1.tgz")
+	require.NoError(t, os.WriteFile(v1Path, v1, 0644))
+	require.NoError(t, mgr.installFromPackageFile(ctx, v1Path, v1Path))
+
+	mgr.saveLocalManifestHook = func(*LocalManifest) error {
+		return fmt.Errorf("injected manifest commit failure")
+	}
+	v2 := createTestPluginArchive(t, "save-fail-pl", "2.0.0", "x")
+	archivePath := filepath.Join(t.TempDir(), "save-fail.tgz")
+	require.NoError(t, os.WriteFile(archivePath, v2, 0644))
+
 	err := mgr.installFromPackageFile(ctx, archivePath, archivePath)
 	require.Error(t, err)
-	lowered := strings.ToLower(err.Error())
-	require.True(t,
-		strings.Contains(lowered, "permission denied") ||
-			strings.Contains(lowered, "operation not permitted"),
-		"unexpected error from saveLocalManifest: %v", err,
-	)
+	assert.Contains(t, err.Error(), "injected manifest commit failure")
+
+	mgr.saveLocalManifestHook = nil
+	localManifest, err := mgr.GetLocalManifest()
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", localManifest.Plugins["save-fail-pl"].Version)
+
+	packageManifest, err := readPluginManifestFromDir(filepath.Join(root, "save-fail-pl"))
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", packageManifest.Version)
 }
 
 func TestFindInstalledPluginInManifest(t *testing.T) {

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -2467,6 +2467,82 @@ func TestManager_installPlugin(t *testing.T) {
 		assert.Contains(t, err.Error(), "Expected: wrong-checksum")
 	})
 
+	t.Run("Error - corrupt archive preserves existing plugin", func(t *testing.T) {
+		root := t.TempDir()
+		mgr := &Manager{rootDir: root}
+		pluginDir := filepath.Join(root, "test-plugin")
+		require.NoError(t, os.MkdirAll(pluginDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "old-binary"), []byte("old"), 0755))
+		require.NoError(t, mgr.saveLocalManifest(&LocalManifest{Plugins: map[string]LocalPlugin{
+			"test-plugin": {
+				Name: "test-plugin", Version: "1.0.0", Path: pluginDir, Command: "test",
+			},
+		}}))
+
+		corruptArchive := []byte("not a gzip archive")
+		checksum, err := calculateSHA256FromBytes(corruptArchive)
+		require.NoError(t, err)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(corruptArchive)
+		}))
+		defer server.Close()
+
+		targetPlugin := &PluginInfo{
+			Name: "test-plugin",
+			Versions: map[string]VersionInfo{
+				"2.0.0": {Platforms: map[string]PlatformInfo{
+					GetCurrentPlatform(): {URL: server.URL + "/test-plugin.tgz", Checksum: checksum},
+				}},
+			},
+		}
+
+		err = mgr.installPlugin(newTestContext(), targetPlugin, "2.0.0", false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gzip")
+		assert.FileExists(t, filepath.Join(pluginDir, "old-binary"))
+		localManifest, manifestErr := mgr.GetLocalManifest()
+		require.NoError(t, manifestErr)
+		assert.Equal(t, "1.0.0", localManifest.Plugins["test-plugin"].Version)
+	})
+
+	t.Run("Error - invalid staged manifest preserves existing plugin", func(t *testing.T) {
+		root := t.TempDir()
+		mgr := &Manager{rootDir: root}
+		pluginDir := filepath.Join(root, "test-plugin")
+		require.NoError(t, os.MkdirAll(pluginDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "old-binary"), []byte("old"), 0755))
+		require.NoError(t, mgr.saveLocalManifest(&LocalManifest{Plugins: map[string]LocalPlugin{
+			"test-plugin": {
+				Name: "test-plugin", Version: "1.0.0", Path: pluginDir, Command: "test",
+			},
+		}}))
+
+		archiveContent := createTestPluginArchiveWithoutManifest(t)
+		checksum, err := calculateSHA256FromBytes(archiveContent)
+		require.NoError(t, err)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(archiveContent)
+		}))
+		defer server.Close()
+
+		targetPlugin := &PluginInfo{
+			Name: "test-plugin",
+			Versions: map[string]VersionInfo{
+				"2.0.0": {Platforms: map[string]PlatformInfo{
+					GetCurrentPlatform(): {URL: server.URL + "/test-plugin.tgz", Checksum: checksum},
+				}},
+			},
+		}
+
+		err = mgr.installPlugin(newTestContext(), targetPlugin, "2.0.0", false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "manifest.json not found")
+		assert.FileExists(t, filepath.Join(pluginDir, "old-binary"))
+		localManifest, manifestErr := mgr.GetLocalManifest()
+		require.NoError(t, manifestErr)
+		assert.Equal(t, "1.0.0", localManifest.Plugins["test-plugin"].Version)
+	})
+
 	t.Run("Error - manifest not found in archive", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		mgr := &Manager{rootDir: tmpDir}

--- a/cli/plugin/path_replacement.go
+++ b/cli/plugin/path_replacement.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// pathReplacement swaps a staged file or directory into its final path while retaining the previous path until the caller commits.
+// It guarantees rollback for errors returned within the current process;
+// it does not provide crash recovery or cross-process serialization for now.
+type pathReplacement struct {
+	finalPath    string
+	backupParent string
+	backupPath   string
+	hadExisting  bool
+}
+
+func replacePathWithRollback(stagedPath, finalPath, backupPattern string) (*pathReplacement, error) {
+	replacement := &pathReplacement{finalPath: finalPath}
+	if _, err := os.Lstat(finalPath); err == nil {
+		replacement.hadExisting = true
+		replacement.backupParent, err = os.MkdirTemp(filepath.Dir(finalPath), backupPattern)
+		if err != nil {
+			return nil, fmt.Errorf("create rollback directory: %w", err)
+		}
+		replacement.backupPath = filepath.Join(replacement.backupParent, "previous")
+		if err := os.Rename(finalPath, replacement.backupPath); err != nil {
+			_ = os.RemoveAll(replacement.backupParent)
+			return nil, fmt.Errorf("backup existing path: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspect existing path: %w", err)
+	}
+
+	if err := os.Rename(stagedPath, finalPath); err != nil {
+		restoreErr := replacement.restorePrevious()
+		if restoreErr != nil {
+			return nil, fmt.Errorf("replace final path: %w; restore previous path: %v", err, restoreErr)
+		}
+		replacement.commit()
+		return nil, fmt.Errorf("replace final path: %w", err)
+	}
+	return replacement, nil
+}
+
+func (r *pathReplacement) restorePrevious() error {
+	if r == nil {
+		return nil
+	}
+	if err := os.RemoveAll(r.finalPath); err != nil {
+		return err
+	}
+	if r.hadExisting {
+		if err := os.Rename(r.backupPath, r.finalPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *pathReplacement) rollback() error {
+	if err := r.restorePrevious(); err != nil {
+		return err
+	}
+	r.commit()
+	return nil
+}
+
+func (r *pathReplacement) commit() {
+	if r != nil && r.backupParent != "" {
+		_ = os.RemoveAll(r.backupParent)
+	}
+}

--- a/cli/plugin/url_redaction.go
+++ b/cli/plugin/url_redaction.go
@@ -1,0 +1,37 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// safePluginPackageURL returns a diagnostic URL without credentials or
+// caller-controlled query and fragment data. The original URL remains
+// unchanged and must be used for the actual download.
+func safePluginPackageURL(value *url.URL) string {
+	if value == nil {
+		return "<unknown>"
+	}
+
+	safe := *value
+	safe.User = nil
+	safe.RawQuery = ""
+	safe.ForceQuery = false
+	safe.Fragment = ""
+	safe.RawFragment = ""
+	return safe.String()
+}
+
+// safePluginDownloadError avoids rendering url.Error.URL, which contains the
+// original package URL and may therefore include credentials or signed query
+// parameters. Wrapping the underlying cause preserves errors.Is/errors.As
+// behavior for transport failures without retaining the credential-bearing
+// URL in the rendered error.
+func safePluginDownloadError(err error, displayURL string) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return fmt.Errorf("download plugin package from %s: %w", displayURL, urlErr.Err)
+	}
+	return fmt.Errorf("download plugin package from %s: %w", displayURL, err)
+}

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Maps uname -m to the macOS package arch suffix published on CDN.
+# Prefer single-arch packages; fall back to universal when unknown.
+resolve_macos_package_arch() {
+  case "${1}" in
+    arm64)
+      printf '%s\n' "arm64"
+      ;;
+    x86_64)
+      printf '%s\n' "amd64"
+      ;;
+    *)
+      printf '%s\n' "universal"
+      ;;
+  esac
+}
+
 set -e +o pipefail
 
 show_help() {
@@ -69,8 +85,9 @@ echo -e "
 
 if [[ -n "${CLI_ON_MACOS-}" ]]
 then
-  curl -O -fsSL https://aliyuncli.alicdn.com/aliyun-cli-macosx-"$VERSION"-universal.tgz
-  tar zxf aliyun-cli-macosx-"$VERSION"-universal.tgz
+  MACOS_ARCH="$(resolve_macos_package_arch "$(uname -m)")"
+  curl -O -fsSL https://aliyuncli.alicdn.com/aliyun-cli-macosx-"$VERSION"-"$MACOS_ARCH".tgz
+  tar zxf aliyun-cli-macosx-"$VERSION"-"$MACOS_ARCH".tgz
   mv ./aliyun /usr/local/bin/
 fi
 

--- a/main/dry_run_test.go
+++ b/main/dry_run_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aliyun/aliyun-cli/v3/config"
+	"github.com/aliyun/aliyun-cli/v3/openapi"
+)
+
+func TestCSDryRunJSONRedactsRawPassword(t *testing.T) {
+	clearAgentDetectionEnv(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	profileJSON := []byte(`{"current":"default","profiles":[{"name":"default","mode":"AK","access_key_id":"test-access-key-id","access_key_secret":"test-access-key-secret","region_id":"cn-hangzhou","language":"en"}]}`)
+	if err := os.WriteFile(configPath, profileJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile, err := config.LoadProfile(configPath, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	root := newRootCommand(profile, &stdout)
+	ctx := newCommandContext(&stdout, &stderr)
+	ctx.EnterCommand(root)
+	root.Execute(ctx, []string{
+		"cs", "POST", "/clusters", "--body", "password=FAKE_SECRET_123", "--cli-dry-run-json",
+		"--config-path", configPath,
+	})
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", &stderr)
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("FAKE_SECRET_123")) {
+		t.Fatal("dry-run output contains the unmasked password")
+	}
+	var output openapi.CliDryRunOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("invalid JSON output: %v; stdout: %s", err, &stdout)
+	}
+	if output.Method != "POST" || output.Pathname != "/clusters" || output.Body != "password=FAKE***" {
+		t.Fatalf("unexpected dry-run output: %+v", output)
+	}
+	t.Logf("actual dry-run JSON: %s", &stdout)
+}

--- a/openapi/cli_dry_run.go
+++ b/openapi/cli_dry_run.go
@@ -72,7 +72,7 @@ func buildCliDryRunFromInvoker(inv Invoker) *CliDryRunOutput {
 	}
 
 	if len(req.Content) > 0 {
-		out.Body = runtimeredact.MaskBodyFull(string(req.Content))
+		out.Body = runtimeredact.MaskBodyFull(string(req.Content), dryRunContentType(req.Headers))
 		out.BodyFormat = "raw"
 	} else if len(req.FormParams) > 0 {
 		out.Query = mergeInto(out.Query, nil)
@@ -146,14 +146,34 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 	}
 
 	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
-		bodyJSON, err := json.Marshal(oc.openapiRequest.Body)
-		if err == nil && string(bodyJSON) != "null" {
-			out.Body = runtimeredact.MaskBodyFull(string(bodyJSON))
+		body := oc.openapiRequest.Body
+		hints := []string{dryRunContentType(out.Headers)}
+		if oc.openapiParams != nil {
+			hints = append(hints, tea.StringValue(oc.openapiParams.ReqBodyType))
+		}
+		if oc.api != nil && oc.api.Operation != nil {
+			hints = append(hints, oc.api.Operation.ReqBodyType, oc.api.Operation.ContentType)
+		}
+		switch value := body.(type) {
+		case string:
+			out.Body = runtimeredact.MaskBodyFull(value, hints...)
+			out.BodyFormat = "raw"
+		case []byte:
+			out.Body = runtimeredact.MaskBodyFull(string(value), hints...)
+			out.BodyFormat = "binary"
+		default:
+			bodyJSON, err := json.Marshal(body)
+			if err == nil && string(bodyJSON) != "null" {
+				out.Body = runtimeredact.MaskBodyFull(string(bodyJSON), hints...)
+			}
 			// Reflect the request-body encoding resolved in Prepare/ProcessBody:
 			// RPC-style products send form fields (ReqBodyType=formData), which
 			// the classic dry-run reports as "form"; ROA keeps the JSON body.
 			out.BodyFormat = "json"
-			if oc.openapiParams != nil && tea.StringValue(oc.openapiParams.ReqBodyType) == "formData" {
+		}
+		if oc.openapiParams != nil && tea.StringValue(oc.openapiParams.ReqBodyType) != "" {
+			out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
+			if out.BodyFormat == "formData" {
 				out.BodyFormat = "form"
 			}
 		}
@@ -180,18 +200,16 @@ func buildCliDryRunFromOpenapi(oc *OpenapiContext) *CliDryRunOutput {
 		}
 	}
 
-	if oc.openapiRequest != nil && oc.openapiRequest.Body != nil {
-		if stream, ok := oc.openapiRequest.Body.([]byte); ok {
-			out.Body = runtimeredact.MaskBodyFull(string(stream))
-			if oc.openapiParams != nil && oc.openapiParams.ReqBodyType != nil {
-				out.BodyFormat = tea.StringValue(oc.openapiParams.ReqBodyType)
-			} else {
-				out.BodyFormat = "binary"
-			}
+	return out
+}
+
+func dryRunContentType(headers map[string]string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, "Content-Type") {
+			return value
 		}
 	}
-
-	return out
+	return ""
 }
 
 func sanitizedDryRunPathname(pattern, pathname string, raw, sanitized map[string]string) string {

--- a/openapi/cli_dry_run_test.go
+++ b/openapi/cli_dry_run_test.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -195,28 +196,54 @@ func TestBuildCliDryRunFromInvoker_MasksPathSecret(t *testing.T) {
 }
 
 func TestCliDryRunPreservesLongBodyAndRedaction(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
 	text := strings.Repeat("流水线", 450) + "正文末尾"
-	for _, tc := range []struct{ name, body, want string }{
-		{"raw", "name=" + text + "&pipelineId=123", "name=" + text + "&pipelineId=123"},
-		{"json", `{"content":"` + text + `","password":"secret-value"}`, `{"content":"` + text + `","password":"secr***"}`},
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"form",
+			"name=" + text + "&password=" + secret,
+			"name=" + text + "&password=FAKE***",
+		},
+		{
+			"xml",
+			"<Name>" + text + "</Name><Password>" + secret + "</Password>",
+			fmt.Sprintf("[body omitted: %d bytes]", len("<Name>"+text+"</Name><Password>"+secret+"</Password>")),
+		},
+		{"raw", "name: " + text + "\npassword: " + secret, "name: " + text + "\npassword: ***"},
+		{
+			"json",
+			`{"content":"` + text + `","password":"` + secret + `"}`,
+			`{"content":"` + text + `","password":"FAKE***"}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			req := requests.NewCommonRequest()
 			req.SetContent([]byte(tc.body))
+			stream := []byte(tc.body)
 			classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
 			openapi := buildCliDryRunFromOpenapi(&OpenapiContext{HttpContext: &HttpContext{
-				openapiRequest: &openapiutil.OpenApiRequest{Body: []byte(tc.body)},
+				openapiRequest: &openapiutil.OpenApiRequest{Body: stream},
+				openapiParams:  &openapiClient.Params{ReqBodyType: tea.String("json")},
 			}})
-			for _, out := range []*CliDryRunOutput{classic, openapi} {
+			textBody := buildCliDryRunFromOpenapi(&OpenapiContext{HttpContext: &HttpContext{openapiRequest: &openapiutil.OpenApiRequest{Body: tc.body}}})
+			for _, out := range []*CliDryRunOutput{classic, openapi, textBody} {
 				assert.Equal(t, tc.want, out.Body)
-				assert.Contains(t, formatCliDryRunHuman(out), tc.want)
+				human := formatCliDryRunHuman(out)
+				assert.Contains(t, human, tc.want)
+				assert.NotContains(t, human, secret)
 				encoded, err := marshalCliDryRunOutput(out)
 				assert.NoError(t, err)
+				assert.NotContains(t, encoded, secret)
 				var decoded CliDryRunOutput
 				assert.NoError(t, json.Unmarshal([]byte(encoded), &decoded))
 				assert.Equal(t, tc.want, decoded.Body)
 			}
 			assert.Equal(t, tc.body, string(req.Content), "dry-run must not mutate the request")
+			assert.Equal(t, tc.body, string(stream), "dry-run must not mutate the OpenAPI body")
 		})
 	}
 }
@@ -268,6 +295,37 @@ func TestBuildCliDryRunFromInvoker_WithFormParams(t *testing.T) {
 	assert.Contains(t, out.Body, "ecs.g6.large")
 	assert.Contains(t, out.Body, `"Password":"form***"`)
 	assert.NotContains(t, out.Body, "form-secret-value")
+}
+
+func TestCliDryRunNestedForm(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	fields := map[string]string{
+		"user.password.1": secret,
+		"user.2.password": secret,
+		"user.name":       "alice",
+		"config":          `{"name":"alice","password":"FAKE_SECRET_123"}`,
+	}
+	req := requests.NewCommonRequest()
+	req.FormParams = fields
+	classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
+	oc := &OpenapiContext{HttpContext: &HttpContext{
+		openapiRequest: &openapiutil.OpenApiRequest{Body: fields},
+		openapiParams:  &openapiClient.Params{ReqBodyType: tea.String("formData")},
+	}}
+	for _, out := range []*CliDryRunOutput{classic, buildCliDryRunFromOpenapi(oc)} {
+		var body map[string]string
+		assert.NoError(t, json.Unmarshal([]byte(out.Body), &body))
+		assert.Equal(t, "FAKE***", body["user.password.1"])
+		assert.Equal(t, "FAKE***", body["user.2.password"])
+		assert.Equal(t, "alice", body["user.name"])
+		assert.Equal(t, `{"name":"alice","password":"FAKE***"}`, body["config"])
+		assert.NotContains(t, formatCliDryRunHuman(out), secret)
+		encoded, err := marshalCliDryRunOutput(out)
+		assert.NoError(t, err)
+		assert.NotContains(t, encoded, secret)
+	}
+	assert.Equal(t, secret, fields["user.password.1"])
+	assert.Equal(t, `{"name":"alice","password":"FAKE_SECRET_123"}`, fields["config"])
 }
 
 func TestBuildCliDryRunFromOpenapi(t *testing.T) {
@@ -478,7 +536,7 @@ func TestBuildCliDryRunFromOpenapi_WithBinaryBody(t *testing.T) {
 	api := &testLegacyAPI{Name: "PutLogs", Product: product}
 	profile := &config.Profile{RegionId: "cn-hangzhou", Endpoint: "cn-hangzhou.log.aliyuncs.com"}
 
-	binaryData := []byte("compressed-data-here")
+	binaryData := []byte(`{"password":"FAKE_SECRET_123"}`)
 	oc := &OpenapiContext{
 		HttpContext: &HttpContext{
 			profile: profile,
@@ -498,7 +556,9 @@ func TestBuildCliDryRunFromOpenapi_WithBinaryBody(t *testing.T) {
 
 	out := buildCliDryRunFromOpenapi(oc)
 	assert.Equal(t, "binary", out.BodyFormat)
-	assert.Equal(t, "compressed-data-here", out.Body)
+	assert.Equal(t, fmt.Sprintf("[body omitted: %d bytes]", len(binaryData)), out.Body)
+	assert.NotContains(t, out.Body, "FAKE_SECRET_123")
+	assert.Equal(t, `{"password":"FAKE_SECRET_123"}`, string(binaryData), "dry-run must not mutate binary data")
 }
 
 func TestBuildCliDryRunFromOpenapi_NilHeaders(t *testing.T) {
@@ -657,6 +717,51 @@ func TestProcessCliDryRunJson(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "RPC", parsed.Style)
 	assert.Equal(t, "ecs.cn-hangzhou.aliyuncs.com", parsed.Endpoint)
+}
+
+func TestProcessCliDryRunRedactsTextBodyInStdoutAndStderr(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	body := strings.Repeat("x", 1100) + "&password=" + secret
+	want := strings.Repeat("x", 1100) + "&password=FAKE***"
+
+	for _, jsonOutput := range []bool{false, true} {
+		name := "human"
+		if jsonOutput {
+			name = "json"
+		}
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+			ctx := cli.NewCommandContext(stdout, stderr)
+			cmd := &cli.Command{}
+			cmd.EnableUnknownFlag = true
+			AddFlags(cmd.Flags())
+			ctx.EnterCommand(cmd)
+
+			req := requests.NewCommonRequest()
+			req.Method = "POST"
+			req.SetContent([]byte(body))
+			invoker := &RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}}
+
+			var err error
+			if jsonOutput {
+				err = processCliDryRunJson(ctx, invoker)
+			} else {
+				err = processCliDryRun(ctx, invoker)
+			}
+			assert.NoError(t, err)
+			if jsonOutput {
+				var decoded CliDryRunOutput
+				assert.NoError(t, json.Unmarshal(stdout.Bytes(), &decoded))
+				assert.Equal(t, want, decoded.Body)
+			} else {
+				assert.Contains(t, stdout.String(), want)
+			}
+			assert.NotContains(t, stdout.String(), secret)
+			assert.NotContains(t, stderr.String(), secret)
+			assert.Empty(t, stderr.String())
+			assert.Equal(t, body, string(req.Content), "dry-run must not mutate the request")
+		})
+	}
 }
 
 func TestProcessCliDryRunOpenapi(t *testing.T) {
@@ -1289,5 +1394,34 @@ func newOpenapiParams(method, pathname, action, version string) *openapiClient.P
 		Pathname: tea.String(pathname),
 		Action:   tea.String(action),
 		Version:  tea.String(version),
+	}
+}
+
+func TestCliDryRunExplicitContentTypes(t *testing.T) {
+	const body = `<Name>visible</Name><Password>FAKE_SECRET_123</Password>`
+	for _, tc := range []struct{ contentType, want string }{
+		{"application/xml", fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"application/octet-stream", fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+		{"application/x-custom-format", fmt.Sprintf("[body omitted: %d bytes]", len(body))},
+	} {
+		t.Run(tc.contentType, func(t *testing.T) {
+			req := requests.NewCommonRequest()
+			req.Content = []byte(body)
+			req.Headers["cOnTeNt-TyPe"] = tc.contentType
+			classic := buildCliDryRunFromInvoker(&RestfulInvoker{BasicInvoker: &BasicInvoker{request: req}})
+			oc := &OpenapiContext{
+				HttpContext: &HttpContext{openapiRequest: &openapiutil.OpenApiRequest{Body: []byte(body)}},
+				api:         &canonicalmeta.API{Operation: &canonicalmeta.Operation{ContentType: tc.contentType}},
+			}
+			for _, out := range []*CliDryRunOutput{classic, buildCliDryRunFromOpenapi(oc)} {
+				assert.Equal(t, tc.want, out.Body)
+				assert.NotContains(t, formatCliDryRunHuman(out), "FAKE_SECRET_123")
+				encoded, err := marshalCliDryRunOutput(out)
+				assert.NoError(t, err)
+				assert.NotContains(t, encoded, "FAKE_SECRET_123")
+			}
+			assert.Equal(t, body, string(req.Content))
+			assert.Equal(t, body, string(oc.openapiRequest.Body.([]byte)))
+		})
 	}
 }

--- a/openapi/commando.go
+++ b/openapi/commando.go
@@ -65,6 +65,12 @@ var hookdo = func(fn func() (*responses.CommonResponse, error)) func() (*respons
 
 var runtimeTryDispatch = runtimehost.TryDispatch
 
+var runtimeDispatch = runtimehost.Dispatch
+
+var installPluginForCommand = func(c *Commando, ctx *cli.Context, commandName, productCode string) (string, error) {
+	return c.findAndInstallPlugin(ctx, commandName, productCode)
+}
+
 var agentErrorNormalizer = normalizeAgentError
 
 var agentErrorNormalizerWithSearch = normalizeAgentErrorWithSearch
@@ -538,21 +544,8 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 			//   - not installed but the engine resolves it (baseline / user meta plugin) -> aliyun-openapi-runtime engine.
 			//     Products marked distribution=="go" are abstained by the engine so they still reach auto-install.
 			if installed {
-				if ptype, ok := plugin.InstalledPluginType(args[0]); ok && ptype == plugin.PluginTypeMeta {
-					if err := plugin.ValidatePluginCliVersion(args[0]); err != nil {
-						return err
-					}
-					// Meta plugins have no executable in which to register the package-level version command.
-					// Read it from the installed manifest instead of forwarding "version" to the OpenAPI runtime as an API name.
-					if apiOrMethod == "version" {
-						name, version, err := plugin.InstalledPluginPackageVersion(args[0])
-						if err != nil {
-							return err
-						}
-						cli.Printf(ctx.Stdout(), "%s %s\n", name, version)
-						return nil
-					}
-					return c.adaptEngineUnknownCommand(runtimehost.Dispatch(ctx, pluginArgs))
+				if handled, dispatchErr := c.dispatchInstalledMetaPlugin(ctx, args[0], apiOrMethod, pluginArgs); handled {
+					return dispatchErr
 				}
 			} else {
 				if validationErr := c.validateCanonicalRuntimeCommand(args, ctx); validationErr != nil {
@@ -575,7 +568,7 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 				commandName := buildCommandName(args)
 				// fmt.Println("commandName", commandName, pluginArgs)
 
-				foundPluginName, err := c.findAndInstallPlugin(ctx, commandName, args[0])
+				foundPluginName, err := installPluginForCommand(c, ctx, commandName, args[0])
 				if err != nil {
 					return err
 				}
@@ -605,6 +598,12 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 					return &InvalidProductOrPluginError{Code: args[0], library: c.library, plugins: plugins}
 				}
 				pluginName = foundPluginName
+
+				// Installation may have added a metadata-only plugin.
+				// Re-evaluate its type in the same invocation instead of falling through to the Go-plugin executor, which would look for a non-existent binary.
+				if handled, dispatchErr := c.dispatchInstalledMetaPlugin(ctx, args[0], apiOrMethod, pluginArgs); handled {
+					return dispatchErr
+				}
 			}
 
 			// Prepare config related env for plugin
@@ -831,6 +830,28 @@ func (c *Commando) main(ctx *cli.Context, args []string) error {
 		return cli.NewErrorWithTip(fmt.Errorf("too many arguments"),
 			"Use `aliyun --help` to show usage")
 	}
+}
+
+// dispatchInstalledMetaPlugin routes an installed metadata plugin through the in-process OpenAPI runtime.
+// It returns handled=false for Go plugins so the caller can continue to the external binary execution path.
+func (c *Commando) dispatchInstalledMetaPlugin(ctx *cli.Context, productCode, apiOrMethod string, pluginArgs []string) (bool, error) {
+	ptype, ok := plugin.InstalledPluginType(productCode)
+	if !ok || ptype != plugin.PluginTypeMeta {
+		return false, nil
+	}
+	if err := plugin.ValidatePluginCliVersion(productCode); err != nil {
+		return true, err
+	}
+	// Meta plugins have no executable in which to register the package-level version command. Read it from the installed manifest instead.
+	if apiOrMethod == "version" {
+		name, version, err := plugin.InstalledPluginPackageVersion(productCode)
+		if err != nil {
+			return true, err
+		}
+		cli.Printf(ctx.Stdout(), "%s %s\n", name, version)
+		return true, nil
+	}
+	return true, c.adaptEngineUnknownCommand(runtimeDispatch(ctx, pluginArgs))
 }
 
 func (c *Commando) processApiInvoke(ctx *cli.Context, product *meta.Product, api *canonicalmeta.API, method string, path string) error {

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -2807,6 +2807,62 @@ func TestMain_UninstalledPluginAlwaysTriesBuiltInRuntime(t *testing.T) {
 	assert.ErrorIs(t, err, wantErr)
 }
 
+func TestMain_AutoInstalledMetaPluginDispatchesWithoutBinary(t *testing.T) {
+	testHome := t.TempDir()
+	cleanup := setTestHomeDir(t, testHome)
+	defer cleanup()
+	writeMinimalConfigJSON(t, testHome)
+	pluginRoot := filepath.Join(testHome, ".aliyun", "plugins")
+	assert.NoError(t, os.MkdirAll(pluginRoot, 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(pluginRoot, "manifest.json"), []byte(`{"plugins":{}}`), 0644))
+
+	w := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	ctx := cli.NewCommandContext(w, stderr)
+	repo, err := meta.MockLoadRepository(nil)
+	assert.NoError(t, err)
+	command := &Commando{library: &Library{builtinRepo: repo, writer: w}}
+	cmd := &cli.Command{EnableUnknownFlag: true}
+	command.InitWithCommand(cmd)
+	AddFlags(cmd.Flags())
+	ctx.EnterCommand(cmd)
+	ctx.Command().Short = &i18n.Text{}
+
+	originalTryDispatch := runtimeTryDispatch
+	runtimeTryDispatch = func(_ *cli.Context, _ []string) (bool, error) {
+		return false, nil
+	}
+	t.Cleanup(func() { runtimeTryDispatch = originalTryDispatch })
+
+	originalInstall := installPluginForCommand
+	installPluginForCommand = func(_ *Commando, _ *cli.Context, commandName, productCode string) (string, error) {
+		assert.Equal(t, "bssopenapi create-instance", commandName)
+		assert.Equal(t, "bssopenapi", productCode)
+		pluginDir := filepath.Join(pluginRoot, "aliyun-cli-bssopenapi")
+		assert.NoError(t, os.MkdirAll(pluginDir, 0755))
+		manifest := fmt.Sprintf(`{"plugins":{"aliyun-cli-bssopenapi":{"name":"aliyun-cli-bssopenapi","version":"0.9.0","type":"meta","path":%q,"command":"bssopenapi"}}}`, pluginDir)
+		assert.NoError(t, os.WriteFile(filepath.Join(pluginRoot, "manifest.json"), []byte(manifest), 0644))
+		return "aliyun-cli-bssopenapi", nil
+	}
+	t.Cleanup(func() { installPluginForCommand = originalInstall })
+
+	wantErr := errors.New("metadata runtime invoked")
+	originalDispatch := runtimeDispatch
+	runtimeDispatch = func(_ *cli.Context, got []string) error {
+		assert.Equal(t, []string{"bssopenapi", "create-instance", "--product-code", "kms"}, got)
+		return wantErr
+	}
+	t.Cleanup(func() { runtimeDispatch = originalDispatch })
+
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+	os.Args = []string{"aliyun", "bssopenapi", "create-instance", "--product-code", "kms"}
+
+	err = command.main(ctx, []string{"bssopenapi", "create-instance"})
+	assert.ErrorIs(t, err, wantErr)
+	assert.NotContains(t, err.Error(), "plugin binary")
+}
+
 func TestMain_InstalledGoPluginOverridesBuiltInRuntime(t *testing.T) {
 	testHome := t.TempDir()
 	cleanup := setTestHomeDir(t, testHome)

--- a/openapi/commando_test.go
+++ b/openapi/commando_test.go
@@ -1515,6 +1515,8 @@ func TestProcessApiInvokeFilterError(t *testing.T) {
 }
 
 func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
+	const secret = "FAKE_SECRET_123"
+	body := strings.Repeat("x", 1100) + "&password=" + secret
 	profile := config.Profile{
 		Language:        "en",
 		Mode:            "AK",
@@ -1531,6 +1533,8 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 	AddFlags(cmd.Flags())
 	ctx.EnterCommand(cmd)
 	DryRunJsonFlag(ctx.Flags()).SetAssigned(true)
+	BodyFlag(ctx.Flags()).SetAssigned(true)
+	BodyFlag(ctx.Flags()).SetValue(body)
 
 	command := NewCommando(stdout, profile)
 	product := &meta.Product{Code: "sls", Version: "2020-03-31"}
@@ -1559,7 +1563,7 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 		}
 	}
 
-	err := command.processApiInvoke(ctx, product, canonicalTestAPI(api), "GET", "/projects/foo")
+	err := command.processApiInvoke(ctx, product, canonicalTestAPI(api), "POST", "/clusters")
 	assert.NoError(t, err)
 
 	output := strings.TrimSpace(stdout.String())
@@ -1568,9 +1572,14 @@ func TestProcessApiInvoke_DryRunJSON(t *testing.T) {
 	var m CliDryRunOutput
 	assert.Nil(t, json.Unmarshal([]byte(output), &m), "stdout must be valid JSON: %q", output)
 	assert.Equal(t, "ROA", m.Style)
-	assert.Equal(t, "GET", m.Method)
+	assert.Equal(t, "POST", m.Method)
 	assert.Equal(t, "GetProject", m.Action)
 	assert.Equal(t, "2020-03-31", m.Version)
+	assert.Equal(t, "json", m.BodyFormat)
+	assert.Equal(t, strings.Repeat("x", 1100)+"&password=FAKE***", m.Body)
+	assert.NotContains(t, stdout.String(), secret)
+	assert.NotContains(t, stderr.String(), secret)
+	assert.Empty(t, stderr.String())
 	// SLS without --endpoint / profile.Endpoint falls back to {region}.log.aliyuncs.com.
 	assert.Equal(t, "cn-hangzhou.log.aliyuncs.com", m.Endpoint)
 }


### PR DESCRIPTION
fix(plugin): harden plugin package installation

- stage installations and roll back failed directory replacements
- update the local manifest atomically
- enforce download, file, extraction, and entry limits
- clean partial downloads and extracted files on failure
- redact credentials and query parameters from URL logs and errors
- add rollback, archive limit, corruption, and redaction tests