### PR TITLE
Harden plugin installation with rollback, archive limits, and URL redaction

### DIFF
--- a/cli/plugin/archive.go
+++ b/cli/plugin/archive.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxPluginArchiveBytes   int64 = 64 << 20
+	maxPluginFileBytes      int64 = 128 << 20
+	maxPluginExtractedBytes int64 = 256 << 20
+	maxPluginArchiveEntries       = 10_000
+)
+
+type pluginArchiveLimits struct {
+	archiveBytes   int64
+	fileBytes      int64
+	extractedBytes int64
+	entries        int
+}
+
+var defaultPluginArchiveLimits = pluginArchiveLimits{
+	archiveBytes:   maxPluginArchiveBytes,
+	fileBytes:      maxPluginFileBytes,
+	extractedBytes: maxPluginExtractedBytes,
+	entries:        maxPluginArchiveEntries,
+}
+
+func downloadFile(url, dest string) error {
+	return downloadFileWithLimit(url, dest, defaultPluginArchiveLimits.archiveBytes)
+}
+
+func downloadFileWithLimit(url, dest string, limit int64) error {
+	resp, err := httpGet(url, pluginArchiveDLTimeout)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %d", resp.StatusCode)
+	}
+	return writePluginArchiveResponse(resp, dest, limit)
+}
+
+func writePluginArchiveResponse(resp *http.Response, dest string, limit int64) error {
+	if resp.ContentLength > limit {
+		return fmt.Errorf("plugin archive download size %d exceeds limit of %d bytes", resp.ContentLength, limit)
+	}
+	return writeReaderWithLimit(resp.Body, dest, limit)
+}
+
+func writeReaderWithLimit(reader io.Reader, dest string, limit int64) (err error) {
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	keep := false
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+			keep = false
+		}
+		if !keep {
+			_ = os.Remove(dest)
+		}
+	}()
+
+	written, err := io.Copy(out, io.LimitReader(reader, limit+1))
+	if err != nil {
+		return err
+	}
+	if written > limit {
+		return fmt.Errorf("plugin archive download exceeds limit of %d bytes", limit)
+	}
+	keep = true
+	return nil
+}
+
+func validatePluginArchiveSize(src string, limit int64) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("plugin archive is a directory: %s", src)
+	}
+	if info.Size() > limit {
+		return fmt.Errorf("plugin archive size %d exceeds limit of %d bytes", info.Size(), limit)
+	}
+	return nil
+}
+
+func untar(src, dest string) error {
+	return untarWithLimits(src, dest, defaultPluginArchiveLimits)
+}
+
+func untarWithLimits(src, dest string, limits pluginArchiveLimits) error {
+	if err := validatePluginArchiveSize(src, limits.archiveBytes); err != nil {
+		return err
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	var extracted int64
+	entries := 0
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		entries++
+		if entries > limits.entries {
+			return fmt.Errorf("plugin archive contains more than %d entries", limits.entries)
+		}
+
+		target, err := safeArchiveTarget(dest, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := validateExtractedFileSize(header.Name, header.Size, extracted, limits); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			written, err := writeExtractedFile(target, os.FileMode(header.Mode), tr, header.Size)
+			if err != nil {
+				return err
+			}
+			if written != header.Size {
+				return fmt.Errorf("plugin archive file %q size changed during extraction", header.Name)
+			}
+			extracted += written
+		}
+	}
+}
+
+func unzip(src, dest string) error {
+	return unzipWithLimits(src, dest, defaultPluginArchiveLimits)
+}
+
+func unzipWithLimits(src, dest string, limits pluginArchiveLimits) error {
+	if err := validatePluginArchiveSize(src, limits.archiveBytes); err != nil {
+		return err
+	}
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if len(r.File) > limits.entries {
+		return fmt.Errorf("plugin archive contains more than %d entries", limits.entries)
+	}
+	var extracted int64
+	for _, file := range r.File {
+		target, err := safeArchiveTarget(dest, file.Name)
+		if err != nil {
+			return err
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+			continue
+		}
+		if file.UncompressedSize64 > uint64(^uint64(0)>>1) {
+			return fmt.Errorf("plugin archive file %q has unsupported size", file.Name)
+		}
+		size := int64(file.UncompressedSize64)
+		if err := validateExtractedFileSize(file.Name, size, extracted, limits); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		written, writeErr := writeExtractedFile(target, file.Mode(), rc, minInt64(limits.fileBytes, limits.extractedBytes-extracted))
+		closeErr := rc.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if written != size {
+			return fmt.Errorf("plugin archive file %q size changed during extraction", file.Name)
+		}
+		extracted += written
+	}
+	return nil
+}
+
+func validateExtractedFileSize(name string, size, extracted int64, limits pluginArchiveLimits) error {
+	if size < 0 {
+		return fmt.Errorf("plugin archive file %q has invalid size %d", name, size)
+	}
+	if size > limits.fileBytes {
+		return fmt.Errorf("plugin archive file %q size %d exceeds per-file limit of %d bytes", name, size, limits.fileBytes)
+	}
+	if size > limits.extractedBytes-extracted {
+		return fmt.Errorf("plugin archive extracted size exceeds limit of %d bytes", limits.extractedBytes)
+	}
+	return nil
+}
+
+func writeExtractedFile(target string, mode os.FileMode, reader io.Reader, limit int64) (written int64, err error) {
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return 0, err
+	}
+	keep := false
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+			keep = false
+		}
+		if !keep {
+			_ = os.Remove(target)
+		}
+	}()
+
+	written, err = io.Copy(out, io.LimitReader(reader, limit+1))
+	if err != nil {
+		return written, err
+	}
+	if written > limit {
+		return written, fmt.Errorf("plugin archive file %q exceeds extraction limit of %d bytes", target, limit)
+	}
+	keep = true
+	return written, nil
+}
+
+func safeArchiveTarget(dest, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("illegal absolute path in archive: %s", name)
+	}
+	if strings.Contains(name, "..") {
+		return "", fmt.Errorf("illegal path with '..' in archive: %s", name)
+	}
+	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
+		return "", fmt.Errorf("illegal path starting with separator in archive: %s", name)
+	}
+
+	target := filepath.Clean(filepath.Join(dest, name))
+	destPath := filepath.Clean(dest) + string(os.PathSeparator)
+	if !strings.HasPrefix(target, destPath) {
+		return "", fmt.Errorf("illegal file path in archive: %s", name)
+	}
+	return target, nil
+}
+
+func minInt64(left, right int64) int64 {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func (m *Manager) effectiveArchiveLimits() pluginArchiveLimits {
+	if m != nil && m.archiveLimits != nil {
+		return *m.archiveLimits
+	}
+	return defaultPluginArchiveLimits
+}

--- a/cli/plugin/archive_test.go
+++ b/cli/plugin/archive_test.go
@@ -1,0 +1,199 @@
+package plugin
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWritePluginArchiveResponseEnforcesStreamingLimit(t *testing.T) {
+	t.Run("exact limit succeeds", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "plugin.tgz")
+		resp := &http.Response{
+			Body:          io.NopCloser(strings.NewReader("12345")),
+			ContentLength: -1,
+		}
+		require.NoError(t, writePluginArchiveResponse(resp, dest, 5))
+		assert.FileExists(t, dest)
+	})
+
+	t.Run("chunked body over limit is removed", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "plugin.tgz")
+		resp := &http.Response{
+			Body:          io.NopCloser(strings.NewReader("123456")),
+			ContentLength: -1,
+		}
+		err := writePluginArchiveResponse(resp, dest, 5)
+		require.ErrorContains(t, err, "exceeds limit")
+		_, statErr := os.Stat(dest)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("content length over limit is rejected", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "plugin.tgz")
+		resp := &http.Response{
+			Body:          io.NopCloser(strings.NewReader("small")),
+			ContentLength: 6,
+		}
+		err := writePluginArchiveResponse(resp, dest, 5)
+		require.ErrorContains(t, err, "size 6 exceeds limit")
+		_, statErr := os.Stat(dest)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+}
+
+func TestUntarResourceLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []testFile
+		limits  pluginArchiveLimits
+		wantErr string
+	}{
+		{
+			name:   "exact limits succeed",
+			files:  []testFile{{name: "file", content: "12345"}},
+			limits: pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 5, entries: 1},
+		},
+		{
+			name:    "single file exceeds limit",
+			files:   []testFile{{name: "file", content: "123456"}},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 10, entries: 2},
+			wantErr: "per-file limit",
+		},
+		{
+			name: "total extracted size exceeds limit",
+			files: []testFile{
+				{name: "first", content: "12345"},
+				{name: "second", content: "6789"},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 8, entries: 2},
+			wantErr: "extracted size exceeds limit",
+		},
+		{
+			name: "entry count exceeds limit",
+			files: []testFile{
+				{name: "one/", isDir: true},
+				{name: "two/", isDir: true},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 10, extractedBytes: 10, entries: 1},
+			wantErr: "more than 1 entries",
+		},
+		{
+			name:    "compressed expansion exceeds total limit",
+			files:   []testFile{{name: "zeros", content: strings.Repeat("0", 4096)}},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 8192, extractedBytes: 1024, entries: 1},
+			wantErr: "extracted size exceeds limit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := filepath.Join(t.TempDir(), "plugin.tgz")
+			require.NoError(t, createTestTarGz(archivePath, test.files))
+			err := untarWithLimits(archivePath, filepath.Join(t.TempDir(), "extract"), test.limits)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestUnzipResourceLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []testFile
+		limits  pluginArchiveLimits
+		wantErr string
+	}{
+		{
+			name:   "exact limits succeed",
+			files:  []testFile{{name: "file", content: "12345"}},
+			limits: pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 5, entries: 1},
+		},
+		{
+			name:    "single file exceeds limit",
+			files:   []testFile{{name: "file", content: "123456"}},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 10, entries: 2},
+			wantErr: "per-file limit",
+		},
+		{
+			name: "total extracted size exceeds limit",
+			files: []testFile{
+				{name: "first", content: "12345"},
+				{name: "second", content: "6789"},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 5, extractedBytes: 8, entries: 2},
+			wantErr: "extracted size exceeds limit",
+		},
+		{
+			name: "entry count exceeds limit",
+			files: []testFile{
+				{name: "one/", isDir: true},
+				{name: "two/", isDir: true},
+			},
+			limits:  pluginArchiveLimits{archiveBytes: 1 << 20, fileBytes: 10, extractedBytes: 10, entries: 1},
+			wantErr: "more than 1 entries",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archivePath := filepath.Join(t.TempDir(), "plugin.zip")
+			require.NoError(t, createTestZip(archivePath, test.files))
+			err := unzipWithLimits(archivePath, filepath.Join(t.TempDir(), "extract"), test.limits)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractPluginFailureCleansStaging(t *testing.T) {
+	root := t.TempDir()
+	archivePath := filepath.Join(root, "broken.tgz")
+	require.NoError(t, os.WriteFile(archivePath, []byte("not gzip"), 0644))
+	extractDir := filepath.Join(root, "staging")
+	require.NoError(t, os.MkdirAll(extractDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(extractDir, "partial"), []byte("partial"), 0644))
+
+	err := (&Manager{rootDir: root}).extractPlugin(archivePath, extractDir, archivePath)
+	require.Error(t, err)
+	_, statErr := os.Stat(extractDir)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestOversizedLocalPackagePreservesExistingPlugin(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "limited-plugin")
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "old-binary"), []byte("old"), 0755))
+
+	archive := createTestPluginArchive(t, "limited-plugin", "2.0.0", "limited")
+	archivePath := filepath.Join(t.TempDir(), "limited-plugin.tgz")
+	require.NoError(t, os.WriteFile(archivePath, archive, 0644))
+	limits := defaultPluginArchiveLimits
+	limits.archiveBytes = int64(len(archive) - 1)
+	mgr := &Manager{rootDir: root, archiveLimits: &limits}
+	require.NoError(t, mgr.saveLocalManifest(&LocalManifest{Plugins: map[string]LocalPlugin{
+		"limited-plugin": {
+			Name: "limited-plugin", Version: "1.0.0", Path: pluginDir, Command: "limited",
+		},
+	}}))
+
+	err := mgr.installFromPackageFile(newTestContext(), archivePath, archivePath)
+	require.ErrorContains(t, err, "plugin archive size")
+	assert.FileExists(t, filepath.Join(pluginDir, "old-binary"))
+	manifest, manifestErr := mgr.GetLocalManifest()
+	require.NoError(t, manifestErr)
+	assert.Equal(t, "1.0.0", manifest.Plugins["limited-plugin"].Version)
+}

--- a/cli/plugin/manager.go
+++ b/cli/plugin/manager.go
@@ -1,9 +1,6 @@
 package plugin
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -64,6 +61,10 @@ type Manager struct {
 	goOnly bool
 	// skipPluginIndexCacheForCLI is set when --source-base is used on this command only.
 	skipPluginIndexCacheForCLI bool
+	// saveLocalManifestHook injects manifest commit failures in transaction tests.
+	saveLocalManifestHook func(*LocalManifest) error
+	// archiveLimits overrides package resource boundaries in tests.
+	archiveLimits *pluginArchiveLimits
 }
 
 func getHomePath() string {
@@ -480,16 +481,49 @@ func (m *Manager) GetLocalManifest() (*LocalManifest, error) {
 }
 
 func (m *Manager) saveLocalManifest(manifest *LocalManifest) error {
+	if m.saveLocalManifestHook != nil {
+		return m.saveLocalManifestHook(manifest)
+	}
+	if err := os.MkdirAll(m.rootDir, 0755); err != nil {
+		return err
+	}
 	path := filepath.Join(m.rootDir, "manifest.json")
-	f, err := os.Create(path)
+	f, err := os.CreateTemp(m.rootDir, ".manifest-*.tmp")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	tmpPath := f.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
-	return enc.Encode(manifest)
+	if err := enc.Encode(manifest); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+
+	replacement, err := replacePathWithRollback(tmpPath, path, ".manifest-rollback-*")
+	if err != nil {
+		return err
+	}
+	removeTemp = false
+	replacement.commit()
+	return nil
 }
 
 func (m *Manager) findPluginInIndex(pluginName string) (*PluginInfo, error) {
@@ -568,153 +602,6 @@ func (m *Manager) validateVersionAndPlatform(ctx *cli.Context, targetPlugin *Plu
 	return &platInfo, nil
 }
 
-func downloadFile(url, dest string) error {
-	resp, err := httpGet(url, pluginArchiveDLTimeout)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed: %d", resp.StatusCode)
-	}
-
-	out, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, resp.Body)
-	return err
-}
-
-func untar(src, dest string) error {
-	f, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return err
-	}
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		// check if the path is absolute or contains suspicious patterns
-		if filepath.IsAbs(header.Name) {
-			return fmt.Errorf("illegal absolute path in archive: %s", header.Name)
-		}
-		if strings.Contains(header.Name, "..") {
-			return fmt.Errorf("illegal path with '..' in archive: %s", header.Name)
-		}
-		// Reject paths starting with / or \ for cross-platform security
-		if strings.HasPrefix(header.Name, "/") || strings.HasPrefix(header.Name, "\\") {
-			return fmt.Errorf("illegal path starting with separator in archive: %s", header.Name)
-		}
-
-		target := filepath.Join(dest, header.Name)
-		target = filepath.Clean(target)
-
-		// Double-check: ensure the target path is within the destination directory
-		destPath := filepath.Clean(dest) + string(os.PathSeparator)
-		if !strings.HasPrefix(target, destPath) {
-			return fmt.Errorf("illegal file path in archive: %s", header.Name)
-		}
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0755); err != nil {
-				return err
-			}
-		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return err
-			}
-			f.Close()
-		}
-	}
-	return nil
-}
-
-func unzip(src, dest string) error {
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-		// check if the path is absolute or contains suspicious patterns
-		if filepath.IsAbs(f.Name) {
-			return fmt.Errorf("illegal absolute path in archive: %s", f.Name)
-		}
-		if strings.Contains(f.Name, "..") {
-			return fmt.Errorf("illegal path with '..' in archive: %s", f.Name)
-		}
-		// Reject paths starting with / or \ for cross-platform security
-		if strings.HasPrefix(f.Name, "/") || strings.HasPrefix(f.Name, "\\") {
-			return fmt.Errorf("illegal path starting with separator in archive: %s", f.Name)
-		}
-
-		fpath := filepath.Join(dest, f.Name)
-		fpath = filepath.Clean(fpath)
-
-		// Double-check: ensure the target path is within the destination directory
-		destPath := filepath.Clean(dest) + string(os.PathSeparator)
-		if !strings.HasPrefix(fpath, destPath) {
-			return fmt.Errorf("illegal file path in archive: %s", f.Name)
-		}
-
-		if f.FileInfo().IsDir() {
-			os.MkdirAll(fpath, os.ModePerm)
-			continue
-		}
-
-		if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-			return err
-		}
-
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			outFile.Close()
-			return err
-		}
-
-		_, err = io.Copy(outFile, rc)
-
-		outFile.Close()
-		rc.Close()
-
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func calculateSHA256(filePath string) (string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -739,7 +626,7 @@ func (m *Manager) downloadAndVerifyPlugin(ctx *cli.Context, platInfo *PlatformIn
 	}
 
 	archivePath := filepath.Join(tmpDir, "plugin.archive")
-	if err := downloadFile(platInfo.URL, archivePath); err != nil {
+	if err := downloadFileWithLimit(platInfo.URL, archivePath, m.effectiveArchiveLimits().archiveBytes); err != nil {
 		os.RemoveAll(tmpDir)
 		return "", err
 	}
@@ -763,18 +650,23 @@ func (m *Manager) downloadAndVerifyPlugin(ctx *cli.Context, platInfo *PlatformIn
 	return archivePath, nil
 }
 
-func (m *Manager) extractPlugin(archivePath, extractDir, downloadURL string) error {
+func (m *Manager) extractPlugin(archivePath, extractDir, downloadURL string) (err error) {
 	if err := os.RemoveAll(extractDir); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(extractDir, 0755); err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(extractDir)
+		}
+	}()
 
 	if strings.HasSuffix(strings.ToLower(downloadURL), ".zip") {
-		return unzip(archivePath, extractDir)
+		return unzipWithLimits(archivePath, extractDir, m.effectiveArchiveLimits())
 	}
-	return untar(archivePath, extractDir)
+	return untarWithLimits(archivePath, extractDir, m.effectiveArchiveLimits())
 }
 
 func expandPluginSourcePath(raw string) (string, error) {
@@ -923,48 +815,23 @@ func validateAndResolvePackageType(extractDir string, manifest *PluginManifest) 
 	return runtimesource.ValidateMetadataPlugin(extractDir, manifest.Metadata)
 }
 
-func copyDirTree(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode().Perm())
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-			return err
-		}
-		return os.WriteFile(target, data, info.Mode().Perm())
-	})
+func (m *Manager) newPluginStagingDir(pattern string) (string, error) {
+	if err := os.MkdirAll(m.rootDir, 0755); err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(m.rootDir, pattern)
 }
 
-func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (string, error) {
+func (m *Manager) promoteExtractedPlugin(tmpExtract, pluginName string) (*pathReplacement, error) {
 	finalDir, err := resolvePluginInstallDir(m.rootDir, pluginName)
 	if err != nil {
-		return "", fmt.Errorf("invalid plugin name: %w", err)
+		return nil, fmt.Errorf("invalid plugin name: %w", err)
 	}
-	if err := os.RemoveAll(finalDir); err != nil {
-		return "", fmt.Errorf("failed to remove existing plugin directory: %w", err)
+	replacement, err := replacePathWithRollback(tmpExtract, finalDir, "."+pluginName+"-rollback-*")
+	if err != nil {
+		return nil, err
 	}
-	if err := os.Rename(tmpExtract, finalDir); err == nil {
-		return finalDir, nil
-	}
-	if err := copyDirTree(tmpExtract, finalDir); err != nil {
-		return "", fmt.Errorf("failed to copy plugin files: %w", err)
-	}
-	if err := os.RemoveAll(tmpExtract); err != nil {
-		return "", fmt.Errorf("failed to remove temporary extract directory: %w", err)
-	}
-	return finalDir, nil
+	return replacement, nil
 }
 
 func (m *Manager) printOverwriteIfPluginInstalled(ctx *cli.Context, pluginName, incomingVersion string) {
@@ -1027,11 +894,12 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL string) e
 		return fmt.Errorf("package URL path must end with .zip, .tar.gz, or .tgz")
 	}
 
-	cli.Printf(ctx.Stdout(), "Downloading plugin package from %s...\n", rawURL)
+	displayURL := safePluginPackageURL(u)
+	cli.Printf(ctx.Stdout(), "Downloading plugin package from %s...\n", displayURL)
 
 	resp, err := httpGet(rawURL, pluginArchiveDLTimeout)
 	if err != nil {
-		return fmt.Errorf("download plugin package: %w", err)
+		return safePluginDownloadError(err, displayURL)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -1049,19 +917,11 @@ func (m *Manager) installFromRemotePackageURL(ctx *cli.Context, rawURL string) e
 		base = "plugin.tgz"
 	}
 	dest := filepath.Join(tmpParent, base)
-	out, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("create temp package file: %w", err)
-	}
-	if _, err := io.Copy(out, resp.Body); err != nil {
-		out.Close()
-		return fmt.Errorf("write plugin package: %w", err)
-	}
-	if err := out.Close(); err != nil {
+	if err := writePluginArchiveResponse(resp, dest, m.effectiveArchiveLimits().archiveBytes); err != nil {
 		return fmt.Errorf("write plugin package: %w", err)
 	}
 
-	return m.installFromPackageFile(ctx, dest, rawURL)
+	return m.installFromPackageFile(ctx, dest, displayURL)
 }
 
 func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing string) error {
@@ -1071,7 +931,7 @@ func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing s
 
 	cli.Printf(ctx.Stdout(), "Installing plugin from %s...\n", userFacing)
 
-	tmpParent, err := os.MkdirTemp("", "aliyun-plugin-local-*")
+	tmpParent, err := m.newPluginStagingDir(".aliyun-plugin-local-*")
 	if err != nil {
 		return err
 	}
@@ -1089,14 +949,18 @@ func (m *Manager) installFromPackageFile(ctx *cli.Context, absPath, userFacing s
 
 	m.printOverwriteIfPluginInstalled(ctx, pManifest.Name, pManifest.Version)
 
-	finalDir, err := m.promoteExtractedPlugin(tmpExtract, pManifest.Name)
+	promotion, err := m.promoteExtractedPlugin(tmpExtract, pManifest.Name)
 	if err != nil {
 		return err
 	}
 
-	if err := m.savePluginToManifest(pManifest.Name, pManifest.Version, finalDir, pManifest); err != nil {
+	if err := m.savePluginToManifest(pManifest.Name, pManifest.Version, promotion.finalPath, pManifest); err != nil {
+		if rollbackErr := promotion.rollback(); rollbackErr != nil {
+			return fmt.Errorf("%w; failed to restore previous plugin: %v", err, rollbackErr)
+		}
 		return err
 	}
+	promotion.commit()
 
 	cli.Printf(ctx.Stdout(), "Plugin %s %s installed successfully!\n", pManifest.Name, pManifest.Version)
 	return nil
@@ -1210,10 +1074,12 @@ func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, vers
 		m.printOverwriteIfPluginInstalled(ctx, actualPluginName, version)
 	}
 
-	extractDir, err := resolvePluginInstallDir(m.rootDir, actualPluginName)
+	stagingParent, err := m.newPluginStagingDir("." + actualPluginName + "-staging-*")
 	if err != nil {
-		return fmt.Errorf("invalid plugin name from repository: %w", err)
+		return fmt.Errorf("create plugin staging directory: %w", err)
 	}
+	defer os.RemoveAll(stagingParent)
+	extractDir := filepath.Join(stagingParent, "extract")
 	if err := m.extractPlugin(archivePath, extractDir, downloadURL); err != nil {
 		return err
 	}
@@ -1227,9 +1093,17 @@ func (m *Manager) installPlugin(ctx *cli.Context, targetPlugin *PluginInfo, vers
 		populateMinCliVersionFromIndex(pManifest, verInfo)
 	}
 
-	if err := m.savePluginToManifest(actualPluginName, version, extractDir, pManifest); err != nil {
+	promotion, err := m.promoteExtractedPlugin(extractDir, actualPluginName)
+	if err != nil {
 		return err
 	}
+	if err := m.savePluginToManifest(actualPluginName, version, promotion.finalPath, pManifest); err != nil {
+		if rollbackErr := promotion.rollback(); rollbackErr != nil {
+			return fmt.Errorf("%w; failed to restore previous plugin: %v", err, rollbackErr)
+		}
+		return err
+	}
+	promotion.commit()
 
 	cli.Printf(ctx.Stdout(), "Plugin %s %s installed successfully!\n", actualPluginName, version)
 	return nil

--- a/cli/plugin/manager_install_local_test.go
+++ b/cli/plugin/manager_install_local_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -16,52 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopyDirTree(t *testing.T) {
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "out")
-
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "nested"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "nested", "b.txt"), []byte("beta"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("alpha"), 0644))
-
-	require.NoError(t, copyDirTree(src, dst))
-
-	b, err := os.ReadFile(filepath.Join(dst, "nested", "b.txt"))
-	require.NoError(t, err)
-	assert.Equal(t, "beta", string(b))
-	a, err := os.ReadFile(filepath.Join(dst, "a.txt"))
-	require.NoError(t, err)
-	assert.Equal(t, "alpha", string(a))
-}
-
-func TestCopyDirTree_emptyTree(t *testing.T) {
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "empty-out")
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "child"), 0755))
-
-	require.NoError(t, copyDirTree(src, dst))
-
-	st, err := os.Stat(filepath.Join(dst, "child"))
-	require.NoError(t, err)
-	assert.True(t, st.IsDir())
-}
-
-func TestCopyDirTree_preservesFilePerm(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permission bits differ on Windows")
-	}
-	src := t.TempDir()
-	dst := filepath.Join(t.TempDir(), "perm-out")
-	p := filepath.Join(src, "secret")
-	require.NoError(t, os.WriteFile(p, []byte("x"), 0600))
-
-	require.NoError(t, copyDirTree(src, dst))
-
-	st, err := os.Stat(filepath.Join(dst, "secret"))
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0600), st.Mode().Perm())
-}
-
 func TestPromoteExtractedPlugin_rename(t *testing.T) {
 	root := t.TempDir()
 	tmpExtract := filepath.Join(root, "_extract_me")
@@ -69,15 +22,36 @@ func TestPromoteExtractedPlugin_rename(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpExtract, "manifest.json"), []byte("{}"), 0644))
 
 	mgr := &Manager{rootDir: root}
-	finalDir, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
+	promotion, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
 	require.NoError(t, err)
+	promotion.commit()
 
 	want := filepath.Join(root, "myplugin")
-	assert.Equal(t, want, finalDir)
+	assert.Equal(t, want, promotion.finalPath)
 	_, err = os.Stat(filepath.Join(want, "manifest.json"))
 	require.NoError(t, err)
 	_, err = os.Stat(tmpExtract)
 	assert.True(t, os.IsNotExist(err), "temp extract dir should be gone after rename")
+}
+
+func TestPromoteExtractedPlugin_rollbackRestoresExistingDirectory(t *testing.T) {
+	root := t.TempDir()
+	finalDir := filepath.Join(root, "myplugin")
+	require.NoError(t, os.MkdirAll(finalDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(finalDir, "version"), []byte("old"), 0644))
+
+	tmpExtract := filepath.Join(root, "_extract_me")
+	require.NoError(t, os.MkdirAll(tmpExtract, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpExtract, "version"), []byte("new"), 0644))
+
+	mgr := &Manager{rootDir: root}
+	promotion, err := mgr.promoteExtractedPlugin(tmpExtract, "myplugin")
+	require.NoError(t, err)
+	require.NoError(t, promotion.rollback())
+
+	version, err := os.ReadFile(filepath.Join(finalDir, "version"))
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(version))
 }
 
 func TestValidatePluginNameRejectsPathValues(t *testing.T) {
@@ -240,16 +214,33 @@ func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
 	mgr := &Manager{rootDir: pluginRoot}
 	archiveBody := createTestPluginArchive(t, "remote-url-plugin", "7.8.9", "x")
 
+	type requestDetails struct {
+		username string
+		password string
+		token    string
+	}
+	requests := make(chan requestDetails, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, _ := r.BasicAuth()
+		requests <- requestDetails{
+			username: username,
+			password: password,
+			token:    r.URL.Query().Get("token"),
+		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = w.Write(archiveBody)
 	}))
 	defer srv.Close()
-	archiveURL := srv.URL + "/pkgs/remote-url-plugin/7.8.9/plugin.tgz"
+	archiveURL := strings.Replace(srv.URL, "http://", "http://log-user:log-password@", 1) +
+		"/pkgs/remote-url-plugin/7.8.9/plugin.tgz?token=query-secret&signature=signature-secret#fragment-secret"
 
 	ctx := newTestContext()
 	err := mgr.InstallFromPackage(ctx, archiveURL)
 	require.NoError(t, err)
+	request := <-requests
+	assert.Equal(t, "log-user", request.username)
+	assert.Equal(t, "log-password", request.password)
+	assert.Equal(t, "query-secret", request.token)
 
 	manifest, err := mgr.GetLocalManifest()
 	require.NoError(t, err)
@@ -259,6 +250,12 @@ func TestManager_InstallFromPackage_RemoteURL(t *testing.T) {
 	out := ctx.Stdout().(*bytes.Buffer).String()
 	assert.Contains(t, out, "Downloading plugin package from")
 	assert.Contains(t, out, "Installing plugin from")
+	assert.Contains(t, out, srv.URL+"/pkgs/remote-url-plugin/7.8.9/plugin.tgz")
+	assert.NotContains(t, out, "log-user")
+	assert.NotContains(t, out, "log-password")
+	assert.NotContains(t, out, "query-secret")
+	assert.NotContains(t, out, "signature-secret")
+	assert.NotContains(t, out, "fragment-secret")
 }
 
 func TestManager_InstallFromPackage_RemoteURLBadSuffix(t *testing.T) {
@@ -292,9 +289,15 @@ func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
 		}))
 		base := srv.URL
 		srv.Close()
-		err := mgr.installFromRemotePackageURL(ctx, base+"/plugin.tgz")
+		rawURL := strings.Replace(base, "http://", "http://error-user:error-password@", 1) +
+			"/plugin.tgz?token=error-token#fragment-secret"
+		err := mgr.installFromRemotePackageURL(ctx, rawURL)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "download plugin package:")
+		assert.Contains(t, err.Error(), "download plugin package from "+base+"/plugin.tgz:")
+		assert.NotContains(t, err.Error(), "error-user")
+		assert.NotContains(t, err.Error(), "error-password")
+		assert.NotContains(t, err.Error(), "error-token")
+		assert.NotContains(t, err.Error(), "fragment-secret")
 	})
 
 	t.Run("non-OK status", func(t *testing.T) {
@@ -308,30 +311,35 @@ func TestManager_installFromRemotePackageURL_downloadErrors(t *testing.T) {
 	})
 }
 
-func TestInstallFromPackageFile_saveLocalManifestFails(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("read-only manifest.json via chmod is not reliable on Windows")
-	}
+func TestInstallFromPackageFile_saveLocalManifestFailsRollsBack(t *testing.T) {
 	root := t.TempDir()
-	mani := filepath.Join(root, "manifest.json")
-	require.NoError(t, os.WriteFile(mani, []byte(`{"plugins":{}}`), 0644))
-	require.NoError(t, os.Chmod(mani, 0444))
-	defer func() { _ = os.Chmod(mani, 0644) }()
-
 	mgr := &Manager{rootDir: root}
-	archiveBody := createTestPluginArchive(t, "save-fail-pl", "2.0.0", "x")
-	archivePath := filepath.Join(t.TempDir(), "save-fail.tgz")
-	require.NoError(t, os.WriteFile(archivePath, archiveBody, 0644))
-
 	ctx := newTestContext()
+
+	v1 := createTestPluginArchive(t, "save-fail-pl", "1.0.0", "x")
+	v1Path := filepath.Join(t.TempDir(), "v1.tgz")
+	require.NoError(t, os.WriteFile(v1Path, v1, 0644))
+	require.NoError(t, mgr.installFromPackageFile(ctx, v1Path, v1Path))
+
+	mgr.saveLocalManifestHook = func(*LocalManifest) error {
+		return fmt.Errorf("injected manifest commit failure")
+	}
+	v2 := createTestPluginArchive(t, "save-fail-pl", "2.0.0", "x")
+	archivePath := filepath.Join(t.TempDir(), "save-fail.tgz")
+	require.NoError(t, os.WriteFile(archivePath, v2, 0644))
+
 	err := mgr.installFromPackageFile(ctx, archivePath, archivePath)
 	require.Error(t, err)
-	lowered := strings.ToLower(err.Error())
-	require.True(t,
-		strings.Contains(lowered, "permission denied") ||
-			strings.Contains(lowered, "operation not permitted"),
-		"unexpected error from saveLocalManifest: %v", err,
-	)
+	assert.Contains(t, err.Error(), "injected manifest commit failure")
+
+	mgr.saveLocalManifestHook = nil
+	localManifest, err := mgr.GetLocalManifest()
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", localManifest.Plugins["save-fail-pl"].Version)
+
+	packageManifest, err := readPluginManifestFromDir(filepath.Join(root, "save-fail-pl"))
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", packageManifest.Version)
 }
 
 func TestFindInstalledPluginInManifest(t *testing.T) {

--- a/cli/plugin/manager_test.go
+++ b/cli/plugin/manager_test.go
@@ -2467,6 +2467,82 @@ func TestManager_installPlugin(t *testing.T) {
 		assert.Contains(t, err.Error(), "Expected: wrong-checksum")
 	})
 
+	t.Run("Error - corrupt archive preserves existing plugin", func(t *testing.T) {
+		root := t.TempDir()
+		mgr := &Manager{rootDir: root}
+		pluginDir := filepath.Join(root, "test-plugin")
+		require.NoError(t, os.MkdirAll(pluginDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "old-binary"), []byte("old"), 0755))
+		require.NoError(t, mgr.saveLocalManifest(&LocalManifest{Plugins: map[string]LocalPlugin{
+			"test-plugin": {
+				Name: "test-plugin", Version: "1.0.0", Path: pluginDir, Command: "test",
+			},
+		}}))
+
+		corruptArchive := []byte("not a gzip archive")
+		checksum, err := calculateSHA256FromBytes(corruptArchive)
+		require.NoError(t, err)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(corruptArchive)
+		}))
+		defer server.Close()
+
+		targetPlugin := &PluginInfo{
+			Name: "test-plugin",
+			Versions: map[string]VersionInfo{
+				"2.0.0": {Platforms: map[string]PlatformInfo{
+					GetCurrentPlatform(): {URL: server.URL + "/test-plugin.tgz", Checksum: checksum},
+				}},
+			},
+		}
+
+		err = mgr.installPlugin(newTestContext(), targetPlugin, "2.0.0", false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gzip")
+		assert.FileExists(t, filepath.Join(pluginDir, "old-binary"))
+		localManifest, manifestErr := mgr.GetLocalManifest()
+		require.NoError(t, manifestErr)
+		assert.Equal(t, "1.0.0", localManifest.Plugins["test-plugin"].Version)
+	})
+
+	t.Run("Error - invalid staged manifest preserves existing plugin", func(t *testing.T) {
+		root := t.TempDir()
+		mgr := &Manager{rootDir: root}
+		pluginDir := filepath.Join(root, "test-plugin")
+		require.NoError(t, os.MkdirAll(pluginDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "old-binary"), []byte("old"), 0755))
+		require.NoError(t, mgr.saveLocalManifest(&LocalManifest{Plugins: map[string]LocalPlugin{
+			"test-plugin": {
+				Name: "test-plugin", Version: "1.0.0", Path: pluginDir, Command: "test",
+			},
+		}}))
+
+		archiveContent := createTestPluginArchiveWithoutManifest(t)
+		checksum, err := calculateSHA256FromBytes(archiveContent)
+		require.NoError(t, err)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(archiveContent)
+		}))
+		defer server.Close()
+
+		targetPlugin := &PluginInfo{
+			Name: "test-plugin",
+			Versions: map[string]VersionInfo{
+				"2.0.0": {Platforms: map[string]PlatformInfo{
+					GetCurrentPlatform(): {URL: server.URL + "/test-plugin.tgz", Checksum: checksum},
+				}},
+			},
+		}
+
+		err = mgr.installPlugin(newTestContext(), targetPlugin, "2.0.0", false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "manifest.json not found")
+		assert.FileExists(t, filepath.Join(pluginDir, "old-binary"))
+		localManifest, manifestErr := mgr.GetLocalManifest()
+		require.NoError(t, manifestErr)
+		assert.Equal(t, "1.0.0", localManifest.Plugins["test-plugin"].Version)
+	})
+
 	t.Run("Error - manifest not found in archive", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		mgr := &Manager{rootDir: tmpDir}

--- a/cli/plugin/path_replacement.go
+++ b/cli/plugin/path_replacement.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2009-present, Alibaba Cloud All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// pathReplacement swaps a staged file or directory into its final path while retaining the previous path until the caller commits.
+// It guarantees rollback for errors returned within the current process;
+// it does not provide crash recovery or cross-process serialization for now.
+type pathReplacement struct {
+	finalPath    string
+	backupParent string
+	backupPath   string
+	hadExisting  bool
+}
+
+func replacePathWithRollback(stagedPath, finalPath, backupPattern string) (*pathReplacement, error) {
+	replacement := &pathReplacement{finalPath: finalPath}
+	if _, err := os.Lstat(finalPath); err == nil {
+		replacement.hadExisting = true
+		replacement.backupParent, err = os.MkdirTemp(filepath.Dir(finalPath), backupPattern)
+		if err != nil {
+			return nil, fmt.Errorf("create rollback directory: %w", err)
+		}
+		replacement.backupPath = filepath.Join(replacement.backupParent, "previous")
+		if err := os.Rename(finalPath, replacement.backupPath); err != nil {
+			_ = os.RemoveAll(replacement.backupParent)
+			return nil, fmt.Errorf("backup existing path: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspect existing path: %w", err)
+	}
+
+	if err := os.Rename(stagedPath, finalPath); err != nil {
+		restoreErr := replacement.restorePrevious()
+		if restoreErr != nil {
+			return nil, fmt.Errorf("replace final path: %w; restore previous path: %v", err, restoreErr)
+		}
+		replacement.commit()
+		return nil, fmt.Errorf("replace final path: %w", err)
+	}
+	return replacement, nil
+}
+
+func (r *pathReplacement) restorePrevious() error {
+	if r == nil {
+		return nil
+	}
+	if err := os.RemoveAll(r.finalPath); err != nil {
+		return err
+	}
+	if r.hadExisting {
+		if err := os.Rename(r.backupPath, r.finalPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *pathReplacement) rollback() error {
+	if err := r.restorePrevious(); err != nil {
+		return err
+	}
+	r.commit()
+	return nil
+}
+
+func (r *pathReplacement) commit() {
+	if r != nil && r.backupParent != "" {
+		_ = os.RemoveAll(r.backupParent)
+	}
+}

--- a/cli/plugin/url_redaction.go
+++ b/cli/plugin/url_redaction.go
@@ -1,0 +1,37 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// safePluginPackageURL returns a diagnostic URL without credentials or
+// caller-controlled query and fragment data. The original URL remains
+// unchanged and must be used for the actual download.
+func safePluginPackageURL(value *url.URL) string {
+	if value == nil {
+		return "<unknown>"
+	}
+
+	safe := *value
+	safe.User = nil
+	safe.RawQuery = ""
+	safe.ForceQuery = false
+	safe.Fragment = ""
+	safe.RawFragment = ""
+	return safe.String()
+}
+
+// safePluginDownloadError avoids rendering url.Error.URL, which contains the
+// original package URL and may therefore include credentials or signed query
+// parameters. Wrapping the underlying cause preserves errors.Is/errors.As
+// behavior for transport failures without retaining the credential-bearing
+// URL in the rendered error.
+func safePluginDownloadError(err error, displayURL string) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return fmt.Errorf("download plugin package from %s: %w", displayURL, urlErr.Err)
+	}
+	return fmt.Errorf("download plugin package from %s: %w", displayURL, err)
+}


### PR DESCRIPTION
fix(plugin): harden plugin package installation

- stage installations and roll back failed directory replacements
- update the local manifest atomically
- enforce download, file, extraction, and entry limits
- clean partial downloads and extracted files on failure
- redact credentials and query parameters from URL logs and errors
- add rollback, archive limit, corruption, and redaction tests